### PR TITLE
[Admin UI extensions 2026-01]: Use 'web components' terminology

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -431,7 +431,7 @@ const transformJson = async (filePath, isExtensions) => {
 
     const filteredDocs = shopifyDevDocsDocsParsed.filter(
       (entry) =>
-        entry.category !== 'Polaris web components' &&
+          entry.category !== 'Web components' &&
         entry.category !== 'Patterns', // Don't include old patterns
     );
 

--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data.json
@@ -4,7 +4,7 @@
     "description": "The Action Extension API lets you [build action extensions](/docs/apps/build/admin/actions-blocks/build-admin-action) that merchants access from the **More actions** menu on details and index pages. Use this API to create workflows for processing resources, configuring settings, or integrating with external systems.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.",
+    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.",
     "defaultExample": {
       "description": "Send selected product IDs to your backend for bulk processing. This example shows how to map selected items, make an authenticated API call, and close the modal when the operation completes.",
       "codeblock": {
@@ -1141,7 +1141,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -1149,7 +1149,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1157,7 +1157,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1165,7 +1165,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1173,7 +1173,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1181,7 +1181,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1189,7 +1189,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2308,7 +2308,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -2316,7 +2316,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2324,7 +2324,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2332,7 +2332,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2340,7 +2340,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2348,7 +2348,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2356,7 +2356,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -3884,7 +3884,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -3892,7 +3892,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -3948,7 +3948,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -3956,7 +3956,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -3964,7 +3964,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4044,7 +4044,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -4052,7 +4052,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4060,7 +4060,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4068,7 +4068,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4076,7 +4076,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4084,7 +4084,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4092,7 +4092,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4390,7 +4390,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -4398,7 +4398,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4406,7 +4406,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4414,7 +4414,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4422,7 +4422,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4430,7 +4430,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4438,7 +4438,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -6929,7 +6929,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -6961,7 +6961,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -6969,7 +6969,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -6977,7 +6977,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7057,7 +7057,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -7065,7 +7065,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7073,7 +7073,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7081,7 +7081,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7089,7 +7089,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7097,7 +7097,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7105,7 +7105,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -11620,7 +11620,7 @@
         "type": "Generic",
         "anchorLink": "best-practices",
         "title": "Best practices",
-        "sectionContent": "- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions."
+        "sectionContent": "- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) components during async operations to prevent duplicate submissions."
       },
       {
         "type": "Generic",
@@ -11635,9 +11635,9 @@
     "description": "The Block Extension API lets you [build block extensions](/docs/apps/build/admin/actions-blocks/build-admin-block) that display inline content directly within admin pages. Use this API to show contextual information, tools, or actions related to the current page without requiring merchants to open a modal.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.",
+    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.",
     "defaultExample": {
-      "description": "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/spinner) component while fetching.",
+      "description": "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/spinner) component while fetching.",
       "codeblock": {
         "title": "Display product information",
         "tabs": [
@@ -13384,7 +13384,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -13392,7 +13392,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13400,7 +13400,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13408,7 +13408,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13416,7 +13416,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13424,7 +13424,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13432,7 +13432,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14551,7 +14551,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -14559,7 +14559,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14567,7 +14567,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14575,7 +14575,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14583,7 +14583,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14591,7 +14591,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14599,7 +14599,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16127,7 +16127,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -16135,7 +16135,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -16191,7 +16191,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -16199,7 +16199,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16207,7 +16207,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16287,7 +16287,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -16295,7 +16295,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16303,7 +16303,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16311,7 +16311,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16319,7 +16319,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16327,7 +16327,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16335,7 +16335,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16633,7 +16633,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -16641,7 +16641,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16649,7 +16649,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16657,7 +16657,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16665,7 +16665,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16673,7 +16673,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16681,7 +16681,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19172,7 +19172,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -19204,7 +19204,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -19212,7 +19212,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19220,7 +19220,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19300,7 +19300,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -19308,7 +19308,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19316,7 +19316,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19324,7 +19324,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19332,7 +19332,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19340,7 +19340,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19348,7 +19348,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -23216,7 +23216,7 @@
       "description": "Common block extension patterns",
       "examples": [
         {
-          "description": "Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+          "description": "Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
           "codeblock": {
             "title": "Navigate to action extension",
             "tabs": [
@@ -23266,9 +23266,9 @@
     "description": "The Validation Settings API lets you [create complex validation rules](/docs/apps/build/checkout/cart-checkout-validation/create-admin-ui-validation) for cart and checkout validation. Use this API to build custom settings interfaces for [Shopify Functions](/docs/apps/build/functions) that implement validation logic.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.",
+    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.",
     "defaultExample": {
-      "description": "Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.",
+      "description": "Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.",
       "codeblock": {
         "title": "Set minimum quantity",
         "tabs": [
@@ -25341,7 +25341,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -25349,7 +25349,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25357,7 +25357,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25365,7 +25365,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25373,7 +25373,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25381,7 +25381,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25389,7 +25389,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26508,7 +26508,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -26516,7 +26516,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26524,7 +26524,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26532,7 +26532,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26540,7 +26540,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26548,7 +26548,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26556,7 +26556,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28084,7 +28084,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -28092,7 +28092,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -28148,7 +28148,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -28156,7 +28156,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28164,7 +28164,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28244,7 +28244,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -28252,7 +28252,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28260,7 +28260,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28268,7 +28268,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28276,7 +28276,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28284,7 +28284,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28292,7 +28292,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28590,7 +28590,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -28598,7 +28598,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28606,7 +28606,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28614,7 +28614,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28622,7 +28622,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28630,7 +28630,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28638,7 +28638,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31129,7 +31129,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -31161,7 +31161,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -31169,7 +31169,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31177,7 +31177,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31257,7 +31257,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -31265,7 +31265,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31273,7 +31273,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31281,7 +31281,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31289,7 +31289,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31297,7 +31297,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31305,7 +31305,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -35243,9 +35243,9 @@
     "description": "The Discount Function Settings API lets you build UI extensions that provide custom configuration interfaces for [discount functions](/docs/apps/build/discounts/build-ui-extension). Use this API to create settings pages for [Shopify Functions](/docs/apps/build/functions) that implement discount logic.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.",
+    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.",
     "defaultExample": {
-      "description": "Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.",
+      "description": "Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.",
       "codeblock": {
         "title": "Configure discount threshold",
         "tabs": [
@@ -36113,9 +36113,9 @@
     "description": "The Order Routing Rule API provides access to [order routing rule](/docs/apps/build/orders-fulfillment/order-routing-apps) configuration and settings management. Use this API to build custom configuration interfaces for order routing rules that determine fulfillment locations.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.",
+    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.",
     "defaultExample": {
-      "description": "Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.",
+      "description": "Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.",
       "codeblock": {
         "title": "Configure location priority",
         "tabs": [
@@ -38061,7 +38061,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -38069,7 +38069,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38077,7 +38077,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38085,7 +38085,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38093,7 +38093,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38101,7 +38101,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38109,7 +38109,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -39228,7 +39228,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -39236,7 +39236,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -39244,7 +39244,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -39252,7 +39252,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -39260,7 +39260,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -39268,7 +39268,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -39276,7 +39276,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40804,7 +40804,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -40812,7 +40812,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -40868,7 +40868,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -40876,7 +40876,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40884,7 +40884,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40964,7 +40964,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -40972,7 +40972,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40980,7 +40980,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40988,7 +40988,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40996,7 +40996,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41004,7 +41004,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41012,7 +41012,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41310,7 +41310,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -41318,7 +41318,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41326,7 +41326,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41334,7 +41334,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41342,7 +41342,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41350,7 +41350,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -41358,7 +41358,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43849,7 +43849,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -43881,7 +43881,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -43889,7 +43889,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43897,7 +43897,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43977,7 +43977,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -43985,7 +43985,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43993,7 +43993,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -44001,7 +44001,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -44009,7 +44009,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -44017,7 +44017,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -44025,7 +44025,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -48121,7 +48121,7 @@
     "description": "The Print Action Extension API lets you [build print action extensions](/docs/apps/build/admin/actions-blocks/build-admin-print-action) that generate custom printable documents for orders, products, and other resources. Use this API to create branded labels, packing slips, custom invoices, or specialty documents.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-print-action) component.",
+    "requires": "the [admin print action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-print-action) component.",
     "defaultExample": {
       "description": "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and returning the printable URL to display the document.",
       "codeblock": {
@@ -49863,7 +49863,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -49871,7 +49871,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49879,7 +49879,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49887,7 +49887,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49895,7 +49895,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49903,7 +49903,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49911,7 +49911,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -51030,7 +51030,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -51038,7 +51038,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -51046,7 +51046,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -51054,7 +51054,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -51062,7 +51062,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -51070,7 +51070,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -51078,7 +51078,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52606,7 +52606,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -52614,7 +52614,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -52670,7 +52670,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -52678,7 +52678,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52686,7 +52686,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52766,7 +52766,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -52774,7 +52774,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52782,7 +52782,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52790,7 +52790,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52798,7 +52798,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52806,7 +52806,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52814,7 +52814,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -53112,7 +53112,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -53120,7 +53120,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -53128,7 +53128,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -53136,7 +53136,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -53144,7 +53144,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -53152,7 +53152,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -53160,7 +53160,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55651,7 +55651,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -55683,7 +55683,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -55691,7 +55691,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55699,7 +55699,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55779,7 +55779,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -55787,7 +55787,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55795,7 +55795,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55803,7 +55803,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55811,7 +55811,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55819,7 +55819,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55827,7 +55827,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -59752,7 +59752,7 @@
     "description": "The Product Details Configuration API lets you [build product configuration extensions for bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) that define product relationships and manage [bundle](/docs/apps/build/product-merchandising/bundles) compositions. Use this API to build configuration interfaces for bundle and component product experiences.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.",
+    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.",
     "defaultExample": {
       "description": "Open the product [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select up to five components for a [bundle](/docs/apps/build/product-merchandising/bundles). This example filters out draft and archived products, saves the bundle configuration to your backend, and tracks the selection count.",
       "codeblock": {
@@ -61772,7 +61772,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -61780,7 +61780,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61788,7 +61788,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61796,7 +61796,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61804,7 +61804,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61812,7 +61812,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61820,7 +61820,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62939,7 +62939,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -62947,7 +62947,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62955,7 +62955,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62963,7 +62963,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62971,7 +62971,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62979,7 +62979,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62987,7 +62987,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64515,7 +64515,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -64523,7 +64523,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -64579,7 +64579,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -64587,7 +64587,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64595,7 +64595,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64675,7 +64675,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -64683,7 +64683,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64691,7 +64691,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64699,7 +64699,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64707,7 +64707,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64715,7 +64715,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64723,7 +64723,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -65021,7 +65021,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -65029,7 +65029,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -65037,7 +65037,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -65045,7 +65045,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -65053,7 +65053,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -65061,7 +65061,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -65069,7 +65069,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67560,7 +67560,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -67592,7 +67592,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -67600,7 +67600,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67608,7 +67608,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67688,7 +67688,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -67696,7 +67696,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67704,7 +67704,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67712,7 +67712,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67720,7 +67720,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67728,7 +67728,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67736,7 +67736,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -71383,7 +71383,7 @@
     "description": "The Product Variant Details Configuration API lets you [build product configuration extensions for bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) that define variant relationships and manage [bundle](/docs/apps/build/product-merchandising/bundles) compositions. Use this API to build configuration interfaces for bundle and component product experiences at the variant level.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.",
+    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.",
     "defaultExample": {
       "description": "Use the product variant [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component variants for a [bundle](/docs/apps/build/product-merchandising/bundles). This example picks product variants, tracks selections, and posts the product variant IDs to configure the bundle.",
       "codeblock": {
@@ -73402,7 +73402,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -73410,7 +73410,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73418,7 +73418,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73426,7 +73426,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73434,7 +73434,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73442,7 +73442,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73450,7 +73450,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -74569,7 +74569,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -74577,7 +74577,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -74585,7 +74585,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -74593,7 +74593,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -74601,7 +74601,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -74609,7 +74609,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -74617,7 +74617,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76145,7 +76145,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -76153,7 +76153,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -76209,7 +76209,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -76217,7 +76217,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76225,7 +76225,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76305,7 +76305,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -76313,7 +76313,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76321,7 +76321,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76329,7 +76329,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76337,7 +76337,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76345,7 +76345,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76353,7 +76353,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76651,7 +76651,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -76659,7 +76659,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76667,7 +76667,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76675,7 +76675,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76683,7 +76683,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76691,7 +76691,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -76699,7 +76699,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79190,7 +79190,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -79222,7 +79222,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -79230,7 +79230,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79238,7 +79238,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79318,7 +79318,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -79326,7 +79326,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79334,7 +79334,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79342,7 +79342,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79350,7 +79350,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79358,7 +79358,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -79366,7 +79366,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -83014,7 +83014,7 @@
     "description": "The Purchase Options Card Configuration API provides access to purchase option selection data for products with [subscription](/docs/apps/build/purchase-options/subscriptions) and [selling plan](/docs/apps/build/purchase-options/subscriptions/selling-plans) configurations. Use this API to build action extensions that interact with selected [purchase options](/docs/apps/build/purchase-options) on product and product variant details pages.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.",
+    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.",
     "defaultExample": {
       "description": "Update a subscription by sending product and selling plan IDs to your backend. This example checks for selling plan presence, posts the update request, and shows a success banner before auto-closing the modal.",
       "codeblock": {
@@ -84763,7 +84763,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -84771,7 +84771,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84779,7 +84779,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84787,7 +84787,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84795,7 +84795,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84803,7 +84803,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84811,7 +84811,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -85930,7 +85930,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -85938,7 +85938,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -85946,7 +85946,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -85954,7 +85954,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -85962,7 +85962,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -85970,7 +85970,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -85978,7 +85978,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87506,7 +87506,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -87514,7 +87514,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -87570,7 +87570,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -87578,7 +87578,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87586,7 +87586,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87666,7 +87666,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -87674,7 +87674,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87682,7 +87682,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87690,7 +87690,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87698,7 +87698,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87706,7 +87706,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87714,7 +87714,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -88012,7 +88012,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -88020,7 +88020,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -88028,7 +88028,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -88036,7 +88036,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -88044,7 +88044,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -88052,7 +88052,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -88060,7 +88060,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90551,7 +90551,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -90583,7 +90583,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -90591,7 +90591,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90599,7 +90599,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90679,7 +90679,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -90687,7 +90687,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90695,7 +90695,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90703,7 +90703,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90711,7 +90711,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90719,7 +90719,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -90727,7 +90727,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96695,7 +96695,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -96703,7 +96703,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96711,7 +96711,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96719,7 +96719,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96727,7 +96727,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96735,7 +96735,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96743,7 +96743,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -97862,7 +97862,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -97870,7 +97870,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -97878,7 +97878,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -97886,7 +97886,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -97894,7 +97894,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -97902,7 +97902,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -97910,7 +97910,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99438,7 +99438,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -99446,7 +99446,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -99502,7 +99502,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -99510,7 +99510,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99518,7 +99518,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99598,7 +99598,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -99606,7 +99606,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99614,7 +99614,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99622,7 +99622,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99630,7 +99630,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99638,7 +99638,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99646,7 +99646,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99944,7 +99944,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -99952,7 +99952,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99960,7 +99960,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99968,7 +99968,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99976,7 +99976,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99984,7 +99984,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -99992,7 +99992,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102483,7 +102483,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -102515,7 +102515,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -102523,7 +102523,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102531,7 +102531,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102611,7 +102611,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -102619,7 +102619,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102627,7 +102627,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102635,7 +102635,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102643,7 +102643,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102651,7 +102651,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -102659,7 +102659,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108318,7 +108318,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -108326,7 +108326,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108334,7 +108334,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108342,7 +108342,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108350,7 +108350,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108358,7 +108358,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108366,7 +108366,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109485,7 +109485,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -109493,7 +109493,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109501,7 +109501,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109509,7 +109509,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109517,7 +109517,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109525,7 +109525,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109533,7 +109533,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111061,7 +111061,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -111069,7 +111069,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -111125,7 +111125,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -111133,7 +111133,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111141,7 +111141,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111221,7 +111221,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -111229,7 +111229,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111237,7 +111237,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111245,7 +111245,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111253,7 +111253,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111261,7 +111261,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111269,7 +111269,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111567,7 +111567,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -111575,7 +111575,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111583,7 +111583,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111591,7 +111591,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111599,7 +111599,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111607,7 +111607,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -111615,7 +111615,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114106,7 +114106,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -114138,7 +114138,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -114146,7 +114146,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114154,7 +114154,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114234,7 +114234,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -114242,7 +114242,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114250,7 +114250,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114258,7 +114258,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114266,7 +114266,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114274,7 +114274,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -114282,7 +114282,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -118265,7 +118265,7 @@
       },
       {
         "title": "Slots",
-        "description": "The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "AdminActionSlots",
         "typeDefinitions": {
           "AdminActionSlots": {
@@ -118295,7 +118295,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Settings and templates",
     "subSections": [
       {
@@ -118307,7 +118307,7 @@
     ],
     "defaultExample": {
       "image": "/assets/templated-apis-screenshots/admin/components/adminaction-example.png",
-      "description": "Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.",
+      "description": "Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.",
       "codeblock": {
         "title": "Configure an admin action modal",
         "tabs": [
@@ -118331,7 +118331,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+              "description": "Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
               "codeblock": {
                 "title": "Show a loading state",
                 "tabs": [
@@ -118348,7 +118348,7 @@
               }
             },
             {
-              "description": "Embed a [form](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/form) inside the action modal to collect merchant input before saving. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) wrapped in a form component.",
+              "description": "Embed a [form](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/form) inside the action modal to collect merchant input before saving. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) wrapped in a form component.",
               "codeblock": {
                 "title": "Add form fields to the modal",
                 "tabs": [
@@ -118365,7 +118365,7 @@
               }
             },
             {
-              "description": "Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) to confirm deletion.",
+              "description": "Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) to confirm deletion.",
               "codeblock": {
                 "title": "Confirm a destructive action",
                 "tabs": [
@@ -118382,7 +118382,7 @@
               }
             },
             {
-              "description": "Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+              "description": "Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
               "codeblock": {
                 "title": "Show resource details in a modal",
                 "tabs": [
@@ -118444,7 +118444,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Settings and templates",
     "subSections": [
       {
@@ -118462,7 +118462,7 @@
     ],
     "defaultExample": {
       "image": "/assets/templated-apis-screenshots/admin/components/adminblock-example.png",
-      "description": "Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) content.",
+      "description": "Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) content.",
       "codeblock": {
         "title": "Display an inline admin block",
         "tabs": [
@@ -118486,7 +118486,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) summary in the block header.",
+              "description": "Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) summary in the block header.",
               "codeblock": {
                 "title": "Show a collapsed summary",
                 "tabs": [
@@ -118503,7 +118503,7 @@
               }
             },
             {
-              "description": "Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/table).",
+              "description": "Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/table).",
               "codeblock": {
                 "title": "Display a data table",
                 "tabs": [
@@ -118520,7 +118520,7 @@
               }
             },
             {
-              "description": "Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge) and a list of risk factors.",
+              "description": "Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge) and a list of risk factors.",
               "codeblock": {
                 "title": "Show status with badges",
                 "tabs": [
@@ -118537,7 +118537,7 @@
               }
             },
             {
-              "description": "Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button-group) for pause and cancel actions.",
+              "description": "Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button-group) for pause and cancel actions.",
               "codeblock": {
                 "title": "Add action buttons to a block",
                 "tabs": [
@@ -118591,7 +118591,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Settings and templates",
     "subSections": [
       {
@@ -118674,8 +118674,8 @@
   },
   {
     "name": "Avatar",
-    "description": "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available.\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image).",
-    "category": "Polaris web components",
+    "description": "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available.\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/avatar.png",
@@ -118864,7 +118864,7 @@
       },
       {
         "title": "Events",
-        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "AvatarEvents",
         "typeDefinitions": {
           "AvatarEvents": {
@@ -119036,7 +119036,7 @@
               }
             },
             {
-              "description": "Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text) components.",
+              "description": "Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text) components.",
               "codeblock": {
                 "title": "Build a merchant profile card",
                 "tabs": [
@@ -119059,8 +119059,8 @@
   },
   {
     "name": "Badge",
-    "description": "The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.",
-    "category": "Polaris web components",
+    "description": "The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) instead.",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/badge.png",
@@ -119251,7 +119251,7 @@
       },
       {
         "title": "Slots",
-        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "BadgeSlots",
         "typeDefinitions": {
           "BadgeSlots": {
@@ -119316,7 +119316,7 @@
               }
             },
             {
-              "description": "Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.",
+              "description": "Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.",
               "codeblock": {
                 "title": "Display badges in a table",
                 "tabs": [
@@ -119356,8 +119356,8 @@
   },
   {
     "name": "Banner",
-    "description": "The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).",
-    "category": "Polaris web components",
+    "description": "The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge).",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/banner.png",
@@ -119549,7 +119549,7 @@
       },
       {
         "title": "Events",
-        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "BannerEvents",
         "typeDefinitions": {
           "BannerEvents": {
@@ -119594,7 +119594,7 @@
       },
       {
         "title": "Slots",
-        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "BannerSlots",
         "typeDefinitions": {
           "BannerSlots": {
@@ -119650,7 +119650,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.",
+              "description": "Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.",
               "codeblock": {
                 "title": "Create a warning banner with buttons for next steps",
                 "tabs": [
@@ -119667,7 +119667,7 @@
               }
             },
             {
-              "description": "Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to review order details and adjust settings.",
+              "description": "Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to review order details and adjust settings.",
               "codeblock": {
                 "title": "Alert merchants to critical issues requiring action",
                 "tabs": [
@@ -119707,8 +119707,8 @@
   },
   {
     "name": "Box",
-    "description": "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components.\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).",
-    "category": "Polaris web components",
+    "description": "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components.\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/box.png",
@@ -119718,7 +119718,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.\n- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.\n- **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.\n- **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.\n- **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components."
+        "sectionContent": "- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.\n- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.\n- **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.\n- **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.\n- **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components."
       }
     ],
     "definitions": [
@@ -119946,7 +119946,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -119955,7 +119955,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -119964,7 +119964,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -119973,7 +119973,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -119982,7 +119982,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -119991,7 +119991,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -120000,7 +120000,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -120197,7 +120197,7 @@
       },
       {
         "title": "Slots",
-        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "BoxSlots",
         "typeDefinitions": {
           "BoxSlots": {
@@ -120319,8 +120319,8 @@
   },
   {
     "name": "Button",
-    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).",
-    "category": "Polaris web components",
+    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button-group).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/button.png",
@@ -120594,7 +120594,7 @@
       },
       {
         "title": "Events",
-        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ButtonEvents",
         "typeDefinitions": {
           "ButtonEvents": {
@@ -120647,7 +120647,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ButtonSlots",
         "typeDefinitions": {
           "ButtonSlots": {
@@ -120871,8 +120871,8 @@
   },
   {
     "name": "Button group",
-    "description": "The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button).",
-    "category": "Polaris web components",
+    "description": "The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/buttongroup.png",
@@ -121039,7 +121039,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ButtonGroupSlots",
         "typeDefinitions": {
           "ButtonGroupSlots": {
@@ -121252,8 +121252,8 @@
   },
   {
     "name": "Checkbox",
-    "description": "The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.\n\nCheckboxes support labels, help text, error states, and an indeterminate state for \"select all\" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/switch) instead.",
-    "category": "Polaris web components",
+    "description": "The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.\n\nCheckboxes support labels, help text, error states, and an indeterminate state for \"select all\" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/switch) instead.",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/checkbox.png",
@@ -121530,7 +121530,7 @@
       },
       {
         "title": "Events",
-        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "CheckboxEvents",
         "typeDefinitions": {
           "CheckboxEvents": {
@@ -121696,8 +121696,8 @@
   },
   {
     "name": "Chip",
-    "description": "The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip).",
-    "category": "Polaris web components",
+    "description": "The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/chip.png",
@@ -121707,7 +121707,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip) instead.\n- **Keep chip text concise and scannable:** Short labels like \"Featured\" or \"On sale\" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.\n- **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.\n- **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.\n- **Add icons to reinforce meaning:** Icons can make chip meanings clearer at a glance, especially for status indicators or commonly recognized categories."
+        "sectionContent": "- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip) instead.\n- **Keep chip text concise and scannable:** Short labels like \"Featured\" or \"On sale\" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.\n- **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.\n- **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.\n- **Add icons to reinforce meaning:** Icons can make chip meanings clearer at a glance, especially for status indicators or commonly recognized categories."
       },
       {
         "title": "Limitations",
@@ -121877,7 +121877,7 @@
       },
       {
         "title": "Slots",
-        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ChipSlots",
         "typeDefinitions": {
           "ChipSlots": {
@@ -121990,8 +121990,8 @@
   },
   {
     "name": "Choice list",
-    "description": "The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select).",
-    "category": "Polaris web components",
+    "description": "The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/choicelist.png",
@@ -122007,7 +122007,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select) dropdown instead.\n- Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.\n- The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.\n- Component types other than choice can't be used as options within the choice list."
+        "sectionContent": "- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select) dropdown instead.\n- Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.\n- The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.\n- Component types other than choice can't be used as options within the choice list."
       }
     ],
     "definitions": [
@@ -122232,7 +122232,7 @@
       },
       {
         "title": "Events",
-        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ChoiceListEvents",
         "typeDefinitions": {
           "ChoiceListEvents": {
@@ -122454,7 +122454,7 @@
       },
       {
         "title": "Slots",
-        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ChoiceSlots",
         "typeDefinitions": {
           "ChoiceSlots": {
@@ -122584,8 +122584,8 @@
   },
   {
     "name": "Clickable",
-    "description": "The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.",
-    "category": "Polaris web components",
+    "description": "The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/clickable.png",
@@ -122880,7 +122880,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -122889,7 +122889,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -122898,7 +122898,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -122907,7 +122907,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -122916,7 +122916,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -122925,7 +122925,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -122934,7 +122934,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -123156,7 +123156,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ClickableEvents",
         "typeDefinitions": {
           "ClickableEvents": {
@@ -123209,7 +123209,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ClickableSlots",
         "typeDefinitions": {
           "ClickableSlots": {
@@ -123405,8 +123405,8 @@
   },
   {
     "name": "Clickable chip",
-    "description": "The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).",
-    "category": "Polaris web components",
+    "description": "The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/clickable-chip.png",
@@ -123416,7 +123416,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.\n- **Choose color variants by importance:** Use `subdued` for less important or secondary chips, `base` (default) for standard selections, and `strong` to emphasize primary or active selections.\n- **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.\n- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing."
+        "sectionContent": "- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.\n- **Choose color variants by importance:** Use `subdued` for less important or secondary chips, `base` (default) for standard selections, and `strong` to emphasize primary or active selections.\n- **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.\n- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing."
       }
     ],
     "definitions": [
@@ -123640,7 +123640,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ClickableChipEvents",
         "typeDefinitions": {
           "ClickableChipEvents": {
@@ -123693,7 +123693,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ClickableChipSlots",
         "typeDefinitions": {
           "ClickableChipSlots": {
@@ -123874,8 +123874,8 @@
   },
   {
     "name": "Color field",
-    "description": "The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-picker).",
-    "category": "Polaris web components",
+    "description": "The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-picker).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/color-field.png",
@@ -124203,7 +124203,7 @@
       },
       {
         "title": "Events",
-        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ColorFieldEvents",
         "typeDefinitions": {
           "ColorFieldEvents": {
@@ -124436,8 +124436,8 @@
   },
   {
     "name": "Color picker",
-    "description": "The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field).",
-    "category": "Polaris web components",
+    "description": "The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/color-picker.png",
@@ -124447,7 +124447,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.\n- **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.\n- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control."
+        "sectionContent": "- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.\n- **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.\n- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control."
       },
       {
         "title": "Limitations",
@@ -124643,7 +124643,7 @@
       },
       {
         "title": "Events",
-        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ColorPickerEvents",
         "typeDefinitions": {
           "ColorPickerEvents": {
@@ -124736,8 +124736,8 @@
   },
   {
     "name": "Date field",
-    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-picker).",
-    "category": "Polaris web components",
+    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-picker).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/datefield.png",
@@ -125102,7 +125102,7 @@
       },
       {
         "title": "Events",
-        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "DateFieldEvents",
         "typeDefinitions": {
           "DateFieldEvents": {
@@ -125363,8 +125363,8 @@
   },
   {
     "name": "Date picker",
-    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-field).",
-    "category": "Polaris web components",
+    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/datepicker.png",
@@ -125628,7 +125628,7 @@
       },
       {
         "title": "Events",
-        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "DatePickerEvents",
         "typeDefinitions": {
           "DatePickerEvents": {
@@ -125796,8 +125796,8 @@
   },
   {
     "name": "Divider",
-    "description": "The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).",
-    "category": "Polaris web components",
+    "description": "The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "subSections": [
@@ -126048,7 +126048,7 @@
   {
     "name": "Drop zone",
     "description": "The drop zone component lets users upload files through drag-and-drop or by clicking to browse. Use for file uploads such as images, documents, or CSV imports.\n\nThe component provides visual feedback during drag operations and supports file type validation through the `accept` property. Rejected files trigger the `droprejected` event for custom error handling.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/dropzone.png",
@@ -126335,7 +126335,7 @@
       },
       {
         "title": "Events",
-        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "DropZoneEvents",
         "typeDefinitions": {
           "DropZoneEvents": {
@@ -126559,8 +126559,8 @@
   },
   {
     "name": "Email field",
-    "description": "The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/emailfield.png",
@@ -126895,7 +126895,7 @@
       },
       {
         "title": "Events",
-        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "EmailFieldEvents",
         "typeDefinitions": {
           "EmailFieldEvents": {
@@ -127055,8 +127055,8 @@
   },
   {
     "name": "Form",
-    "description": "The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/function-settings).",
-    "category": "Polaris web components",
+    "description": "The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/function-settings).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/form.png",
@@ -127066,7 +127066,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.\n- **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.\n- **Mark required fields clearly:** Use the `required` property and show validation errors only after user interaction or submission attempt.\n- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.\n- **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.\n- **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist."
+        "sectionContent": "- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.\n- **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.\n- **Mark required fields clearly:** Use the `required` property and show validation errors only after user interaction or submission attempt.\n- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.\n- **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.\n- **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist."
       },
       {
         "title": "Limitations",
@@ -127078,7 +127078,7 @@
     "definitions": [
       {
         "title": "Events",
-        "description": "The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "FormEvents",
         "typeDefinitions": {
           "FormEvents": {
@@ -127326,7 +127326,7 @@
       }
     ],
     "defaultExample": {
-      "description": "Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+      "description": "Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
       "codeblock": {
         "title": "Submit a basic form",
         "tabs": [
@@ -127350,7 +127350,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.",
+              "description": "Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.",
               "codeblock": {
                 "title": "Build a campaign form with date and money fields",
                 "tabs": [
@@ -127367,7 +127367,7 @@
               }
             },
             {
-              "description": "Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline validation errors.",
+              "description": "Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline validation errors.",
               "codeblock": {
                 "title": "Show field validation errors",
                 "tabs": [
@@ -127384,7 +127384,7 @@
               }
             },
             {
-              "description": "Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.",
+              "description": "Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.",
               "codeblock": {
                 "title": "Use select and checkbox fields",
                 "tabs": [
@@ -127401,7 +127401,7 @@
               }
             },
             {
-              "description": "Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to separate contact information from shipping preferences.",
+              "description": "Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to separate contact information from shipping preferences.",
               "codeblock": {
                 "title": "Group fields into sections",
                 "tabs": [
@@ -127424,8 +127424,8 @@
   },
   {
     "name": "Function settings",
-    "description": "The function settings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use function settings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/form).",
-    "category": "Polaris web components",
+    "description": "The function settings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use function settings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/form).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "requires": "the [Discount Function Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/discount-function-settings-api), [Validation Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/validation-settings-api), or [Order Routing Rule API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/order-routing-rule-api).",
@@ -127436,13 +127436,13 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.\n- **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.\n- **Explain impact with field details:** Use the `details` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.\n- **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.\n- **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly."
+        "sectionContent": "- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.\n- **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.\n- **Explain impact with field details:** Use the `details` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.\n- **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.\n- **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly."
       }
     ],
     "definitions": [
       {
         "title": "Events",
-        "description": "The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "FormEvents",
         "typeDefinitions": {
           "FormEvents": {
@@ -127690,7 +127690,7 @@
       }
     ],
     "defaultExample": {
-      "description": "Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for a discount percentage input inside a function settings component.",
+      "description": "Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for a discount percentage input inside a function settings component.",
       "codeblock": {
         "title": "Add a settings field for a function",
         "tabs": [
@@ -127714,7 +127714,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.",
+              "description": "Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.",
               "codeblock": {
                 "title": "Set up tiered discount rules",
                 "tabs": [
@@ -127731,7 +127731,7 @@
               }
             },
             {
-              "description": "Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline error messages.",
+              "description": "Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline error messages.",
               "codeblock": {
                 "title": "Show validation errors on settings",
                 "tabs": [
@@ -127748,7 +127748,7 @@
               }
             },
             {
-              "description": "Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for a filter value.",
+              "description": "Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for a filter value.",
               "codeblock": {
                 "title": "Add a select dropdown to settings",
                 "tabs": [
@@ -127765,7 +127765,7 @@
               }
             },
             {
-              "description": "Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field).",
+              "description": "Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field).",
               "codeblock": {
                 "title": "Toggle a feature with a switch",
                 "tabs": [
@@ -127788,8 +127788,8 @@
   },
   {
     "name": "Grid",
-    "description": "The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).",
-    "category": "Polaris web components",
+    "description": "The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "subSections": [
@@ -127970,7 +127970,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128006,7 +128006,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -128015,7 +128015,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -128024,7 +128024,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -128105,7 +128105,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -128114,7 +128114,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128123,7 +128123,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128132,7 +128132,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128141,7 +128141,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128150,7 +128150,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128159,7 +128159,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128195,7 +128195,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128446,7 +128446,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "GridSlots",
         "typeDefinitions": {
           "GridSlots": {
@@ -128709,7 +128709,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -128718,7 +128718,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128727,7 +128727,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128736,7 +128736,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128745,7 +128745,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128754,7 +128754,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128763,7 +128763,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -128960,7 +128960,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "GridItemSlots",
         "typeDefinitions": {
           "GridItemSlots": {
@@ -129065,8 +129065,8 @@
   },
   {
     "name": "Heading",
-    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.",
-    "category": "Polaris web components",
+    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/heading.png",
@@ -129249,7 +129249,7 @@
       },
       {
         "title": "Slots",
-        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "HeadingSlots",
         "typeDefinitions": {
           "HeadingSlots": {
@@ -129354,8 +129354,8 @@
   },
   {
     "name": "Icon",
-    "description": "The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.",
-    "category": "Polaris web components",
+    "description": "The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) to enhance visual communication.",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/icon.png",
@@ -129377,7 +129377,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.\n- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image) component instead.\n- Icon color is determined by the `tone` and `color` properties. Custom colors or gradients aren't available."
+        "sectionContent": "- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.\n- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image) component instead.\n- Icon color is determined by the `tone` and `color` properties. Custom colors or gradients aren't available."
       }
     ],
     "definitions": [
@@ -129710,8 +129710,8 @@
   },
   {
     "name": "Image",
-    "description": "The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).",
-    "category": "Polaris web components",
+    "description": "The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/image.png",
@@ -130064,7 +130064,7 @@
       },
       {
         "title": "Events",
-        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ImageEvents",
         "typeDefinitions": {
           "ImageEvents": {
@@ -130202,7 +130202,7 @@
               }
             },
             {
-              "description": "Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.",
+              "description": "Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.",
               "codeblock": {
                 "title": "Use in a grid layout",
                 "tabs": [
@@ -130225,8 +130225,8 @@
   },
   {
     "name": "Link",
-    "description": "The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.",
-    "category": "Polaris web components",
+    "description": "The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) instead.",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/link.png",
@@ -130464,7 +130464,7 @@
       },
       {
         "title": "Events",
-        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "LinkEvents",
         "typeDefinitions": {
           "LinkEvents": {
@@ -130501,7 +130501,7 @@
       },
       {
         "title": "Slots",
-        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "LinkSlots",
         "typeDefinitions": {
           "LinkSlots": {
@@ -130813,7 +130813,7 @@
   {
     "name": "Menu",
     "description": "The menu component displays a list of actions that can be performed on a resource or within a specific context. Use menu to present multiple related actions in a compact dropdown format, reducing visual clutter while maintaining discoverability.\n\nMenus support action grouping, icons for visual clarity, and keyboard navigation for efficient interaction.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/menu.png",
@@ -131004,7 +131004,7 @@
       },
       {
         "title": "Slots",
-        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "MenuSlots",
         "typeDefinitions": {
           "MenuSlots": {
@@ -131203,8 +131203,8 @@
   },
   {
     "name": "Money field",
-    "description": "The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field).",
-    "category": "Polaris web components",
+    "description": "The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/number-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/moneyfield.png",
@@ -131532,7 +131532,7 @@
       },
       {
         "title": "Events",
-        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "MoneyFieldEvents",
         "typeDefinitions": {
           "MoneyFieldEvents": {
@@ -131674,8 +131674,8 @@
   },
   {
     "name": "Number field",
-    "description": "The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/money-field).",
-    "category": "Polaris web components",
+    "description": "The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/money-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/numberfield.png",
@@ -131685,7 +131685,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) instead.\n- **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.\n- **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.\n- **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter."
+        "sectionContent": "- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) instead.\n- **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.\n- **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.\n- **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter."
       },
       {
         "title": "Limitations",
@@ -132046,7 +132046,7 @@
       },
       {
         "title": "Events",
-        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "NumberFieldEvents",
         "typeDefinitions": {
           "NumberFieldEvents": {
@@ -132189,8 +132189,8 @@
   },
   {
     "name": "Ordered list",
-    "description": "The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list).",
-    "category": "Polaris web components",
+    "description": "The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/ordered-list.png",
@@ -132200,7 +132200,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
+        "sectionContent": "- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
       },
       {
         "title": "Limitations",
@@ -132212,7 +132212,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "OrderedListSlots",
         "typeDefinitions": {
           "OrderedListSlots": {
@@ -132369,7 +132369,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {
@@ -132440,8 +132440,8 @@
   },
   {
     "name": "Paragraph",
-    "description": "The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).",
-    "category": "Polaris web components",
+    "description": "The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/paragraph.png",
@@ -132651,7 +132651,7 @@
       },
       {
         "title": "Slots",
-        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ParagraphSlots",
         "typeDefinitions": {
           "ParagraphSlots": {
@@ -132807,8 +132807,8 @@
   },
   {
     "name": "Password field",
-    "description": "The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/passwordfield.png",
@@ -133143,7 +133143,7 @@
       },
       {
         "title": "Events",
-        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "PasswordFieldEvents",
         "typeDefinitions": {
           "PasswordFieldEvents": {
@@ -133320,7 +133320,7 @@
   {
     "name": "Query container",
     "description": "The query container component establishes a container query context for responsive design. Use query container to define an element as a containment context, enabling child components or styles to adapt based on the container's size rather than viewport width.\n\nQuery containers support modern responsive patterns where components respond to their container dimensions, creating more flexible and reusable layouts.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "requires": "",
@@ -133486,7 +133486,7 @@
       },
       {
         "title": "Slots",
-        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "QueryContainerSlots",
         "typeDefinitions": {
           "QueryContainerSlots": {
@@ -133557,8 +133557,8 @@
   },
   {
     "name": "Search field",
-    "description": "The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/searchfield.png",
@@ -133887,7 +133887,7 @@
       },
       {
         "title": "Events",
-        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "SearchFieldEvents",
         "typeDefinitions": {
           "SearchFieldEvents": {
@@ -134030,8 +134030,8 @@
   },
   {
     "name": "Section",
-    "description": "The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/divider).",
-    "category": "Polaris web components",
+    "description": "The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/divider).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "isVisualComponent": true,
@@ -134212,7 +134212,7 @@
       },
       {
         "title": "Slots",
-        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "SectionSlots",
         "typeDefinitions": {
           "SectionSlots": {
@@ -134334,8 +134334,8 @@
   },
   {
     "name": "Select",
-    "description": "The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list).",
-    "category": "Polaris web components",
+    "description": "The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/select.png",
@@ -134345,13 +134345,13 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.\n- **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.\n- **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.\n- **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.\n- **Provide clear validation feedback:** When selection is required or invalid, explain what the merchant needs to do. Context-specific error messages help merchants complete forms faster than generic validation messages."
+        "sectionContent": "- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.\n- **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.\n- **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.\n- **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.\n- **Provide clear validation feedback:** When selection is required or invalid, explain what the merchant needs to do. Context-specific error messages help merchants complete forms faster than generic validation messages."
       },
       {
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.\n- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list) with checkboxes or build a custom multi-select component.\n- Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.\n- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).\n- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components."
+        "sectionContent": "- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.\n- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list) with checkboxes or build a custom multi-select component.\n- Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.\n- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu).\n- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu) components."
       }
     ],
     "definitions": [
@@ -134618,7 +134618,7 @@
       },
       {
         "title": "Events",
-        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "SelectEvents",
         "typeDefinitions": {
           "SelectEvents": {
@@ -134663,7 +134663,7 @@
       },
       {
         "title": "Slots",
-        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "SelectSlots",
         "typeDefinitions": {
           "SelectSlots": {
@@ -134855,7 +134855,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "OptionSlots",
         "typeDefinitions": {
           "OptionSlots": {
@@ -135029,7 +135029,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "OptionGroupSlots",
         "typeDefinitions": {
           "OptionGroupSlots": {
@@ -135184,8 +135184,8 @@
   },
   {
     "name": "Spinner",
-    "description": "The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.",
-    "category": "Polaris web components",
+    "description": "The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) component instead.",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/spinner.png",
@@ -135201,7 +135201,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.\n- The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.\n- Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.\n- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) alongside the spinner."
+        "sectionContent": "- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.\n- The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.\n- Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.\n- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) alongside the spinner."
       }
     ],
     "definitions": [
@@ -135440,8 +135440,8 @@
   },
   {
     "name": "Stack",
-    "description": "The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).",
-    "category": "Polaris web components",
+    "description": "The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/stack.png",
@@ -135622,7 +135622,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -135640,7 +135640,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'",
                 "isOptional": true
               },
@@ -135667,7 +135667,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -135739,7 +135739,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -135748,7 +135748,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -135757,7 +135757,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -135766,7 +135766,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -135775,7 +135775,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -135784,7 +135784,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -135793,7 +135793,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -135811,7 +135811,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -136055,7 +136055,7 @@
       },
       {
         "title": "Slots",
-        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "StackSlots",
         "typeDefinitions": {
           "StackSlots": {
@@ -136177,8 +136177,8 @@
   },
   {
     "name": "Switch",
-    "description": "The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/checkbox) instead.",
-    "category": "Polaris web components",
+    "description": "The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/checkbox) instead.",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/switch.png",
@@ -136447,7 +136447,7 @@
       },
       {
         "title": "Events",
-        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "SwitchEvents",
         "typeDefinitions": {
           "SwitchEvents": {
@@ -136625,7 +136625,7 @@
   {
     "name": "Table",
     "description": "The table component displays data clearly in rows and columns, helping users view, analyze, and compare structured information. Use table to present datasets, product lists, order details, or any tabular content that benefits from organized rows and columns.\n\nTables automatically adapt to screen size, rendering as lists on small screens and tables on larger ones for optimal readability across devices.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/table.png",
@@ -136905,7 +136905,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableSlots",
         "typeDefinitions": {
           "TableSlots": {
@@ -136936,7 +136936,7 @@
       },
       {
         "title": "Events",
-        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "TableEvents",
         "typeDefinitions": {
           "TableEvents": {
@@ -137115,7 +137115,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableBodySlots",
         "typeDefinitions": {
           "TableBodySlots": {
@@ -137288,7 +137288,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableCellSlots",
         "typeDefinitions": {
           "TableCellSlots": {
@@ -137476,7 +137476,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableHeaderSlots",
         "typeDefinitions": {
           "TableHeaderSlots": {
@@ -137633,7 +137633,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableHeaderRowSlots",
         "typeDefinitions": {
           "TableHeaderRowSlots": {
@@ -137798,7 +137798,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableRowSlots",
         "typeDefinitions": {
           "TableRowSlots": {
@@ -137937,8 +137937,8 @@
   },
   {
     "name": "Text",
-    "description": "The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).",
-    "category": "Polaris web components",
+    "description": "The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/text.png",
@@ -137954,7 +137954,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph) component or wrap in layout components.\n- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading) with line clamping if truncation is needed.\n- Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements."
+        "sectionContent": "- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph) component or wrap in layout components.\n- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading) with line clamping if truncation is needed.\n- Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements."
       }
     ],
     "definitions": [
@@ -138156,7 +138156,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TextSlots",
         "typeDefinitions": {
           "TextSlots": {
@@ -138329,8 +138329,8 @@
   },
   {
     "name": "Text area",
-    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/textarea.png",
@@ -138674,7 +138674,7 @@
       },
       {
         "title": "Events",
-        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "TextAreaEvents",
         "typeDefinitions": {
           "TextAreaEvents": {
@@ -138834,8 +138834,8 @@
   },
   {
     "name": "Text field",
-    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/search-field).",
-    "category": "Polaris web components",
+    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/search-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/textfield.png",
@@ -138851,7 +138851,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The `maxLength` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed `maxLength`. Always validate length server-side.\n- The `accessory` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable) components with text content."
+        "sectionContent": "- The `maxLength` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed `maxLength`. Always validate length server-side.\n- The `accessory` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable) components with text content."
       }
     ],
     "definitions": [
@@ -139204,7 +139204,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TextFieldSlots",
         "typeDefinitions": {
           "TextFieldSlots": {
@@ -139227,7 +139227,7 @@
       },
       {
         "title": "Events",
-        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "TextFieldEvents",
         "typeDefinitions": {
           "TextFieldEvents": {
@@ -139404,8 +139404,8 @@
   },
   {
     "name": "Thumbnail",
-    "description": "The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).",
-    "category": "Polaris web components",
+    "description": "The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/thumbnail.png",
@@ -139593,7 +139593,7 @@
       },
       {
         "title": "Events",
-        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ThumbnailEvents",
         "typeDefinitions": {
           "ThumbnailEvents": {
@@ -139721,7 +139721,7 @@
   {
     "name": "Tooltip",
     "description": "The tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.\n\nTooltips support keyboard accessibility, positioning options, and activation on both hover and focus for inclusive interaction patterns.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/tooltip.png",
@@ -139743,7 +139743,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TooltipSlots",
         "typeDefinitions": {
           "TooltipSlots": {
@@ -139847,8 +139847,8 @@
   },
   {
     "name": "URL field",
-    "description": "The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/urlfield.png",
@@ -140183,7 +140183,7 @@
       },
       {
         "title": "Events",
-        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "URLFieldEvents",
         "typeDefinitions": {
           "URLFieldEvents": {
@@ -140325,8 +140325,8 @@
   },
   {
     "name": "Unordered list",
-    "description": "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list).",
-    "category": "Polaris web components",
+    "description": "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/unordered-list.png",
@@ -140336,7 +140336,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
+        "sectionContent": "- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
       },
       {
         "title": "Limitations",
@@ -140348,7 +140348,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "UnorderedListSlots",
         "typeDefinitions": {
           "UnorderedListSlots": {
@@ -140505,7 +140505,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {

--- a/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Abbreviation',
   description:
     'Displays abbreviated text or acronyms, revealing their full meaning or additional context through a tooltip on hover or focus. Use to clarify shortened terms, initialisms, or technical language without interrupting the reading flow.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Announcement.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Announcement.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Announcement',
   description:
     'The Announcement component provides a less disruptive alternative to auto-open modals for capturing user attention. It provides a standardized way to engage users without being too intrusive.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Avatar.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Avatar.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Avatar',
   description:
     "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available." +
-    '\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image).',
-  category: 'Polaris web components',
+    '\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image).',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Badge.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Badge.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
     'The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.' +
-    '\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.',
-  category: 'Polaris web components',
+    '\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) instead.',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Banner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Banner.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
     'The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.' +
-    '\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).',
-  category: 'Polaris web components',
+    '\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge).',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Box.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Box.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
     "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components." +
-    '\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
-  category: 'Polaris web components',
+    '\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Button.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Button.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
     'The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use buttons to let users perform specific tasks or initiate interactions throughout the interface.' +
-    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).',
-  category: 'Polaris web components',
+    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button-group).',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Button group',
   description:
     'The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.' +
-    '\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button).',
-  category: 'Polaris web components',
+    '\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button).',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Checkbox',
   description:
     'The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.' +
-    '\n\nCheckboxes support labels, help text, error states, and an indeterminate state for "select all" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/switch) instead.',
-  category: 'Polaris web components',
+    '\n\nCheckboxes support labels, help text, error states, and an indeterminate state for "select all" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/switch) instead.',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Chip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Chip.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Chip',
   description:
     'The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.' +
-    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip).',
-  category: 'Polaris web components',
+    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Choice.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Choice.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The choice component creates individual selectable options within a choice list. Use choice to define each option that merchants can select, supporting both single selection (radio buttons) and multiple selection (checkboxes) modes.' +
     '\n\nChoice components support labels, help text, and custom content through slots, providing flexible option presentation within choice lists.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Choice list',
   description:
     'The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
-    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select).',
-  category: 'Polaris web components',
+    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Clickable.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Clickable.ts
@@ -3,9 +3,9 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.' +
+    'The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.' +
     '\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Clickable chip',
   description:
     'The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.' +
-    '\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).',
-  category: 'Polaris web components',
+    '\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip).',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ClipboardItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ClipboardItem.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Clipboard item',
   description:
     'Enables copying text to the user’s clipboard. Use alongside Button or Link components to let users easily copy content. `<s-clipboard-item>` doesn’t render visually.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ColorField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Color field',
   description:
     'The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.' +
-    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-picker).',
-  category: 'Polaris web components',
+    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-picker).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Color picker',
   description:
     'The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.' +
-    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field).',
-  category: 'Polaris web components',
+    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ConsentCheckbox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ConsentCheckbox.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Consent checkbox',
   description:
     'Use buyer consent checkboxes for collecting the buyer’s approval for a given policy.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ConsentPhoneField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ConsentPhoneField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Consent phone field',
   description:
     'Display a phone field for customers to sign up for text message marketing, noting that the phone field value will be automatically saved during checkout.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/DateField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DateField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Date field',
   description:
     'The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-picker).',
-  category: 'Polaris web components',
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-picker).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Date picker',
   description:
     'The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Details.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Details.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Details',
   description:
     'Creates a collapsible content area that can be expanded or collapsed by users. Use with Summary to provide expandable sections for additional information or settings.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Divider.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Divider.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
     'The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.' +
-    '\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).',
-  category: 'Polaris web components',
+    '\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/DropZone.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DropZone.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Drop zone',
   description:
     'The drop zone component lets users upload files through drag-and-drop or by clicking to browse. Use for file uploads such as images, documents, or CSV imports.\n\nThe component provides visual feedback during drag operations and supports file type validation through the `accept` property. Rejected files trigger the `droprejected` event for custom error handling.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/EmailField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/EmailField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Email field',
   description:
     'The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-  category: 'Polaris web components',
+    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Form.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Form.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Form',
   description:
     'The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.' +
-    "\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/function-settings).",
-  category: 'Polaris web components',
+    "\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/function-settings).",
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/FunctionSettings.ts
+++ b/packages/ui-extensions/src/docs/shared/components/FunctionSettings.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Function settings',
   description:
     'The function settings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use function settings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.' +
-    '\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/form).',
-  category: 'Polaris web components',
+    '\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/form).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Grid.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Grid.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Grid',
   description:
     'The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.' +
-    '\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
-  category: 'Polaris web components',
+    '\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/GridItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/GridItem.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The grid item component represents a single cell within a grid layout, allowing you to control how content is positioned and sized within the grid. Use grid item as a child of grid to specify column span, row span, and positioning for individual content areas.' +
     '\n\nGrid item supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Heading.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Heading.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
     'The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.' +
-    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
-  category: 'Polaris web components',
+    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Icon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Icon.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
     'The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.' +
-    '\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.',
-  category: 'Polaris web components',
+    '\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) to enhance visual communication.',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Image.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Image.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
     'The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.' +
-    '\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
-  category: 'Polaris web components',
+    '\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Link.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Link.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Link',
   description:
     'The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.' +
-    '\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.',
-  category: 'Polaris web components',
+    '\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) instead.',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ListItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ListItem.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The list item component represents a single entry within an ordered list or unordered list. Use list item to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.' +
     '\n\nList item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Map.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Map.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Map',
   description:
     'Use Map to display a map on a page. This component is useful for displaying a map of a location, such as a store or a customer’s address.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/MapMarker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/MapMarker.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Map marker',
   description:
     'Use MapMarker to display a marker on a map. Use only as a child of `s-map` component.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Menu.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Menu.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The menu component displays a list of actions that can be performed on a resource or within a specific context. Use menu to present multiple related actions in a compact dropdown format, reducing visual clutter while maintaining discoverability.' +
     '\n\nMenus support action grouping, icons for visual clarity, and keyboard navigation for efficient interaction.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Modal.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Modal.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
     'The modal component displays content in an overlay. Use to create a distraction-free experience such as a confirmation dialog or a settings panel.\n\nA button triggers the modal using the `commandFor` attribute. Content within the modal scrolls if it exceeds available height.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Money field',
   description:
     'The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.' +
-    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field).',
-  category: 'Polaris web components',
+    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/number-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/NumberField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/NumberField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Number field',
   description:
     'The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
-    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/money-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/money-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Option.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Option.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Option',
   description:
     'Represents a single option within a select component. Use only as a child of `s-select` components.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/OptionGroup.ts
+++ b/packages/ui-extensions/src/docs/shared/components/OptionGroup.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Option group',
   description:
     'Represents a group of options within a select component. Use only as a child of `s-select` components.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Ordered list',
   description:
     'The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.' +
-    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list).",
-  category: 'Polaris web components',
+    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list).",
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Page.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Page.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
     "The page component provides a styled page layout within your app, including breadcrumbs, page actions, and content areas with automatic spacing.\n\nUse page when you need a complete page layout with Polaris styling. For apps that need to set the Shopify admin's native title bar (title, breadcrumbs, actions) without a styled page layout, use the [title bar](/docs/api/{API_NAME}/{API_VERSION}/app-bridge-web-components/title-bar) App Bridge component instead.",
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Paragraph',
   description:
     'The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.' +
-    '\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).',
-  category: 'Polaris web components',
+    '\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Password field',
   description:
     'The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.' +
-    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PaymentIcon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PaymentIcon.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Payment icon',
   description:
     'Displays icons representing payment methods. Use to visually communicate available or saved payment options clearly',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PhoneField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PhoneField.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Phone field',
   description: 'Use PhoneField to allow users to enter phone numbers.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Popover.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Popover.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Popover',
   description:
-    "The popover component displays contextual content in an overlay triggered by a button using the [`commandFor`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) attribute. Use for secondary actions, settings, or information that doesn't require a full modal.\n\nFor interactions that need more space or user focus, such as confirmations or complex forms, use [modal](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/overlays/modal) instead.",
-  category: 'Polaris web components',
+    "The popover component displays contextual content in an overlay triggered by a button using the [`commandFor`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) attribute. Use for secondary actions, settings, or information that doesn't require a full modal.\n\nFor interactions that need more space or user focus, such as confirmations or complex forms, use [modal](/docs/api/{API_NAME}/{API_VERSION}/web-components/overlays/modal) instead.",
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PressButton.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PressButton.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Press button',
   description:
     'Allows users to toggle between active/inactive states. Use to represent a persistent on/off or selected/unselected status.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ProductThumbnail.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ProductThumbnail.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Product thumbnail',
   description: 'Use ProductThumbnail to display a product thumbnail',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Progress.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Progress.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Progress',
   description:
     'Displays an indicator showing the completion status of a task. Use to visually communicate progress in either determinate (known percentage) or indeterminate (unknown duration) states.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/QRCode.ts
+++ b/packages/ui-extensions/src/docs/shared/components/QRCode.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'QR code',
   description:
     'Displays a scannable QR code representing data such as URLs or text. Use to let users quickly access information by scanning with a smartphone or other device.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/QueryContainer.ts
+++ b/packages/ui-extensions/src/docs/shared/components/QueryContainer.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     "The query container component establishes a container query context for responsive design. Use query container to define an element as a containment context, enabling child components or styles to adapt based on the container's size rather than viewport width." +
     '\n\nQuery containers support modern responsive patterns where components respond to their container dimensions, creating more flexible and reusable layouts.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ScrollBox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ScrollBox.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Scroll box',
   description:
     'Provides a scrollable container for long content that exceeds the available space. Use to display lists, order summaries, or other lengthy content while maintaining a constrained layout.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/SearchField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SearchField.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Search field',
   description:
-    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Section.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Section.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
     'The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.' +
-    '\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/divider).',
-  category: 'Polaris web components',
+    '\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/divider).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Select.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Select.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Select',
   description:
     'The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.' +
-    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list).',
-  category: 'Polaris web components',
+    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Sheet.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Sheet.ts
@@ -6,7 +6,7 @@ const data: SharedReferenceEntityTemplateSchema = {
 The Sheet component displays essential information for customers at the bottom of the screen, appearing above other elements. Use it sparingly to avoid distracting customers during checkout. This component requires access to [Customer Privacy API](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be rendered.
 
 The library automatically applies the [WAI-ARIA Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) to both the activator and the sheet content.`,
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/SkeletonParagraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SkeletonParagraph.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Skeleton paragraph',
   description:
     'Displays a placeholder representation of text content while it loads. Use to improve perceived performance by showing users where text will appear.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Spinner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Spinner.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Spinner',
   description:
     'The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.' +
-    '\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.',
-  category: 'Polaris web components',
+    '\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) component instead.',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Stack.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Stack.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
     'The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.' +
-    '\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
-  category: 'Polaris web components',
+    '\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Summary.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Summary.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Summary',
   description:
     'Provides a clickable label for collapsible Details content. Use to create clear, accessible disclosure controls that show or hide additional information.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Switch.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Switch.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Switch',
   description:
     'The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.' +
-    "\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/checkbox) instead.",
-  category: 'Polaris web components',
+    "\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/checkbox) instead.",
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Table.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Table.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table component displays data clearly in rows and columns, helping users view, analyze, and compare structured information. Use table to present datasets, product lists, order details, or any tabular content that benefits from organized rows and columns.' +
     '\n\nTables automatically adapt to screen size, rendering as lists on small screens and tables on larger ones for optimal readability across devices.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableBody.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableBody.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table body component represents the main content area of a table, containing the data rows. Use table body as a child of table to structure your table data, with each table row within the body representing a single record or entry.' +
     '\n\nTable body must contain table row components, which in turn contain table cell components for the actual data values.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableCell.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableCell.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table cell component represents a single data cell within a table row. Use table cell as a child of table row to display individual data values, with each cell corresponding to a column in the table.' +
     '\n\nTable cell automatically inherits styling and alignment from its parent table structure and supports text content or other inline components.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table header component represents a single column header within a table header row. Use table header as a child of table header row to define column headings and optionally enable column sorting.' +
     '\n\nTable header provides semantic meaning for screen readers and can include sorting controls when configured. Each header corresponds to a column in the table body.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table header row component represents the header row of a table, containing column headings. Use table header row as the first child of table (before table body) to define the table structure and provide column labels.' +
     '\n\nTable header row must contain table header components for each column. These headers provide context for the data columns and can support sorting functionality.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableRow.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table row component represents a single row of data within a table body. Use table row as a child of table body to structure individual records or entries in the table.' +
     '\n\nTable row must contain table cell components, with each cell representing a data value for the corresponding column. The number of cells should match the number of headers in the table.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Text.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Text.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
     'The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.' +
-    '\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).',
-  category: 'Polaris web components',
+    '\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TextArea.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextArea.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text area',
   description:
     'The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TextField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text field',
   description:
     'The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/search-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/search-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Thumbnail',
   description:
     'The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.' +
-    '\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
-  category: 'Polaris web components',
+    '\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Time.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Time.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Time',
   description:
     'Represents a specific point or duration in time. Use to display dates, times, or durations clearly and consistently. May include a machine-readable `datetime` attribute for improved accessibility and functionality.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.' +
     '\n\nTooltips support keyboard accessibility, positioning options, and activation on both hover and focus for inclusive interaction patterns.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/URLField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/URLField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'URL field',
   description:
     'The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.' +
-    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Unordered list',
   description:
     "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning." +
-    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list).',
-  category: 'Polaris web components',
+    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.',
   defaultExample: {
     description:
       'Send selected product IDs to your backend for bulk processing. This example shows how to map selected items, make an authenticated API call, and close the modal when the operation completes.',
@@ -74,7 +74,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n' +
-        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
+        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) components during async operations to prevent duplicate submissions.",
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
-      "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/spinner) component while fetching.",
+      "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/spinner) component while fetching.",
     codeblock: {
       title: 'Display product information',
       tabs: [
@@ -35,7 +35,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+          'Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
         codeblock: {
           title: 'Navigate to action extension',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.',
+      'Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.',
     codeblock: {
       title: 'Set minimum quantity',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.',
+      'Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.',
     codeblock: {
       title: 'Configure discount threshold',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',
+      'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',
     codeblock: {
       title: 'Configure location priority',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-print-action) component.',
+    'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-print-action) component.',
   defaultExample: {
     description:
       "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and setting the printable URL as the `src` prop to display the document.",

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
       'Open the product [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select up to five components for a [bundle](/docs/apps/build/product-merchandising/bundles). This example filters out draft and archived products, saves the bundle configuration to your backend, and tracks the selection count.',

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
       'Use the product variant [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component variants for a [bundle](/docs/apps/build/product-merchandising/bundles). This example picks product variants, tracks selections, and posts the product variant IDs to configure the bundle.',

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.',
   defaultExample: {
     description:
       'Update a subscription by sending product and selling plan IDs to your backend. This example checks for selling plan presence, posts the update request, and shows a success banner before auto-closing the modal.',

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -5282,7 +5282,7 @@ export interface BoxProps
    *
    * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -5294,7 +5294,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5302,7 +5302,7 @@ export interface BoxProps
   /**
    * The block-start padding (top in horizontal writing modes).
    *
-   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5310,7 +5310,7 @@ export interface BoxProps
   /**
    * The block-end padding (bottom in horizontal writing modes).
    *
-   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5322,7 +5322,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5330,7 +5330,7 @@ export interface BoxProps
   /**
    * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5338,7 +5338,7 @@ export interface BoxProps
   /**
    * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -6664,9 +6664,9 @@ export interface GridProps
    * Adjusts spacing between elements.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`
    * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
@@ -6675,8 +6675,8 @@ export interface GridProps
    * s spacing between elements in the block axis. This overrides the row value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -6685,8 +6685,8 @@ export interface GridProps
    * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -6696,7 +6696,7 @@ export interface GridProps
    *
    * Accepts:
    * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
@@ -6706,7 +6706,7 @@ export interface GridProps
    *
    * Accepts:
    * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
@@ -8072,9 +8072,9 @@ export interface StackProps
    * Adjusts spacing between elements.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`
    * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
@@ -8083,8 +8083,8 @@ export interface StackProps
    * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -8093,8 +8093,8 @@ export interface StackProps
    * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -8104,7 +8104,7 @@ export interface StackProps
    *
    * Accepts:
    * - A single value, either `inline` or `block`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value
    *
    * @default 'block'
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ext.doc.ts
@@ -21,11 +21,11 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'AdminActionSlots',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Settings and templates',
   subSections: [
     {
@@ -42,7 +42,7 @@ const data: ReferenceEntityTemplateSchema = {
     image:
       '/assets/templated-apis-screenshots/admin/components/adminaction-example.png',
     description:
-      'Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.',
+      'Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.',
     codeblock: {
       title: 'Configure an admin action modal',
       tabs: [
@@ -62,7 +62,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+              'Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
             codeblock: {
               title: 'Show a loading state',
               tabs: [
@@ -76,7 +76,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Collect merchant input inside the action modal using form fields. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) arranged in a [stack](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
+              'Collect merchant input inside the action modal using form fields. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) arranged in a [stack](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/stack).',
             codeblock: {
               title: 'Add form fields to the modal',
               tabs: [
@@ -90,7 +90,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) to confirm deletion.',
+              'Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) to confirm deletion.',
             codeblock: {
               title: 'Confirm a destructive action',
               tabs: [
@@ -104,7 +104,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+              'Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
             codeblock: {
               title: 'Show resource details in a modal',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
@@ -19,7 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'AdminBlockProps',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Settings and templates',
   subSections: [
     {
@@ -45,7 +45,7 @@ const data: ReferenceEntityTemplateSchema = {
     image:
       '/assets/templated-apis-screenshots/admin/components/adminblock-example.png',
     description:
-      'Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) content.',
+      'Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) content.',
     codeblock: {
       title: 'Display an inline admin block',
       tabs: [
@@ -65,7 +65,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) summary in the block header.',
+              'Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) summary in the block header.',
             codeblock: {
               title: 'Show a collapsed summary',
               tabs: [
@@ -79,7 +79,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/table).',
+              'Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/table).',
             codeblock: {
               title: 'Display a data table',
               tabs: [
@@ -93,7 +93,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge) and a list of risk factors.',
+              'Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge) and a list of risk factors.',
             codeblock: {
               title: 'Show status with badges',
               tabs: [
@@ -107,7 +107,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button-group) for pause and cancel actions.',
+              'Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button-group) for pause and cancel actions.',
             codeblock: {
               title: 'Add action buttons to a block',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ext.doc.ts
@@ -19,7 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'AdminPrintActionProps',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Settings and templates',
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'AvatarEvents',
     },
   ],
@@ -137,7 +137,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text) components.',
+              'Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text) components.',
             codeblock: {
               title: 'Build a merchant profile card',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -208,7 +208,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'BadgeSlots',
     },
   ],
@@ -76,7 +76,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.',
+              'Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.',
             codeblock: {
               title: 'Display badges in a table',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
@@ -36,13 +36,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'BannerEvents',
     },
     {
       title: 'Slots',
       description:
-        'The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'BannerSlots',
     },
   ],
@@ -69,7 +69,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.',
+              'Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.',
             codeblock: {
               title: 'Create a warning banner with buttons for next steps',
               tabs: [
@@ -83,7 +83,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to review order details and adjust settings.',
+              'Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to review order details and adjust settings.',
             codeblock: {
               title: 'Alert merchants to critical issues requiring action',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
@@ -10,8 +10,8 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.
-- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.
+      sectionContent: `- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.
+- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.
 - **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.
 - **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.
 - **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components.`,
@@ -26,7 +26,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'BoxSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -44,7 +44,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
@@ -36,13 +36,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ButtonEvents',
     },
     {
       title: 'Slots',
       description:
-        'The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ButtonSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ButtonGroupSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'CheckboxEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip/Chip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip/Chip.doc.ts
@@ -10,7 +10,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip) instead.
+      sectionContent: `- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip) instead.
 - **Keep chip text concise and scannable:** Short labels like "Featured" or "On sale" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.
 - **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.
 - **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ChipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -22,7 +22,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select) dropdown instead.
+      sectionContent: `- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select) dropdown instead.
 - Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.
 - The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.
 - Component types other than choice can't be used as options within the choice list.`,
@@ -38,7 +38,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ChoiceListEvents',
     },
     {
@@ -49,7 +49,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ChoiceSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -197,7 +197,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -209,7 +209,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -219,7 +219,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -229,7 +229,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -241,7 +241,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -251,7 +251,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -261,7 +261,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
@@ -26,20 +26,20 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ClickableEvents',
     },
     {
       title: 'Slots',
       description:
-        'The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ClickableSlots',
     },
   ],
   defaultExample: {
     image: 'clickable-default.png',
     description:
-      "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
+      "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
     codeblock: {
       title: 'Create a custom interactive element',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip/ClickableChip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip/ClickableChip.doc.ts
@@ -14,7 +14,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       sectionContent: `- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.
 - **Choose color variants by importance:** Use \`subdued\` for less important or secondary chips, \`base\` (default) for standard selections, and \`strong\` to emphasize primary or active selections.
 - **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.
-- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing.`,
+- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing.`,
     },
   ],
   definitions: [
@@ -27,13 +27,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ClickableChipEvents',
     },
     {
       title: 'Slots',
       description:
-        'The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ClickableChipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
@@ -31,7 +31,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ColorFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
@@ -13,7 +13,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.
 - **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.
-- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control.`,
+- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control.`,
     },
     {
       title: 'Limitations',
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ColorPickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'DateFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'DatePickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
@@ -3,7 +3,7 @@ import shared from '../../../../docs/shared/components/DropZone';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/dropzone.png',
   isVisualComponent: true,
   subSections: [
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'DropZoneEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'EmailFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
@@ -3,7 +3,7 @@ import shared from '../../../../docs/shared/components/Form';
 
 const data: ReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/form.png',
   isVisualComponent: true,
   subSections: [
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.
 - **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.
 - **Mark required fields clearly:** Use the \`required\` property and show validation errors only after user interaction or submission attempt.
-- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.
+- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.
 - **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.
 - **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist.`,
     },
@@ -29,13 +29,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'FormEvents',
     },
   ],
   defaultExample: {
     description:
-      'Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+      'Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
     codeblock: {
       title: 'Submit a basic form',
       tabs: [
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.',
+              'Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.',
             codeblock: {
               title: 'Build a campaign form with date and money fields',
               tabs: [
@@ -69,7 +69,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline validation errors.',
+              'Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline validation errors.',
             codeblock: {
               title: 'Show field validation errors',
               tabs: [
@@ -83,7 +83,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.',
+              'Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.',
             codeblock: {
               title: 'Use select and checkbox fields',
               tabs: [
@@ -97,7 +97,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to separate contact information from shipping preferences.',
+              'Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to separate contact information from shipping preferences.',
             codeblock: {
               title: 'Group fields into sections',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
@@ -5,7 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   ...shared,
   requires:
     'the [Discount Function Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/discount-function-settings-api), [Validation Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/validation-settings-api), or [Order Routing Rule API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/order-routing-rule-api).',
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/form.png',
   isVisualComponent: true,
   subSections: [
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.
 - **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.
-- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.
+- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.
 - **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.
 - **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly.`,
     },
@@ -24,13 +24,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'FormEvents',
     },
   ],
   defaultExample: {
     description:
-      'Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for a discount percentage input inside a function settings component.',
+      'Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for a discount percentage input inside a function settings component.',
     codeblock: {
       title: 'Add a settings field for a function',
       tabs: [
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.',
+              'Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.',
             codeblock: {
               title: 'Set up tiered discount rules',
               tabs: [
@@ -64,7 +64,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline error messages.',
+              'Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline error messages.',
             codeblock: {
               title: 'Show validation errors on settings',
               tabs: [
@@ -78,7 +78,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for a filter value.',
+              'Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for a filter value.',
             codeblock: {
               title: 'Add a select dropdown to settings',
               tabs: [
@@ -92,7 +92,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field).',
+              'Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field).',
             codeblock: {
               title: 'Toggle a feature with a switch',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -175,7 +175,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -187,7 +187,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -197,7 +197,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -207,7 +207,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -219,7 +219,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -229,7 +229,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -239,7 +239,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -362,31 +362,31 @@ export interface GridProps
     | `${AlignContentKeyword} ${JustifyContentKeyword}`
     | AlignContentKeyword;
   /**
-   * The spacing between grid rows and columns. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for rows and columns. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between grid rows and columns. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for rows and columns. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gap: ResponsiveGridProps['gap'];
   /**
-   * The spacing between grid rows. This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between grid rows. This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveGridProps['rowGap'];
   /**
-   * The spacing between grid columns. This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between grid columns. This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveGridProps['columnGap'];
   /**
-   * The number of columns and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 1fr)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The number of columns and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 1fr)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];
   /**
-   * The number of rows and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 100px)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The number of rows and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 100px)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
@@ -32,7 +32,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'GridSlots',
     },
     {
@@ -43,7 +43,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'GridItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -170,7 +170,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -182,7 +182,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -192,7 +192,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -202,7 +202,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -214,7 +214,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -224,7 +224,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -234,7 +234,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'HeadingSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.
-- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image) component instead.
+- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image) component instead.
 - Icon color is determined by the \`tone\` and \`color\` properties. Custom colors or gradients aren't available.`,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -205,7 +205,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -217,7 +217,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -227,7 +227,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -237,7 +237,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -249,7 +249,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -259,7 +259,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -269,7 +269,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
@@ -11,7 +11,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'best-practices',
       sectionContent: `- **Always provide descriptive alternative text:** Write alt text that describes what's in the image, not what the image is for. Use "Blue cotton t-shirt with crew neck" instead of "Product image." For decorative images that don't add information, use an empty alt attribute.
-- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [Icon](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/icon) component instead.
+- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [Icon](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/icon) component instead.
 - **Ensure images are accessible and performant:** Use appropriate image formats (WebP for photos, PNG for graphics with transparency, SVG for logos). Ensure images load from reliable sources with proper CORS configuration if cross-origin.
 - **Consider the image's purpose and context:** Use images to help merchants understand products, visualize data, or follow instructions. Every image should serve a clear purpose in your interface.`,
     },
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ImageEvents',
     },
   ],
@@ -116,7 +116,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.',
+              'Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.',
             codeblock: {
               title: 'Use in a grid layout',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
@@ -31,13 +31,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'LinkEvents',
     },
     {
       title: 'Slots',
       description:
-        'The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'LinkSlots',
     },
   ],
@@ -64,7 +64,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Embed links within a [Paragraph](/docs/api/app-home/polaris-web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.',
+              'Embed links within a [Paragraph](/docs/api/app-home/web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.',
             codeblock: {
               title: 'Embed links in paragraph text',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu/Menu.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu/Menu.doc.ts
@@ -36,7 +36,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'MenuSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Modal/Modal.ab.doc.ts
@@ -34,13 +34,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).',
       type: 'ModalEvents',
     },
     {
       title: 'Slots',
       description:
-        'The modal component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The modal component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).',
       type: 'ModalSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -37,7 +37,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'MoneyFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -11,7 +11,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) instead.
+      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) instead.
 - **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.
 - **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.
 - **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter.`,
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'NumberFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list) instead.
+      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'OrderedListSlots',
     },
     {
@@ -39,7 +39,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ListItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Page/Page.ab.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The page component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The page component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).',
       type: 'PageSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
@@ -35,7 +35,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ParagraphSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'PasswordFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
@@ -3,7 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Popover';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/popover.png',
   isVisualComponent: true,
   subSections: [
@@ -34,13 +34,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The popover component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).',
+        'The popover component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).',
       type: 'PopoverEvents',
     },
     {
       title: 'Slots',
       description:
-        'The popover component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).',
+        'The popover component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).',
       type: 'PopoverSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer/QueryContainer.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer/QueryContainer.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'QueryContainerSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'SearchFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'SectionSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.
+      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.
 - **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.
 - **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.
 - **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.
@@ -23,10 +23,10 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.
-- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list) with checkboxes or build a custom multi-select component.
+- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list) with checkboxes or build a custom multi-select component.
 - Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.
-- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).
-- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components.`,
+- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu).
+- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu) components.`,
     },
   ],
   definitions: [
@@ -39,13 +39,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'SelectEvents',
     },
     {
       title: 'Slots',
       description:
-        'The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'SelectSlots',
     },
     {
@@ -56,7 +56,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'OptionSlots',
     },
     {
@@ -67,7 +67,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'OptionGroupSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
@@ -22,7 +22,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       sectionContent: `- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.
 - The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.
 - Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.
-- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) alongside the spinner.`,
+- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) alongside the spinner.`,
     },
   ],
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -174,7 +174,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -186,7 +186,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -196,7 +196,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -206,7 +206,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -218,7 +218,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -228,7 +228,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -238,7 +238,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -340,25 +340,25 @@ export interface StackProps
    */
   alignContent: AlignContentKeyword;
   /**
-   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gap: ResponsiveStackProps['gap'];
   /**
-   * The spacing between children in the block axis (vertical in horizontal writing modes). This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the block axis (vertical in horizontal writing modes). This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveStackProps['rowGap'];
   /**
-   * The spacing between children in the inline axis (horizontal in left-to-right languages). This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the inline axis (horizontal in left-to-right languages). This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveStackProps['columnGap'];
   /**
-   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'block'
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
@@ -30,7 +30,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'StackSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'SwitchEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -39,13 +39,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableSlots',
     },
     {
       title: 'Events',
       description:
-        'The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'TableEvents',
     },
     {
@@ -56,7 +56,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableBodySlots',
     },
     {
@@ -67,7 +67,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableCellSlots',
     },
     {
@@ -78,7 +78,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableHeaderSlots',
     },
     {
@@ -89,7 +89,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableHeaderRowSlots',
     },
     {
@@ -100,7 +100,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableRowSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
@@ -19,8 +19,8 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph) component or wrap in layout components.
-- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading) with line clamping if truncation is needed.
+      sectionContent: `- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph) component or wrap in layout components.
+- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading) with line clamping if truncation is needed.
 - Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements.`,
     },
   ],
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TextSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'TextAreaEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -59,7 +59,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
@@ -21,7 +21,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- The \`maxLength\` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed \`maxLength\`. Always validate length server-side.
-- The \`accessory\` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable) components with text content.`,
+- The \`accessory\` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable) components with text content.`,
     },
   ],
   definitions: [
@@ -34,13 +34,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TextFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'TextFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
@@ -36,7 +36,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ThumbnailEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.doc.ts
@@ -29,7 +29,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TooltipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -37,7 +37,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'URLFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list) instead.
+      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'UnorderedListSlots',
     },
     {
@@ -39,7 +39,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ListItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/accountConnection.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/accountConnection.ab.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Settings'],
   defaultExample: {
     description:
-      'Merchants need to connect or disconnect external services (e.g. marketing platforms, sales channels) from your app. This pattern displays account connection layout with a connect button and terms. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) aligns account information and button, the [section](/docs/api/app-home/polaris-web-components/layout-and-structure/section) provides padding, and the terms text below describes the connection agreement.',
+      'Merchants need to connect or disconnect external services (e.g. marketing platforms, sales channels) from your app. This pattern displays account connection layout with a connect button and terms. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) aligns account information and button, the [section](/docs/api/app-home/web-components/layout-and-structure/section) provides padding, and the terms text below describes the connection agreement.',
     codeblock: {
       title: 'Display connection status with connect button and terms',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/appCard.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/appCard.ab.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Homepage'],
   defaultExample: {
     description:
-      "Merchants can discover and install complementary apps that extend your app's functionality. This pattern displays a tappable app card with thumbnail and content layout. The [clickable](/docs/api/app-home/polaris-web-components/actions/clickable) component wraps the card, the [thumbnail](/docs/api/app-home/polaris-web-components/images/thumbnail) shows the app icon, and the [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) aligns the content.",
+      "Merchants can discover and install complementary apps that extend your app's functionality. This pattern displays a tappable app card with thumbnail and content layout. The [clickable](/docs/api/app-home/web-components/actions/clickable) component wraps the card, the [thumbnail](/docs/api/app-home/web-components/images/thumbnail) shows the app icon, and the [grid](/docs/api/app-home/web-components/layout-and-structure/grid) aligns the content.",
     codeblock: {
       title: 'Display a tappable app card with thumbnail and content',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/calloutCard.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/calloutCard.ab.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Homepage'],
   defaultExample: {
     description:
-      'Merchants can take action on new features or opportunities you highlight. This pattern presents a callout card that stacks content on smaller screens with a prominent illustration and call-to-action. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) uses responsive column templates. The illustration and button draw attention to important actions or promotions.',
+      'Merchants can take action on new features or opportunities you highlight. This pattern presents a callout card that stacks content on smaller screens with a prominent illustration and call-to-action. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) uses responsive column templates. The illustration and button draw attention to important actions or promotions.',
     codeblock: {
       title: 'Display a callout card with illustration and call-to-action',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/emptyState.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/emptyState.ab.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Index'],
   defaultExample: {
     description:
-      'Merchants need guidance and a clear next step when a list or page is empty. This pattern displays an empty state with centered content and primary and secondary actions. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) centers content vertically and horizontally. Use the [button group](/docs/api/app-home/polaris-web-components/actions/button-group) with `slot="primary-action"` and `slot="secondary-actions"` for clear next steps.',
+      'Merchants need guidance and a clear next step when a list or page is empty. This pattern displays an empty state with centered content and primary and secondary actions. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) centers content vertically and horizontally. Use the [button group](/docs/api/app-home/web-components/actions/button-group) with `slot="primary-action"` and `slot="secondary-actions"` for clear next steps.',
     codeblock: {
       title: 'Display an empty state with centered content and actions',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/footerHelp.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/footerHelp.ab.doc.ts
@@ -18,7 +18,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Homepage', 'Index', 'Details', 'Settings'],
   defaultExample: {
     description:
-      'Merchants can find documentation or support when they need more context than a page provides. This pattern displays centered help text with an external documentation link. The [stack](/docs/api/app-home/polaris-web-components/layout-and-structure/stack) uses `alignItems="center"` to center the text, and the [link](/docs/api/app-home/polaris-web-components/navigation/link) uses `target="_blank"` for links that open in a new tab.',
+      'Merchants can find documentation or support when they need more context than a page provides. This pattern displays centered help text with an external documentation link. The [stack](/docs/api/app-home/web-components/layout-and-structure/stack) uses `alignItems="center"` to center the text, and the [link](/docs/api/app-home/web-components/navigation/link) uses `target="_blank"` for links that open in a new tab.',
     codeblock: {
       title: 'Display centered help text with documentation link',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/indexTable.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/indexTable.ab.doc.ts
@@ -36,7 +36,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Index'],
   defaultExample: {
     description:
-      'Merchants need to view, search, filter, and take bulk actions on collections of items. This pattern displays an index table with search, sort, and bulk actions. Key attributes include `slot="filters"` on the [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) to place controls in the filters area, `clickDelegate` on [table rows](/docs/api/app-home/polaris-web-components/layout-and-structure/table) to connect clicks to checkboxes, and `listSlot` on [table headers](/docs/api/app-home/polaris-web-components/layout-and-structure/table) to control responsive stacking. Use the [Navigation API](/docs/api/app-home/apis/navigation) for programmatic navigation and the [Toast API](/docs/api/app-home/apis/toast) for confirming successful actions.',
+      'Merchants need to view, search, filter, and take bulk actions on collections of items. This pattern displays an index table with search, sort, and bulk actions. Key attributes include `slot="filters"` on the [grid](/docs/api/app-home/web-components/layout-and-structure/grid) to place controls in the filters area, `clickDelegate` on [table rows](/docs/api/app-home/web-components/layout-and-structure/table) to connect clicks to checkboxes, and `listSlot` on [table headers](/docs/api/app-home/web-components/layout-and-structure/table) to control responsive stacking. Use the [Navigation API](/docs/api/app-home/apis/navigation) for programmatic navigation and the [Toast API](/docs/api/app-home/apis/toast) for confirming successful actions.',
     codeblock: {
       title: 'Display an index table with search, sort, and bulk actions',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/interstitialNav.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/interstitialNav.ab.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Settings'],
   defaultExample: {
     description:
-      'Merchants need clear paths to deeper pages (e.g. settings, features) without cluttering main navigation. This pattern displays a navigation menu with drill-down rows. [Clickable](/docs/api/app-home/polaris-web-components/actions/clickable) rows sit in a bordered [box](/docs/api/app-home/polaris-web-components/layout-and-structure/box). Each row uses the [icon](/docs/api/app-home/polaris-web-components/images/icon) with `name="chevron-right"` to indicate navigation.',
+      'Merchants need clear paths to deeper pages (e.g. settings, features) without cluttering main navigation. This pattern displays a navigation menu with drill-down rows. [Clickable](/docs/api/app-home/web-components/actions/clickable) rows sit in a bordered [box](/docs/api/app-home/web-components/layout-and-structure/box). Each row uses the [icon](/docs/api/app-home/web-components/images/icon) with `name="chevron-right"` to indicate navigation.',
     codeblock: {
       title: 'Display a navigation menu with drill-down rows',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/mediaCard.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/mediaCard.ab.doc.ts
@@ -26,7 +26,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Homepage'],
   defaultExample: {
     description:
-      'Merchants can see visual content (images, illustrations) paired with actions, like tutorials or feature highlights. This pattern displays a media card with a tappable image and footer layout. The [box](/docs/api/app-home/polaris-web-components/layout-and-structure/box) uses `border` and `borderRadius` for the container, the [clickable](/docs/api/app-home/polaris-web-components/actions/clickable) component makes the image tappable, and the [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) lays out the footer with title and action button.',
+      'Merchants can see visual content (images, illustrations) paired with actions, like tutorials or feature highlights. This pattern displays a media card with a tappable image and footer layout. The [box](/docs/api/app-home/web-components/layout-and-structure/box) uses `border` and `borderRadius` for the container, the [clickable](/docs/api/app-home/web-components/actions/clickable) component makes the image tappable, and the [grid](/docs/api/app-home/web-components/layout-and-structure/grid) lays out the footer with title and action button.',
     codeblock: {
       title: 'Display a media card with tappable image and footer',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/metricsCard.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/metricsCard.ab.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Index'],
   defaultExample: {
     description:
-      'Merchants want to see key numbers and trends at a glance. This pattern displays metrics in a responsive grid with trend indicators. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) uses responsive column templates for side-by-side layout on large screens and stacked layout on small screens. The [badge](/docs/api/app-home/polaris-web-components/feedback/badge) component shows trend indicators.',
+      'Merchants want to see key numbers and trends at a glance. This pattern displays metrics in a responsive grid with trend indicators. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) uses responsive column templates for side-by-side layout on large screens and stacked layout on small screens. The [badge](/docs/api/app-home/web-components/feedback/badge) component shows trend indicators.',
     codeblock: {
       title: 'Display metrics in a responsive grid with trend indicators',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/resourceList.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/resourceList.ab.doc.ts
@@ -41,7 +41,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Details'],
   defaultExample: {
     description:
-      'Merchants need to browse and select from a collection of items and navigate to details. This pattern provides search, filtering, and row selection for a resource list. The [text field](/docs/api/app-home/polaris-web-components/forms/text-field) uses `icon="search"` for filtering, the [popover](/docs/api/app-home/polaris-web-components/overlays/popover) holds filter options, and the [checkbox](/docs/api/app-home/polaris-web-components/forms/checkbox) enables row selection.',
+      'Merchants need to browse and select from a collection of items and navigate to details. This pattern provides search, filtering, and row selection for a resource list. The [text field](/docs/api/app-home/web-components/forms/text-field) uses `icon="search"` for filtering, the [popover](/docs/api/app-home/web-components/overlays/popover) holds filter options, and the [checkbox](/docs/api/app-home/web-components/forms/checkbox) enables row selection.',
     codeblock: {
       title: 'Provide search, filtering, and row selection for a resource list',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/setupGuide.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/setupGuide.ab.doc.ts
@@ -29,7 +29,7 @@ const data: AdminReferenceEntityTemplateSchema = {
   recommendedTemplates: ['Homepage'],
   defaultExample: {
     description:
-      'New merchants need an interactive checklist to complete onboarding or setup tasks. This pattern guides merchants through setup with expandable steps and completion tracking. The [checkbox](/docs/api/app-home/polaris-web-components/forms/checkbox) tracks completion status. Each step includes a heading, description, illustration, and action button, with a progress indicator for overall completion.',
+      'New merchants need an interactive checklist to complete onboarding or setup tasks. This pattern guides merchants through setup with expandable steps and completion tracking. The [checkbox](/docs/api/app-home/web-components/forms/checkbox) tracks completion status. Each step includes a heading, description, illustration, and action button, with a progress indicator for overall completion.',
     codeblock: {
       title: 'Guide merchants through setup with expandable steps',
       tabs: [


### PR DESCRIPTION
## This PR: 
- Revises the terminology from "Polaris web components" to "Web components", in response to Eytan's release feedback
- Relates to https://github.com/shop/world/pull/484742