### PR TITLE
[Admin UI extensions 2025-10]: Use 'web components' terminology

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -423,7 +423,7 @@ const transformJson = async (filePath, isExtensions) => {
 
     const filteredDocs = shopifyDevDocsDocsParsed.filter(
       (entry) =>
-        entry.category !== 'Polaris web components' &&
+        entry.category !== 'Web components' &&
         entry.category !== 'Patterns', // Don't include old patterns
     );
 

--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data.json
@@ -4,7 +4,7 @@
     "description": "The Action Extension API lets you [build action extensions](/docs/apps/build/admin/actions-blocks/build-admin-action) that merchants access from the **More actions** menu on details and index pages. Use this API to create workflows for processing resources, configuring settings, or integrating with external systems.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.",
+    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.",
     "defaultExample": {
       "description": "Send selected product IDs to your backend for bulk processing. This example shows how to map selected items, make an authenticated API call, and close the modal when the operation completes.",
       "codeblock": {
@@ -1141,7 +1141,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -1149,7 +1149,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1157,7 +1157,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1165,7 +1165,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1173,7 +1173,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1181,7 +1181,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -1189,7 +1189,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2308,7 +2308,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -2316,7 +2316,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2324,7 +2324,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2332,7 +2332,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2340,7 +2340,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2348,7 +2348,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -2356,7 +2356,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -3884,7 +3884,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -3892,7 +3892,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -3948,7 +3948,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -3956,7 +3956,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -3964,7 +3964,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4044,7 +4044,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -4052,7 +4052,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4060,7 +4060,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4068,7 +4068,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4076,7 +4076,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4084,7 +4084,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4092,7 +4092,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4390,7 +4390,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -4398,7 +4398,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4406,7 +4406,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4414,7 +4414,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4422,7 +4422,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4430,7 +4430,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -4438,7 +4438,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -6929,7 +6929,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -6961,7 +6961,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -6969,7 +6969,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -6977,7 +6977,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7057,7 +7057,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -7065,7 +7065,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7073,7 +7073,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7081,7 +7081,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7089,7 +7089,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7097,7 +7097,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -7105,7 +7105,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -11471,7 +11471,7 @@
         "type": "Generic",
         "anchorLink": "best-practices",
         "title": "Best practices",
-        "sectionContent": "- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions."
+        "sectionContent": "- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) components during async operations to prevent duplicate submissions."
       },
       {
         "type": "Generic",
@@ -11486,9 +11486,9 @@
     "description": "The Block Extension API lets you [build block extensions](/docs/apps/build/admin/actions-blocks/build-admin-block) that display inline content directly within admin pages. Use this API to show contextual information, tools, or actions related to the current page without requiring merchants to open a modal.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.",
+    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.",
     "defaultExample": {
-      "description": "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/spinner) component while fetching.",
+      "description": "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/spinner) component while fetching.",
       "codeblock": {
         "title": "Display product information",
         "tabs": [
@@ -13235,7 +13235,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -13243,7 +13243,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13251,7 +13251,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13259,7 +13259,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13267,7 +13267,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13275,7 +13275,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -13283,7 +13283,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14402,7 +14402,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -14410,7 +14410,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14418,7 +14418,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14426,7 +14426,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14434,7 +14434,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14442,7 +14442,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -14450,7 +14450,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -15978,7 +15978,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -15986,7 +15986,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -16042,7 +16042,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -16050,7 +16050,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16058,7 +16058,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16138,7 +16138,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -16146,7 +16146,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16154,7 +16154,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16162,7 +16162,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16170,7 +16170,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16178,7 +16178,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16186,7 +16186,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16484,7 +16484,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -16492,7 +16492,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16500,7 +16500,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16508,7 +16508,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16516,7 +16516,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16524,7 +16524,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -16532,7 +16532,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19023,7 +19023,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -19055,7 +19055,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -19063,7 +19063,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19071,7 +19071,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19151,7 +19151,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -19159,7 +19159,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19167,7 +19167,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19175,7 +19175,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19183,7 +19183,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19191,7 +19191,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -19199,7 +19199,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -22918,7 +22918,7 @@
       "description": "Common block extension patterns",
       "examples": [
         {
-          "description": "Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+          "description": "Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
           "codeblock": {
             "title": "Navigate to action extension",
             "tabs": [
@@ -22968,9 +22968,9 @@
     "description": "The Validation Settings API lets you [create complex validation rules](/docs/apps/build/checkout/cart-checkout-validation/create-admin-ui-validation) for cart and checkout validation. Use this API to build custom settings interfaces for [Shopify Functions](/docs/apps/build/functions) that implement validation logic.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.",
+    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.",
     "defaultExample": {
-      "description": "Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.",
+      "description": "Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.",
       "codeblock": {
         "title": "Set minimum quantity",
         "tabs": [
@@ -25043,7 +25043,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -25051,7 +25051,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25059,7 +25059,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25067,7 +25067,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25075,7 +25075,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25083,7 +25083,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -25091,7 +25091,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26210,7 +26210,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -26218,7 +26218,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26226,7 +26226,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26234,7 +26234,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26242,7 +26242,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26250,7 +26250,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -26258,7 +26258,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27786,7 +27786,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -27794,7 +27794,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -27850,7 +27850,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -27858,7 +27858,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27866,7 +27866,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27946,7 +27946,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -27954,7 +27954,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27962,7 +27962,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27970,7 +27970,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27978,7 +27978,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27986,7 +27986,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -27994,7 +27994,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28292,7 +28292,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -28300,7 +28300,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28308,7 +28308,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28316,7 +28316,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28324,7 +28324,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28332,7 +28332,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -28340,7 +28340,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -30831,7 +30831,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -30863,7 +30863,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -30871,7 +30871,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -30879,7 +30879,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -30959,7 +30959,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -30967,7 +30967,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -30975,7 +30975,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -30983,7 +30983,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -30991,7 +30991,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -30999,7 +30999,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -31007,7 +31007,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -34796,9 +34796,9 @@
     "description": "The Discount Function Settings API lets you build UI extensions that provide custom configuration interfaces for [discount functions](/docs/apps/build/discounts/build-ui-extension). Use this API to create settings pages for [Shopify Functions](/docs/apps/build/functions) that implement discount logic.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.",
+    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.",
     "defaultExample": {
-      "description": "Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.",
+      "description": "Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.",
       "codeblock": {
         "title": "Configure discount threshold",
         "tabs": [
@@ -35681,9 +35681,9 @@
     "description": "The Order Routing Rule API provides access to [order routing rule](/docs/apps/build/orders-fulfillment/order-routing-apps) configuration and settings management. Use this API to build custom configuration interfaces for order routing rules that determine fulfillment locations.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.",
+    "requires": "the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.",
     "defaultExample": {
-      "description": "Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.",
+      "description": "Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.",
       "codeblock": {
         "title": "Configure location priority",
         "tabs": [
@@ -37615,7 +37615,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -37623,7 +37623,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -37631,7 +37631,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -37639,7 +37639,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -37647,7 +37647,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -37655,7 +37655,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -37663,7 +37663,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38782,7 +38782,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -38790,7 +38790,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38798,7 +38798,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38806,7 +38806,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38814,7 +38814,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38822,7 +38822,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -38830,7 +38830,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40358,7 +40358,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -40366,7 +40366,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -40422,7 +40422,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -40430,7 +40430,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40438,7 +40438,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40518,7 +40518,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -40526,7 +40526,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40534,7 +40534,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40542,7 +40542,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40550,7 +40550,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40558,7 +40558,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40566,7 +40566,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40864,7 +40864,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -40872,7 +40872,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40880,7 +40880,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40888,7 +40888,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40896,7 +40896,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40904,7 +40904,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -40912,7 +40912,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43403,7 +43403,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -43435,7 +43435,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -43443,7 +43443,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43451,7 +43451,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43531,7 +43531,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -43539,7 +43539,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43547,7 +43547,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43555,7 +43555,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43563,7 +43563,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43571,7 +43571,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -43579,7 +43579,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -47540,7 +47540,7 @@
     "description": "The Print Action Extension API lets you [build print action extensions](/docs/apps/build/admin/actions-blocks/build-admin-print-action) that generate custom printable documents for orders, products, and other resources. Use this API to create branded labels, packing slips, custom invoices, or specialty documents.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-print-action) component.",
+    "requires": "the [admin print action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-print-action) component.",
     "defaultExample": {
       "description": "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and returning the printable URL to display the document.",
       "codeblock": {
@@ -49282,7 +49282,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -49290,7 +49290,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49298,7 +49298,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49306,7 +49306,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49314,7 +49314,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49322,7 +49322,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -49330,7 +49330,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -50449,7 +50449,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -50457,7 +50457,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -50465,7 +50465,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -50473,7 +50473,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -50481,7 +50481,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -50489,7 +50489,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -50497,7 +50497,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52025,7 +52025,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -52033,7 +52033,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -52089,7 +52089,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -52097,7 +52097,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52105,7 +52105,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52185,7 +52185,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -52193,7 +52193,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52201,7 +52201,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52209,7 +52209,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52217,7 +52217,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52225,7 +52225,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52233,7 +52233,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52531,7 +52531,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -52539,7 +52539,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52547,7 +52547,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52555,7 +52555,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52563,7 +52563,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52571,7 +52571,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -52579,7 +52579,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55070,7 +55070,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -55102,7 +55102,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -55110,7 +55110,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55118,7 +55118,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55198,7 +55198,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -55206,7 +55206,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55214,7 +55214,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55222,7 +55222,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55230,7 +55230,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55238,7 +55238,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -55246,7 +55246,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -59022,7 +59022,7 @@
     "description": "The Product Details Configuration API lets you [build product configuration extensions for bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) that define product relationships and manage [bundle](/docs/apps/build/product-merchandising/bundles) compositions. Use this API to build configuration interfaces for bundle and component product experiences.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.",
+    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.",
     "defaultExample": {
       "description": "Open the product [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select up to five components for a [bundle](/docs/apps/build/product-merchandising/bundles). This example filters out draft and archived products, saves the bundle configuration to your backend, and tracks the selection count.",
       "codeblock": {
@@ -61042,7 +61042,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -61050,7 +61050,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61058,7 +61058,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61066,7 +61066,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61074,7 +61074,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61082,7 +61082,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -61090,7 +61090,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62209,7 +62209,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -62217,7 +62217,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62225,7 +62225,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62233,7 +62233,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62241,7 +62241,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62249,7 +62249,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -62257,7 +62257,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63785,7 +63785,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -63793,7 +63793,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -63849,7 +63849,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -63857,7 +63857,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63865,7 +63865,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63945,7 +63945,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -63953,7 +63953,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63961,7 +63961,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63969,7 +63969,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63977,7 +63977,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63985,7 +63985,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -63993,7 +63993,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64291,7 +64291,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -64299,7 +64299,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64307,7 +64307,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64315,7 +64315,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64323,7 +64323,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64331,7 +64331,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -64339,7 +64339,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -66830,7 +66830,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -66862,7 +66862,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -66870,7 +66870,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -66878,7 +66878,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -66958,7 +66958,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -66966,7 +66966,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -66974,7 +66974,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -66982,7 +66982,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -66990,7 +66990,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -66998,7 +66998,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -67006,7 +67006,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -70504,7 +70504,7 @@
     "description": "The Product Variant Details Configuration API lets you [build product configuration extensions for bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) that define variant relationships and manage [bundle](/docs/apps/build/product-merchandising/bundles) compositions. Use this API to build configuration interfaces for bundle and component product experiences at the variant level.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.",
+    "requires": "the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.",
     "defaultExample": {
       "description": "Use the product variant [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component variants for a [bundle](/docs/apps/build/product-merchandising/bundles). This example picks product variants, tracks selections, and posts the product variant IDs to configure the bundle.",
       "codeblock": {
@@ -72523,7 +72523,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -72531,7 +72531,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -72539,7 +72539,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -72547,7 +72547,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -72555,7 +72555,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -72563,7 +72563,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -72571,7 +72571,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73690,7 +73690,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -73698,7 +73698,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73706,7 +73706,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73714,7 +73714,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73722,7 +73722,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73730,7 +73730,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -73738,7 +73738,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75266,7 +75266,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -75274,7 +75274,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -75330,7 +75330,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -75338,7 +75338,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75346,7 +75346,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75426,7 +75426,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -75434,7 +75434,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75442,7 +75442,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75450,7 +75450,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75458,7 +75458,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75466,7 +75466,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75474,7 +75474,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75772,7 +75772,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -75780,7 +75780,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75788,7 +75788,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75796,7 +75796,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75804,7 +75804,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75812,7 +75812,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -75820,7 +75820,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78311,7 +78311,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -78343,7 +78343,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -78351,7 +78351,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78359,7 +78359,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78439,7 +78439,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -78447,7 +78447,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78455,7 +78455,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78463,7 +78463,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78471,7 +78471,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78479,7 +78479,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -78487,7 +78487,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -81986,7 +81986,7 @@
     "description": "The Purchase Options Card Configuration API provides access to purchase option selection data for products with [subscription](/docs/apps/build/purchase-options/subscriptions) and [selling plan](/docs/apps/build/purchase-options/subscriptions/selling-plans) configurations. Use this API to build action extensions that interact with selected [purchase options](/docs/apps/build/purchase-options) on product and product variant details pages.",
     "isVisualComponent": false,
     "type": "API",
-    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.",
+    "requires": "the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.",
     "defaultExample": {
       "description": "Update a subscription by sending product and selling plan IDs to your backend. This example checks for selling plan presence, posts the update request, and shows a success banner before auto-closing the modal.",
       "codeblock": {
@@ -83735,7 +83735,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -83743,7 +83743,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -83751,7 +83751,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -83759,7 +83759,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -83767,7 +83767,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -83775,7 +83775,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -83783,7 +83783,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84902,7 +84902,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -84910,7 +84910,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84918,7 +84918,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84926,7 +84926,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84934,7 +84934,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84942,7 +84942,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -84950,7 +84950,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86478,7 +86478,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -86486,7 +86486,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -86542,7 +86542,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -86550,7 +86550,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86558,7 +86558,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86638,7 +86638,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -86646,7 +86646,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86654,7 +86654,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86662,7 +86662,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86670,7 +86670,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86678,7 +86678,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86686,7 +86686,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -86984,7 +86984,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -86992,7 +86992,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87000,7 +87000,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87008,7 +87008,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87016,7 +87016,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87024,7 +87024,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -87032,7 +87032,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89523,7 +89523,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -89555,7 +89555,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -89563,7 +89563,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89571,7 +89571,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89651,7 +89651,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -89659,7 +89659,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89667,7 +89667,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89675,7 +89675,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89683,7 +89683,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89691,7 +89691,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -89699,7 +89699,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -95518,7 +95518,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -95526,7 +95526,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -95534,7 +95534,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -95542,7 +95542,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -95550,7 +95550,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -95558,7 +95558,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -95566,7 +95566,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96685,7 +96685,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -96693,7 +96693,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96701,7 +96701,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96709,7 +96709,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96717,7 +96717,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96725,7 +96725,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -96733,7 +96733,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98261,7 +98261,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -98269,7 +98269,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -98325,7 +98325,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -98333,7 +98333,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98341,7 +98341,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98421,7 +98421,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -98429,7 +98429,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98437,7 +98437,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98445,7 +98445,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98453,7 +98453,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98461,7 +98461,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98469,7 +98469,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98767,7 +98767,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -98775,7 +98775,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98783,7 +98783,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98791,7 +98791,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98799,7 +98799,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98807,7 +98807,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -98815,7 +98815,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101306,7 +101306,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -101338,7 +101338,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -101346,7 +101346,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101354,7 +101354,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101434,7 +101434,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -101442,7 +101442,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101450,7 +101450,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101458,7 +101458,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101466,7 +101466,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101474,7 +101474,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -101482,7 +101482,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -106992,7 +106992,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -107000,7 +107000,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -107008,7 +107008,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -107016,7 +107016,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -107024,7 +107024,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -107032,7 +107032,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -107040,7 +107040,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108159,7 +108159,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -108167,7 +108167,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108175,7 +108175,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108183,7 +108183,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108191,7 +108191,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108199,7 +108199,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -108207,7 +108207,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109735,7 +109735,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -109743,7 +109743,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -109799,7 +109799,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -109807,7 +109807,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109815,7 +109815,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109895,7 +109895,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -109903,7 +109903,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109911,7 +109911,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109919,7 +109919,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109927,7 +109927,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109935,7 +109935,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -109943,7 +109943,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -110241,7 +110241,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -110249,7 +110249,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -110257,7 +110257,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -110265,7 +110265,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -110273,7 +110273,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -110281,7 +110281,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -110289,7 +110289,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112780,7 +112780,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'"
               },
               {
@@ -112812,7 +112812,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'"
               },
               {
@@ -112820,7 +112820,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112828,7 +112828,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112908,7 +112908,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'"
               },
               {
@@ -112916,7 +112916,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112924,7 +112924,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112932,7 +112932,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112940,7 +112940,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112948,7 +112948,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -112956,7 +112956,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override"
               },
               {
@@ -116790,7 +116790,7 @@
       },
       {
         "title": "Slots",
-        "description": "The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "AdminActionSlots",
         "typeDefinitions": {
           "AdminActionSlots": {
@@ -116820,7 +116820,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Settings and templates",
     "subSections": [
       {
@@ -116832,7 +116832,7 @@
     ],
     "defaultExample": {
       "image": "/assets/templated-apis-screenshots/admin/components/adminaction-example.png",
-      "description": "Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.",
+      "description": "Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.",
       "codeblock": {
         "title": "Configure an admin action modal",
         "tabs": [
@@ -116856,7 +116856,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+              "description": "Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
               "codeblock": {
                 "title": "Show a loading state",
                 "tabs": [
@@ -116873,7 +116873,7 @@
               }
             },
             {
-              "description": "Embed a [form](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/form) inside the action modal to collect merchant input before saving. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) wrapped in a form component.",
+              "description": "Embed a [form](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/form) inside the action modal to collect merchant input before saving. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) wrapped in a form component.",
               "codeblock": {
                 "title": "Add form fields to the modal",
                 "tabs": [
@@ -116890,7 +116890,7 @@
               }
             },
             {
-              "description": "Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) to confirm deletion.",
+              "description": "Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) to confirm deletion.",
               "codeblock": {
                 "title": "Confirm a destructive action",
                 "tabs": [
@@ -116907,7 +116907,7 @@
               }
             },
             {
-              "description": "Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+              "description": "Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
               "codeblock": {
                 "title": "Show resource details in a modal",
                 "tabs": [
@@ -116969,7 +116969,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Settings and templates",
     "subSections": [
       {
@@ -116987,7 +116987,7 @@
     ],
     "defaultExample": {
       "image": "/assets/templated-apis-screenshots/admin/components/adminblock-example.png",
-      "description": "Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) content.",
+      "description": "Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) content.",
       "codeblock": {
         "title": "Display an inline admin block",
         "tabs": [
@@ -117011,7 +117011,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) summary in the block header.",
+              "description": "Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) summary in the block header.",
               "codeblock": {
                 "title": "Show a collapsed summary",
                 "tabs": [
@@ -117028,7 +117028,7 @@
               }
             },
             {
-              "description": "Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/table).",
+              "description": "Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/table).",
               "codeblock": {
                 "title": "Display a data table",
                 "tabs": [
@@ -117045,7 +117045,7 @@
               }
             },
             {
-              "description": "Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge) and a list of risk factors.",
+              "description": "Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge) and a list of risk factors.",
               "codeblock": {
                 "title": "Show status with badges",
                 "tabs": [
@@ -117062,7 +117062,7 @@
               }
             },
             {
-              "description": "Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button-group) for pause and cancel actions.",
+              "description": "Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button-group) for pause and cancel actions.",
               "codeblock": {
                 "title": "Add action buttons to a block",
                 "tabs": [
@@ -117116,7 +117116,7 @@
         }
       }
     ],
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Settings and templates",
     "subSections": [
       {
@@ -117199,8 +117199,8 @@
   },
   {
     "name": "Avatar",
-    "description": "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available.\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image).",
-    "category": "Polaris web components",
+    "description": "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available.\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/avatar.png",
@@ -117389,7 +117389,7 @@
       },
       {
         "title": "Events",
-        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "AvatarEvents",
         "typeDefinitions": {
           "AvatarEvents": {
@@ -117561,7 +117561,7 @@
               }
             },
             {
-              "description": "Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text) components.",
+              "description": "Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text) components.",
               "codeblock": {
                 "title": "Build a merchant profile card",
                 "tabs": [
@@ -117584,8 +117584,8 @@
   },
   {
     "name": "Badge",
-    "description": "The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.",
-    "category": "Polaris web components",
+    "description": "The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) instead.",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/badge.png",
@@ -117776,7 +117776,7 @@
       },
       {
         "title": "Slots",
-        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "BadgeSlots",
         "typeDefinitions": {
           "BadgeSlots": {
@@ -117841,7 +117841,7 @@
               }
             },
             {
-              "description": "Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.",
+              "description": "Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.",
               "codeblock": {
                 "title": "Display badges in a table",
                 "tabs": [
@@ -117881,8 +117881,8 @@
   },
   {
     "name": "Banner",
-    "description": "The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).",
-    "category": "Polaris web components",
+    "description": "The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge).",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/banner.png",
@@ -118074,7 +118074,7 @@
       },
       {
         "title": "Events",
-        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "BannerEvents",
         "typeDefinitions": {
           "BannerEvents": {
@@ -118119,7 +118119,7 @@
       },
       {
         "title": "Slots",
-        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "BannerSlots",
         "typeDefinitions": {
           "BannerSlots": {
@@ -118175,7 +118175,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.",
+              "description": "Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.",
               "codeblock": {
                 "title": "Create a warning banner with buttons for next steps",
                 "tabs": [
@@ -118192,7 +118192,7 @@
               }
             },
             {
-              "description": "Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to review order details and adjust settings.",
+              "description": "Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to review order details and adjust settings.",
               "codeblock": {
                 "title": "Alert merchants to critical issues requiring action",
                 "tabs": [
@@ -118232,8 +118232,8 @@
   },
   {
     "name": "Box",
-    "description": "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components.\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).",
-    "category": "Polaris web components",
+    "description": "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components.\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/box.png",
@@ -118243,7 +118243,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.\n- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.\n- **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.\n- **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.\n- **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components."
+        "sectionContent": "- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.\n- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.\n- **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.\n- **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.\n- **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components."
       }
     ],
     "definitions": [
@@ -118471,7 +118471,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -118480,7 +118480,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -118489,7 +118489,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -118498,7 +118498,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -118507,7 +118507,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -118516,7 +118516,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -118525,7 +118525,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -118722,7 +118722,7 @@
       },
       {
         "title": "Slots",
-        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "BoxSlots",
         "typeDefinitions": {
           "BoxSlots": {
@@ -118844,8 +118844,8 @@
   },
   {
     "name": "Button",
-    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).",
-    "category": "Polaris web components",
+    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button-group).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/button.png",
@@ -119119,7 +119119,7 @@
       },
       {
         "title": "Events",
-        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ButtonEvents",
         "typeDefinitions": {
           "ButtonEvents": {
@@ -119172,7 +119172,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ButtonSlots",
         "typeDefinitions": {
           "ButtonSlots": {
@@ -119396,8 +119396,8 @@
   },
   {
     "name": "Button group",
-    "description": "The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button).",
-    "category": "Polaris web components",
+    "description": "The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/buttongroup.png",
@@ -119564,7 +119564,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ButtonGroupSlots",
         "typeDefinitions": {
           "ButtonGroupSlots": {
@@ -119702,8 +119702,8 @@
   },
   {
     "name": "Checkbox",
-    "description": "The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.\n\nCheckboxes support labels, help text, error states, and an indeterminate state for \"select all\" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/switch) instead.",
-    "category": "Polaris web components",
+    "description": "The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.\n\nCheckboxes support labels, help text, error states, and an indeterminate state for \"select all\" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/switch) instead.",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/checkbox.png",
@@ -119980,7 +119980,7 @@
       },
       {
         "title": "Events",
-        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "CheckboxEvents",
         "typeDefinitions": {
           "CheckboxEvents": {
@@ -120146,8 +120146,8 @@
   },
   {
     "name": "Chip",
-    "description": "The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip).",
-    "category": "Polaris web components",
+    "description": "The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/chip.png",
@@ -120157,7 +120157,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip) instead.\n- **Keep chip text concise and scannable:** Short labels like \"Featured\" or \"On sale\" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.\n- **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.\n- **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.\n- **Add icons to reinforce meaning:** Icons can make chip meanings clearer at a glance, especially for status indicators or commonly recognized categories."
+        "sectionContent": "- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip) instead.\n- **Keep chip text concise and scannable:** Short labels like \"Featured\" or \"On sale\" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.\n- **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.\n- **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.\n- **Add icons to reinforce meaning:** Icons can make chip meanings clearer at a glance, especially for status indicators or commonly recognized categories."
       },
       {
         "title": "Limitations",
@@ -120327,7 +120327,7 @@
       },
       {
         "title": "Slots",
-        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ChipSlots",
         "typeDefinitions": {
           "ChipSlots": {
@@ -120440,8 +120440,8 @@
   },
   {
     "name": "Choice list",
-    "description": "The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select).",
-    "category": "Polaris web components",
+    "description": "The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/choicelist.png",
@@ -120457,7 +120457,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select) dropdown instead.\n- Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.\n- The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.\n- Component types other than choice can't be used as options within the choice list."
+        "sectionContent": "- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select) dropdown instead.\n- Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.\n- The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.\n- Component types other than choice can't be used as options within the choice list."
       }
     ],
     "definitions": [
@@ -120682,7 +120682,7 @@
       },
       {
         "title": "Events",
-        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ChoiceListEvents",
         "typeDefinitions": {
           "ChoiceListEvents": {
@@ -120904,7 +120904,7 @@
       },
       {
         "title": "Slots",
-        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ChoiceSlots",
         "typeDefinitions": {
           "ChoiceSlots": {
@@ -121034,8 +121034,8 @@
   },
   {
     "name": "Clickable",
-    "description": "The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.",
-    "category": "Polaris web components",
+    "description": "The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/clickable.png",
@@ -121330,7 +121330,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -121339,7 +121339,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -121348,7 +121348,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -121357,7 +121357,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -121366,7 +121366,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -121375,7 +121375,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -121384,7 +121384,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -121606,7 +121606,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ClickableEvents",
         "typeDefinitions": {
           "ClickableEvents": {
@@ -121659,7 +121659,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ClickableSlots",
         "typeDefinitions": {
           "ClickableSlots": {
@@ -121683,7 +121683,7 @@
     ],
     "defaultExample": {
       "image": "clickable-default.png",
-      "description": "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
+      "description": "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
       "codeblock": {
         "title": "Create a custom interactive element",
         "tabs": [
@@ -121798,8 +121798,8 @@
   },
   {
     "name": "Clickable chip",
-    "description": "The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).",
-    "category": "Polaris web components",
+    "description": "The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/clickable-chip.png",
@@ -121809,7 +121809,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.\n- **Choose color variants by importance:** Use `subdued` for less important or secondary chips, `base` (default) for standard selections, and `strong` to emphasize primary or active selections.\n- **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.\n- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing."
+        "sectionContent": "- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.\n- **Choose color variants by importance:** Use `subdued` for less important or secondary chips, `base` (default) for standard selections, and `strong` to emphasize primary or active selections.\n- **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.\n- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing."
       }
     ],
     "definitions": [
@@ -122033,7 +122033,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ClickableChipEvents",
         "typeDefinitions": {
           "ClickableChipEvents": {
@@ -122086,7 +122086,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ClickableChipSlots",
         "typeDefinitions": {
           "ClickableChipSlots": {
@@ -122216,8 +122216,8 @@
   },
   {
     "name": "Color field",
-    "description": "The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-picker).",
-    "category": "Polaris web components",
+    "description": "The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-picker).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/color-field.png",
@@ -122545,7 +122545,7 @@
       },
       {
         "title": "Events",
-        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ColorFieldEvents",
         "typeDefinitions": {
           "ColorFieldEvents": {
@@ -122778,8 +122778,8 @@
   },
   {
     "name": "Color picker",
-    "description": "The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field).",
-    "category": "Polaris web components",
+    "description": "The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/color-picker.png",
@@ -122789,7 +122789,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.\n- **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.\n- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control."
+        "sectionContent": "- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.\n- **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.\n- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control."
       },
       {
         "title": "Limitations",
@@ -122985,7 +122985,7 @@
       },
       {
         "title": "Events",
-        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ColorPickerEvents",
         "typeDefinitions": {
           "ColorPickerEvents": {
@@ -123078,8 +123078,8 @@
   },
   {
     "name": "Date field",
-    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-picker).",
-    "category": "Polaris web components",
+    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-picker).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/datefield.png",
@@ -123444,7 +123444,7 @@
       },
       {
         "title": "Events",
-        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "DateFieldEvents",
         "typeDefinitions": {
           "DateFieldEvents": {
@@ -123705,8 +123705,8 @@
   },
   {
     "name": "Date picker",
-    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-field).",
-    "category": "Polaris web components",
+    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/datepicker.png",
@@ -123970,7 +123970,7 @@
       },
       {
         "title": "Events",
-        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "DatePickerEvents",
         "typeDefinitions": {
           "DatePickerEvents": {
@@ -124138,8 +124138,8 @@
   },
   {
     "name": "Divider",
-    "description": "The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).",
-    "category": "Polaris web components",
+    "description": "The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "subSections": [
@@ -124390,7 +124390,7 @@
   {
     "name": "Drop zone",
     "description": "The drop zone component lets users upload files through drag-and-drop or by clicking to browse. Use for file uploads such as images, documents, or CSV imports.\n\nThe component provides visual feedback during drag operations and supports file type validation through the `accept` property. Rejected files trigger the `droprejected` event for custom error handling.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/dropzone.png",
@@ -124677,7 +124677,7 @@
       },
       {
         "title": "Events",
-        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "DropZoneEvents",
         "typeDefinitions": {
           "DropZoneEvents": {
@@ -124901,8 +124901,8 @@
   },
   {
     "name": "Email field",
-    "description": "The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/emailfield.png",
@@ -125237,7 +125237,7 @@
       },
       {
         "title": "Events",
-        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "EmailFieldEvents",
         "typeDefinitions": {
           "EmailFieldEvents": {
@@ -125397,8 +125397,8 @@
   },
   {
     "name": "Form",
-    "description": "The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/function-settings).",
-    "category": "Polaris web components",
+    "description": "The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/function-settings).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/form.png",
@@ -125408,7 +125408,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.\n- **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.\n- **Mark required fields clearly:** Use the `required` property and show validation errors only after user interaction or submission attempt.\n- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.\n- **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.\n- **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist."
+        "sectionContent": "- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.\n- **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.\n- **Mark required fields clearly:** Use the `required` property and show validation errors only after user interaction or submission attempt.\n- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.\n- **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.\n- **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist."
       },
       {
         "title": "Limitations",
@@ -125420,7 +125420,7 @@
     "definitions": [
       {
         "title": "Events",
-        "description": "The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "FormEvents",
         "typeDefinitions": {
           "FormEvents": {
@@ -125668,7 +125668,7 @@
       }
     ],
     "defaultExample": {
-      "description": "Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).",
+      "description": "Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).",
       "codeblock": {
         "title": "Submit a basic form",
         "tabs": [
@@ -125692,7 +125692,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.",
+              "description": "Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.",
               "codeblock": {
                 "title": "Build a campaign form with date and money fields",
                 "tabs": [
@@ -125709,7 +125709,7 @@
               }
             },
             {
-              "description": "Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline validation errors.",
+              "description": "Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline validation errors.",
               "codeblock": {
                 "title": "Show field validation errors",
                 "tabs": [
@@ -125726,7 +125726,7 @@
               }
             },
             {
-              "description": "Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.",
+              "description": "Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.",
               "codeblock": {
                 "title": "Use select and checkbox fields",
                 "tabs": [
@@ -125743,7 +125743,7 @@
               }
             },
             {
-              "description": "Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to separate contact information from shipping preferences.",
+              "description": "Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to separate contact information from shipping preferences.",
               "codeblock": {
                 "title": "Group fields into sections",
                 "tabs": [
@@ -125766,8 +125766,8 @@
   },
   {
     "name": "Function settings",
-    "description": "The function settings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use function settings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/form).",
-    "category": "Polaris web components",
+    "description": "The function settings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use function settings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/form).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "requires": "the [Discount Function Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/discount-function-settings-api), [Validation Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/validation-settings-api), or [Order Routing Rule API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/order-routing-rule-api).",
@@ -125778,13 +125778,13 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.\n- **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.\n- **Explain impact with field details:** Use the `details` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.\n- **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.\n- **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly."
+        "sectionContent": "- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.\n- **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.\n- **Explain impact with field details:** Use the `details` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.\n- **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.\n- **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly."
       }
     ],
     "definitions": [
       {
         "title": "Events",
-        "description": "The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "FormEvents",
         "typeDefinitions": {
           "FormEvents": {
@@ -126032,7 +126032,7 @@
       }
     ],
     "defaultExample": {
-      "description": "Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for a discount percentage input inside a function settings component.",
+      "description": "Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for a discount percentage input inside a function settings component.",
       "codeblock": {
         "title": "Add a settings field for a function",
         "tabs": [
@@ -126056,7 +126056,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.",
+              "description": "Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.",
               "codeblock": {
                 "title": "Set up tiered discount rules",
                 "tabs": [
@@ -126073,7 +126073,7 @@
               }
             },
             {
-              "description": "Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline error messages.",
+              "description": "Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline error messages.",
               "codeblock": {
                 "title": "Show validation errors on settings",
                 "tabs": [
@@ -126090,7 +126090,7 @@
               }
             },
             {
-              "description": "Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for a filter value.",
+              "description": "Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for a filter value.",
               "codeblock": {
                 "title": "Add a select dropdown to settings",
                 "tabs": [
@@ -126107,7 +126107,7 @@
               }
             },
             {
-              "description": "Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field).",
+              "description": "Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field).",
               "codeblock": {
                 "title": "Toggle a feature with a switch",
                 "tabs": [
@@ -126130,8 +126130,8 @@
   },
   {
     "name": "Grid",
-    "description": "The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).",
-    "category": "Polaris web components",
+    "description": "The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "subSections": [
@@ -126312,7 +126312,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126348,7 +126348,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -126357,7 +126357,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -126366,7 +126366,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -126447,7 +126447,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -126456,7 +126456,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126465,7 +126465,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126474,7 +126474,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126483,7 +126483,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126492,7 +126492,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126501,7 +126501,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126537,7 +126537,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -126788,7 +126788,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "GridSlots",
         "typeDefinitions": {
           "GridSlots": {
@@ -127051,7 +127051,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -127060,7 +127060,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -127069,7 +127069,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -127078,7 +127078,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -127087,7 +127087,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -127096,7 +127096,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -127105,7 +127105,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -127302,7 +127302,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "GridItemSlots",
         "typeDefinitions": {
           "GridItemSlots": {
@@ -127407,8 +127407,8 @@
   },
   {
     "name": "Heading",
-    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.",
-    "category": "Polaris web components",
+    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/heading.png",
@@ -127591,7 +127591,7 @@
       },
       {
         "title": "Slots",
-        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "HeadingSlots",
         "typeDefinitions": {
           "HeadingSlots": {
@@ -127696,8 +127696,8 @@
   },
   {
     "name": "Icon",
-    "description": "The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.",
-    "category": "Polaris web components",
+    "description": "The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) to enhance visual communication.",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/icon.png",
@@ -127719,7 +127719,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.\n- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image) component instead.\n- Icon color is determined by the `tone` and `color` properties. Custom colors or gradients aren't available."
+        "sectionContent": "- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.\n- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image) component instead.\n- Icon color is determined by the `tone` and `color` properties. Custom colors or gradients aren't available."
       }
     ],
     "definitions": [
@@ -128052,8 +128052,8 @@
   },
   {
     "name": "Image",
-    "description": "The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).",
-    "category": "Polaris web components",
+    "description": "The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/image.png",
@@ -128406,7 +128406,7 @@
       },
       {
         "title": "Events",
-        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ImageEvents",
         "typeDefinitions": {
           "ImageEvents": {
@@ -128544,7 +128544,7 @@
               }
             },
             {
-              "description": "Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.",
+              "description": "Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.",
               "codeblock": {
                 "title": "Use in a grid layout",
                 "tabs": [
@@ -128567,8 +128567,8 @@
   },
   {
     "name": "Link",
-    "description": "The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.",
-    "category": "Polaris web components",
+    "description": "The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) instead.",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/link.png",
@@ -128806,7 +128806,7 @@
       },
       {
         "title": "Events",
-        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "LinkEvents",
         "typeDefinitions": {
           "LinkEvents": {
@@ -128843,7 +128843,7 @@
       },
       {
         "title": "Slots",
-        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "LinkSlots",
         "typeDefinitions": {
           "LinkSlots": {
@@ -128891,7 +128891,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Embed links within a [Paragraph](/docs/api/app-home/polaris-web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.",
+              "description": "Embed links within a [Paragraph](/docs/api/app-home/web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.",
               "codeblock": {
                 "title": "Embed links in paragraph text",
                 "tabs": [
@@ -129017,7 +129017,7 @@
   {
     "name": "Menu",
     "description": "The menu component displays a list of actions that can be performed on a resource or within a specific context. Use menu to present multiple related actions in a compact dropdown format, reducing visual clutter while maintaining discoverability.\n\nMenus support action grouping, icons for visual clarity, and keyboard navigation for efficient interaction.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/menu.png",
@@ -129208,7 +129208,7 @@
       },
       {
         "title": "Slots",
-        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "MenuSlots",
         "typeDefinitions": {
           "MenuSlots": {
@@ -129347,8 +129347,8 @@
   },
   {
     "name": "Money field",
-    "description": "The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field).",
-    "category": "Polaris web components",
+    "description": "The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/number-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/moneyfield.png",
@@ -129676,7 +129676,7 @@
       },
       {
         "title": "Events",
-        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "MoneyFieldEvents",
         "typeDefinitions": {
           "MoneyFieldEvents": {
@@ -129818,8 +129818,8 @@
   },
   {
     "name": "Number field",
-    "description": "The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/money-field).",
-    "category": "Polaris web components",
+    "description": "The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/money-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/numberfield.png",
@@ -129829,7 +129829,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) instead.\n- **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.\n- **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.\n- **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter."
+        "sectionContent": "- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) instead.\n- **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.\n- **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.\n- **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter."
       },
       {
         "title": "Limitations",
@@ -130190,7 +130190,7 @@
       },
       {
         "title": "Events",
-        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "NumberFieldEvents",
         "typeDefinitions": {
           "NumberFieldEvents": {
@@ -130333,8 +130333,8 @@
   },
   {
     "name": "Ordered list",
-    "description": "The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list).",
-    "category": "Polaris web components",
+    "description": "The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/ordered-list.png",
@@ -130344,7 +130344,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
+        "sectionContent": "- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
       },
       {
         "title": "Limitations",
@@ -130356,7 +130356,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "OrderedListSlots",
         "typeDefinitions": {
           "OrderedListSlots": {
@@ -130513,7 +130513,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {
@@ -130584,8 +130584,8 @@
   },
   {
     "name": "Paragraph",
-    "description": "The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).",
-    "category": "Polaris web components",
+    "description": "The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/paragraph.png",
@@ -130795,7 +130795,7 @@
       },
       {
         "title": "Slots",
-        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ParagraphSlots",
         "typeDefinitions": {
           "ParagraphSlots": {
@@ -130951,8 +130951,8 @@
   },
   {
     "name": "Password field",
-    "description": "The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/passwordfield.png",
@@ -131287,7 +131287,7 @@
       },
       {
         "title": "Events",
-        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "PasswordFieldEvents",
         "typeDefinitions": {
           "PasswordFieldEvents": {
@@ -131464,7 +131464,7 @@
   {
     "name": "Query container",
     "description": "The query container component establishes a container query context for responsive design. Use query container to define an element as a containment context, enabling child components or styles to adapt based on the container's size rather than viewport width.\n\nQuery containers support modern responsive patterns where components respond to their container dimensions, creating more flexible and reusable layouts.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "requires": "",
@@ -131630,7 +131630,7 @@
       },
       {
         "title": "Slots",
-        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "QueryContainerSlots",
         "typeDefinitions": {
           "QueryContainerSlots": {
@@ -131701,8 +131701,8 @@
   },
   {
     "name": "Search field",
-    "description": "The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/searchfield.png",
@@ -132031,7 +132031,7 @@
       },
       {
         "title": "Events",
-        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "SearchFieldEvents",
         "typeDefinitions": {
           "SearchFieldEvents": {
@@ -132174,8 +132174,8 @@
   },
   {
     "name": "Section",
-    "description": "The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/divider).",
-    "category": "Polaris web components",
+    "description": "The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/divider).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "isVisualComponent": true,
@@ -132356,7 +132356,7 @@
       },
       {
         "title": "Slots",
-        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "SectionSlots",
         "typeDefinitions": {
           "SectionSlots": {
@@ -132478,8 +132478,8 @@
   },
   {
     "name": "Select",
-    "description": "The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list).",
-    "category": "Polaris web components",
+    "description": "The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/select.png",
@@ -132489,13 +132489,13 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.\n- **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.\n- **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.\n- **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.\n- **Provide clear validation feedback:** When selection is required or invalid, explain what the merchant needs to do. Context-specific error messages help merchants complete forms faster than generic validation messages."
+        "sectionContent": "- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.\n- **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.\n- **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.\n- **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.\n- **Provide clear validation feedback:** When selection is required or invalid, explain what the merchant needs to do. Context-specific error messages help merchants complete forms faster than generic validation messages."
       },
       {
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.\n- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list) with checkboxes or build a custom multi-select component.\n- Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.\n- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).\n- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components."
+        "sectionContent": "- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.\n- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list) with checkboxes or build a custom multi-select component.\n- Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.\n- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu).\n- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu) components."
       }
     ],
     "definitions": [
@@ -132762,7 +132762,7 @@
       },
       {
         "title": "Events",
-        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "SelectEvents",
         "typeDefinitions": {
           "SelectEvents": {
@@ -132807,7 +132807,7 @@
       },
       {
         "title": "Slots",
-        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "SelectSlots",
         "typeDefinitions": {
           "SelectSlots": {
@@ -132999,7 +132999,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "OptionSlots",
         "typeDefinitions": {
           "OptionSlots": {
@@ -133173,7 +133173,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "OptionGroupSlots",
         "typeDefinitions": {
           "OptionGroupSlots": {
@@ -133328,8 +133328,8 @@
   },
   {
     "name": "Spinner",
-    "description": "The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.",
-    "category": "Polaris web components",
+    "description": "The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) component instead.",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/spinner.png",
@@ -133345,7 +133345,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.\n- The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.\n- Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.\n- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) alongside the spinner."
+        "sectionContent": "- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.\n- The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.\n- Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.\n- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) alongside the spinner."
       }
     ],
     "definitions": [
@@ -133584,8 +133584,8 @@
   },
   {
     "name": "Stack",
-    "description": "The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).",
-    "category": "Polaris web components",
+    "description": "The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/stack.png",
@@ -133766,7 +133766,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -133784,7 +133784,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'",
                 "isOptional": true
               },
@@ -133811,7 +133811,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -133883,7 +133883,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -133892,7 +133892,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -133901,7 +133901,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -133910,7 +133910,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -133919,7 +133919,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -133928,7 +133928,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -133937,7 +133937,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -133955,7 +133955,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -134199,7 +134199,7 @@
       },
       {
         "title": "Slots",
-        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "StackSlots",
         "typeDefinitions": {
           "StackSlots": {
@@ -134321,8 +134321,8 @@
   },
   {
     "name": "Switch",
-    "description": "The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/checkbox) instead.",
-    "category": "Polaris web components",
+    "description": "The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/checkbox) instead.",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/switch.png",
@@ -134591,7 +134591,7 @@
       },
       {
         "title": "Events",
-        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "SwitchEvents",
         "typeDefinitions": {
           "SwitchEvents": {
@@ -134769,7 +134769,7 @@
   {
     "name": "Table",
     "description": "The table component displays data clearly in rows and columns, helping users view, analyze, and compare structured information. Use table to present datasets, product lists, order details, or any tabular content that benefits from organized rows and columns.\n\nTables automatically adapt to screen size, rendering as lists on small screens and tables on larger ones for optimal readability across devices.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/table.png",
@@ -135049,7 +135049,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableSlots",
         "typeDefinitions": {
           "TableSlots": {
@@ -135080,7 +135080,7 @@
       },
       {
         "title": "Events",
-        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "TableEvents",
         "typeDefinitions": {
           "TableEvents": {
@@ -135259,7 +135259,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableBodySlots",
         "typeDefinitions": {
           "TableBodySlots": {
@@ -135432,7 +135432,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableCellSlots",
         "typeDefinitions": {
           "TableCellSlots": {
@@ -135620,7 +135620,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableHeaderSlots",
         "typeDefinitions": {
           "TableHeaderSlots": {
@@ -135777,7 +135777,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableHeaderRowSlots",
         "typeDefinitions": {
           "TableHeaderRowSlots": {
@@ -135942,7 +135942,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TableRowSlots",
         "typeDefinitions": {
           "TableRowSlots": {
@@ -136081,8 +136081,8 @@
   },
   {
     "name": "Text",
-    "description": "The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).",
-    "category": "Polaris web components",
+    "description": "The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/text.png",
@@ -136098,7 +136098,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph) component or wrap in layout components.\n- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading) with line clamping if truncation is needed.\n- Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements."
+        "sectionContent": "- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph) component or wrap in layout components.\n- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading) with line clamping if truncation is needed.\n- Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements."
       }
     ],
     "definitions": [
@@ -136300,7 +136300,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TextSlots",
         "typeDefinitions": {
           "TextSlots": {
@@ -136473,8 +136473,8 @@
   },
   {
     "name": "Text area",
-    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/textarea.png",
@@ -136818,7 +136818,7 @@
       },
       {
         "title": "Events",
-        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "TextAreaEvents",
         "typeDefinitions": {
           "TextAreaEvents": {
@@ -136978,8 +136978,8 @@
   },
   {
     "name": "Text field",
-    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/search-field).",
-    "category": "Polaris web components",
+    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/search-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/textfield.png",
@@ -136995,7 +136995,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The `maxLength` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed `maxLength`. Always validate length server-side.\n- The `accessory` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable) components with text content."
+        "sectionContent": "- The `maxLength` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed `maxLength`. Always validate length server-side.\n- The `accessory` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable) components with text content."
       }
     ],
     "definitions": [
@@ -137348,7 +137348,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TextFieldSlots",
         "typeDefinitions": {
           "TextFieldSlots": {
@@ -137371,7 +137371,7 @@
       },
       {
         "title": "Events",
-        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "TextFieldEvents",
         "typeDefinitions": {
           "TextFieldEvents": {
@@ -137548,8 +137548,8 @@
   },
   {
     "name": "Thumbnail",
-    "description": "The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).",
-    "category": "Polaris web components",
+    "description": "The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/thumbnail.png",
@@ -137737,7 +137737,7 @@
       },
       {
         "title": "Events",
-        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ThumbnailEvents",
         "typeDefinitions": {
           "ThumbnailEvents": {
@@ -137865,7 +137865,7 @@
   {
     "name": "Tooltip",
     "description": "The tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.\n\nTooltips support keyboard accessibility, positioning options, and activation on both hover and focus for inclusive interaction patterns.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/tooltip.png",
@@ -137887,7 +137887,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "TooltipSlots",
         "typeDefinitions": {
           "TooltipSlots": {
@@ -137991,8 +137991,8 @@
   },
   {
     "name": "URL field",
-    "description": "The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/urlfield.png",
@@ -138327,7 +138327,7 @@
       },
       {
         "title": "Events",
-        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "URLFieldEvents",
         "typeDefinitions": {
           "URLFieldEvents": {
@@ -138469,8 +138469,8 @@
   },
   {
     "name": "Unordered list",
-    "description": "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list).",
-    "category": "Polaris web components",
+    "description": "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/unordered-list.png",
@@ -138480,7 +138480,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
+        "sectionContent": "- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
       },
       {
         "title": "Limitations",
@@ -138492,7 +138492,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "UnorderedListSlots",
         "typeDefinitions": {
           "UnorderedListSlots": {
@@ -138649,7 +138649,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {

--- a/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Abbreviation.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Abbreviation',
   description:
     'Displays abbreviated text or acronyms, revealing their full meaning or additional context through a tooltip on hover or focus. Use to clarify shortened terms, initialisms, or technical language without interrupting the reading flow.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Announcement.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Announcement.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Announcement',
   description:
     'The Announcement component provides a less disruptive alternative to auto-open modals for capturing user attention. It provides a standardized way to engage users without being too intrusive.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Avatar.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Avatar.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Avatar',
   description:
     "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available." +
-    '\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image).',
-  category: 'Polaris web components',
+    '\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image).',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Badge.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Badge.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Badge',
   description:
     'The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.' +
-    '\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.',
-  category: 'Polaris web components',
+    '\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) instead.',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Banner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Banner.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Banner',
   description:
     'The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.' +
-    '\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).',
-  category: 'Polaris web components',
+    '\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge).',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Box.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Box.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Box',
   description:
     "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components." +
-    '\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
-  category: 'Polaris web components',
+    '\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Button.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Button.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Button',
   description:
     'The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use buttons to let users perform specific tasks or initiate interactions throughout the interface.' +
-    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).',
-  category: 'Polaris web components',
+    '\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button-group).',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ButtonGroup.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Button group',
   description:
     'The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.' +
-    '\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button).',
-  category: 'Polaris web components',
+    '\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button).',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Checkbox.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Checkbox',
   description:
     'The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.' +
-    '\n\nCheckboxes support labels, help text, error states, and an indeterminate state for "select all" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/switch) instead.',
-  category: 'Polaris web components',
+    '\n\nCheckboxes support labels, help text, error states, and an indeterminate state for "select all" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/switch) instead.',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Chip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Chip.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Chip',
   description:
     'The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.' +
-    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip).',
-  category: 'Polaris web components',
+    '\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Choice.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Choice.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The choice component creates individual selectable options within a choice list. Use choice to define each option that merchants can select, supporting both single selection (radio buttons) and multiple selection (checkboxes) modes.' +
     '\n\nChoice components support labels, help text, and custom content through slots, providing flexible option presentation within choice lists.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ChoiceList.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Choice list',
   description:
     'The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.' +
-    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select).',
-  category: 'Polaris web components',
+    '\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Clickable.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Clickable.ts
@@ -3,9 +3,9 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Clickable',
   description:
-    'The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.' +
+    'The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.' +
     '\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ClickableChip.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Clickable chip',
   description:
     'The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.' +
-    '\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).',
-  category: 'Polaris web components',
+    '\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip).',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ClipboardItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ClipboardItem.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Clipboard item',
   description:
     'Enables copying text to the user’s clipboard. Use alongside Button or Link components to let users easily copy content. `<s-clipboard-item>` doesn’t render visually.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ColorField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Color field',
   description:
     'The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.' +
-    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-picker).',
-  category: 'Polaris web components',
+    '\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-picker).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ColorPicker.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Color picker',
   description:
     'The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.' +
-    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field).',
-  category: 'Polaris web components',
+    '\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ConsentCheckbox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ConsentCheckbox.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Consent checkbox',
   description:
     'Use buyer consent checkboxes for collecting the buyer’s approval for a given policy.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ConsentPhoneField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ConsentPhoneField.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Consent phone field',
   description:
     'Display a phone field for customers to sign up for text message marketing, noting that the phone field value will be automatically saved during checkout.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/DateField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DateField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Date field',
   description:
     'The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.' +
-    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-picker).',
-  category: 'Polaris web components',
+    '\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-picker).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DatePicker.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Date picker',
   description:
     'The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.' +
-    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Details.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Details.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Details',
   description:
     'Creates a collapsible content area that can be expanded or collapsed by users. Use with Summary to provide expandable sections for additional information or settings.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Divider.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Divider.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Divider',
   description:
     'The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.' +
-    '\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).',
-  category: 'Polaris web components',
+    '\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/DropZone.ts
+++ b/packages/ui-extensions/src/docs/shared/components/DropZone.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Drop zone',
   description:
     'The drop zone component lets users upload files through drag-and-drop or by clicking to browse. Use for file uploads such as images, documents, or CSV imports.\n\nThe component provides visual feedback during drag operations and supports file type validation through the `accept` property. Rejected files trigger the `droprejected` event for custom error handling.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/EmailField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/EmailField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Email field',
   description:
     'The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.' +
-    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-  category: 'Polaris web components',
+    "\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Form.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Form.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Form',
   description:
     'The form component wraps form controls and enables implicit submission, allowing users to submit from any input by pressing **Enter**. Use form to group related input fields and handle form submission through JavaScript event handlers.' +
-    "\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/function-settings).",
-  category: 'Polaris web components',
+    "\n\nUnlike HTML forms, form doesn't automatically submit data using HTTP—you must register a `submit` event to process form data programmatically. For Shopify Functions configuration forms, use [function settings](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/function-settings).",
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/FunctionSettings.ts
+++ b/packages/ui-extensions/src/docs/shared/components/FunctionSettings.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Function settings',
   description:
     'The function settings component configures metafield settings for [Shopify Functions](/docs/api/functions). Use function settings to create configuration interfaces that allow merchants to customize function behavior through structured input fields and controls.' +
-    '\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/form).',
-  category: 'Polaris web components',
+    '\n\nThis component provides a standardized layout for settings forms and integrates with the native save bar to handle form submission and reset actions automatically. For general form submission, use [form](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/form).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Grid.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Grid.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Grid',
   description:
     'The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.' +
-    '\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
-  category: 'Polaris web components',
+    '\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/GridItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/GridItem.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The grid item component represents a single cell within a grid layout, allowing you to control how content is positioned and sized within the grid. Use grid item as a child of grid to specify column span, row span, and positioning for individual content areas.' +
     '\n\nGrid item supports precise placement control through column and row properties, enabling you to create complex layouts where different items occupy varying amounts of space or appear in specific grid positions.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Heading.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Heading.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Heading',
   description:
     'The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.' +
-    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
-  category: 'Polaris web components',
+    '\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Icon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Icon.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Icon',
   description:
     'The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.' +
-    '\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.',
-  category: 'Polaris web components',
+    '\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) to enhance visual communication.',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Image.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Image.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Image',
   description:
     'The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.' +
-    '\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
-  category: 'Polaris web components',
+    '\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Link.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Link.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Link',
   description:
     'The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.' +
-    '\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.',
-  category: 'Polaris web components',
+    '\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) instead.',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ListItem.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ListItem.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The list item component represents a single entry within an ordered list or unordered list. Use list item to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.' +
     '\n\nList item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Map.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Map.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Map',
   description:
     'Use Map to display a map on a page. This component is useful for displaying a map of a location, such as a store or a customer’s address.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/MapMarker.ts
+++ b/packages/ui-extensions/src/docs/shared/components/MapMarker.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Map marker',
   description:
     'Use MapMarker to display a marker on a map. Use only as a child of `s-map` component.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Menu.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Menu.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The menu component displays a list of actions that can be performed on a resource or within a specific context. Use menu to present multiple related actions in a compact dropdown format, reducing visual clutter while maintaining discoverability.' +
     '\n\nMenus support action grouping, icons for visual clarity, and keyboard navigation for efficient interaction.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Modal.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Modal.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Modal',
   description:
     'Displays content in an overlay. Use to create a distraction-free experience such as a confirmation dialog or a settings panel.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/MoneyField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Money field',
   description:
     'The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.' +
-    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field).',
-  category: 'Polaris web components',
+    '\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/number-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/NumberField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/NumberField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Number field',
   description:
     'The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.' +
-    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/money-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/money-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Option.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Option.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Option',
   description:
     'Represents a single option within a select component. Use only as a child of `s-select` components.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/OptionGroup.ts
+++ b/packages/ui-extensions/src/docs/shared/components/OptionGroup.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Option group',
   description:
     'Represents a group of options within a select component. Use only as a child of `s-select` components.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/OrderedList.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Ordered list',
   description:
     'The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.' +
-    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list).",
-  category: 'Polaris web components',
+    "\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list).",
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Page.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Page.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Page',
   description:
     ' Use `s-page` as the main container for placing content in your app. Page comes with preset layouts and automatically adds spacing between elements.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Paragraph.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Paragraph',
   description:
     'The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.' +
-    '\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).',
-  category: 'Polaris web components',
+    '\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PasswordField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Password field',
   description:
     'The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.' +
-    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    '\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PaymentIcon.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PaymentIcon.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Payment icon',
   description:
     'Displays icons representing payment methods. Use to visually communicate available or saved payment options clearly',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PhoneField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PhoneField.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Phone field',
   description: 'Use PhoneField to allow users to enter phone numbers.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Popover.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Popover.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Popover',
   description:
     'Popovers are used to display content in an overlay that can be triggered by a button.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/PressButton.ts
+++ b/packages/ui-extensions/src/docs/shared/components/PressButton.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Press button',
   description:
     'Allows users to toggle between active/inactive states. Use to represent a persistent on/off or selected/unselected status.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Actions',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ProductThumbnail.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ProductThumbnail.ts
@@ -3,7 +3,7 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Product thumbnail',
   description: 'Use ProductThumbnail to display a product thumbnail',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Progress.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Progress.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Progress',
   description:
     'Displays an indicator showing the completion status of a task. Use to visually communicate progress in either determinate (known percentage) or indeterminate (unknown duration) states.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/QRCode.ts
+++ b/packages/ui-extensions/src/docs/shared/components/QRCode.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'QR code',
   description:
     'Displays a scannable QR code representing data such as URLs or text. Use to let users quickly access information by scanning with a smartphone or other device.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/QueryContainer.ts
+++ b/packages/ui-extensions/src/docs/shared/components/QueryContainer.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     "The query container component establishes a container query context for responsive design. Use query container to define an element as a containment context, enabling child components or styles to adapt based on the container's size rather than viewport width." +
     '\n\nQuery containers support modern responsive patterns where components respond to their container dimensions, creating more flexible and reusable layouts.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/ScrollBox.ts
+++ b/packages/ui-extensions/src/docs/shared/components/ScrollBox.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Scroll box',
   description:
     'Provides a scrollable container for long content that exceeds the available space. Use to display lists, order summaries, or other lengthy content while maintaining a constrained layout.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/SearchField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SearchField.ts
@@ -3,8 +3,8 @@ import type {SharedReferenceEntityTemplateSchema} from '../docs-type';
 const data: SharedReferenceEntityTemplateSchema = {
   name: 'Search field',
   description:
-    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    'The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Section.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Section.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Section',
   description:
     'The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.' +
-    '\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/divider).',
-  category: 'Polaris web components',
+    '\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/divider).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Select.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Select.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Select',
   description:
     'The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.' +
-    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list).',
-  category: 'Polaris web components',
+    '\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Sheet.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Sheet.ts
@@ -6,7 +6,7 @@ const data: SharedReferenceEntityTemplateSchema = {
 The Sheet component displays essential information for customers at the bottom of the screen, appearing above other elements. Use it sparingly to avoid distracting customers during checkout. This component requires access to [Customer Privacy API](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be rendered.
 
 The library automatically applies the [WAI-ARIA Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) to both the activator and the sheet content.`,
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/SkeletonParagraph.ts
+++ b/packages/ui-extensions/src/docs/shared/components/SkeletonParagraph.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Skeleton paragraph',
   description:
     'Displays a placeholder representation of text content while it loads. Use to improve perceived performance by showing users where text will appear.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Spinner.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Spinner.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Spinner',
   description:
     'The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.' +
-    '\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.',
-  category: 'Polaris web components',
+    '\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) component instead.',
+  category: 'Web components',
   subCategory: 'Feedback and status indicators',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Stack.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Stack.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Stack',
   description:
     'The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.' +
-    '\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).',
-  category: 'Polaris web components',
+    '\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Summary.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Summary.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Summary',
   description:
     'Provides a clickable label for collapsible Details content. Use to create clear, accessible disclosure controls that show or hide additional information.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Switch.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Switch.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Switch',
   description:
     'The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.' +
-    "\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/checkbox) instead.",
-  category: 'Polaris web components',
+    "\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/checkbox) instead.",
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Table.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Table.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table component displays data clearly in rows and columns, helping users view, analyze, and compare structured information. Use table to present datasets, product lists, order details, or any tabular content that benefits from organized rows and columns.' +
     '\n\nTables automatically adapt to screen size, rendering as lists on small screens and tables on larger ones for optimal readability across devices.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Layout and structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableBody.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableBody.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table body component represents the main content area of a table, containing the data rows. Use table body as a child of table to structure your table data, with each table row within the body representing a single record or entry.' +
     '\n\nTable body must contain table row components, which in turn contain table cell components for the actual data values.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableCell.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableCell.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table cell component represents a single data cell within a table row. Use table cell as a child of table row to display individual data values, with each cell corresponding to a column in the table.' +
     '\n\nTable cell automatically inherits styling and alignment from its parent table structure and supports text content or other inline components.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeader.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table header component represents a single column header within a table header row. Use table header as a child of table header row to define column headings and optionally enable column sorting.' +
     '\n\nTable header provides semantic meaning for screen readers and can include sorting controls when configured. Each header corresponds to a column in the table body.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableHeaderRow.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table header row component represents the header row of a table, containing column headings. Use table header row as the first child of table (before table body) to define the table structure and provide column labels.' +
     '\n\nTable header row must contain table header components for each column. These headers provide context for the data columns and can support sorting functionality.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TableRow.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TableRow.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The table row component represents a single row of data within a table body. Use table row as a child of table body to structure individual records or entries in the table.' +
     '\n\nTable row must contain table cell components, with each cell representing a data value for the corresponding column. The number of cells should match the number of headers in the table.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Structure',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Text.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Text.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text',
   description:
     'The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.' +
-    '\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).',
-  category: 'Polaris web components',
+    '\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TextArea.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextArea.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text area',
   description:
     'The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.' +
-    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/TextField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/TextField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Text field',
   description:
     'The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.' +
-    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/search-field).',
-  category: 'Polaris web components',
+    '\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/search-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Thumbnail.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Thumbnail',
   description:
     'The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.' +
-    '\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).',
-  category: 'Polaris web components',
+    '\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).',
+  category: 'Web components',
   subCategory: 'Media and visuals',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Time.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Time.ts
@@ -4,7 +4,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Time',
   description:
     'Represents a specific point or duration in time. Use to display dates, times, or durations clearly and consistently. May include a machine-readable `datetime` attribute for improved accessibility and functionality.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
@@ -5,7 +5,7 @@ const data: SharedReferenceEntityTemplateSchema = {
   description:
     'The tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.' +
     '\n\nTooltips support keyboard accessibility, positioning options, and activation on both hover and focus for inclusive interaction patterns.',
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/URLField.ts
+++ b/packages/ui-extensions/src/docs/shared/components/URLField.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'URL field',
   description:
     'The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.' +
-    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).',
-  category: 'Polaris web components',
+    '\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).',
+  category: 'Web components',
   subCategory: 'Forms',
   related: [],
 };

--- a/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
+++ b/packages/ui-extensions/src/docs/shared/components/UnorderedList.ts
@@ -4,8 +4,8 @@ const data: SharedReferenceEntityTemplateSchema = {
   name: 'Unordered list',
   description:
     "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning." +
-    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list).',
-  category: 'Polaris web components',
+    '\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list).',
+  category: 'Web components',
   subCategory: 'Typography and content',
   related: [],
 };

--- a/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/action/action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.',
   defaultExample: {
     description:
       'Send selected product IDs to your backend for bulk processing. This example shows how to map selected items, make an authenticated API call, and close the modal when the operation completes.',
@@ -74,7 +74,7 @@ const data: ReferenceEntityTemplateSchema = {
       title: 'Best practices',
       sectionContent:
         '- **Check array length for bulk operations:** When actions appear on index pages with bulk selection, `api.data.selected` can contain multiple resources. Check the array length and handle batch operations accordingly.\n' +
-        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) components during async operations to prevent duplicate submissions.",
+        "- **Use `loading` state on buttons:** Modal actions don't show loading indicators automatically. Use the `loading` prop on [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) components during async operations to prevent duplicate submissions.",
     },
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/block/block.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
-      "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/spinner) component while fetching.",
+      "Fetch and display a product's title, inventory, and status in a [block extension](/docs/api/admin-extensions/{API_VERSION}#building-your-extension). This example uses `useEffect` to query the [GraphQL Admin API](/docs/api/admin-graphql/) when the page loads and renders a loading [spinner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/spinner) component while fetching.",
     codeblock: {
       title: 'Display product information',
       tabs: [
@@ -35,7 +35,7 @@ const data: ReferenceEntityTemplateSchema = {
     examples: [
       {
         description:
-          'Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+          'Check product eligibility with your backend API before launching an action extension. This example validates that the product meets criteria, shows a loading state during the check, and conditionally displays a navigation [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
         codeblock: {
           title: 'Navigate to action extension',
           tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/checkout-rules/validation-settings.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.',
+      'Save a minimum quantity validation rule with a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) input. This example calls `applyMetafieldChange`, checks the result type, and displays success or error banners based on the response.',
     codeblock: {
       title: 'Set minimum quantity',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.',
+      'Save a minimum purchase threshold to a metafield with decimal number validation. This example uses a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for input, calls `applyMetafieldChange`, and displays success or error feedback.',
     codeblock: {
       title: 'Configure discount threshold',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/order-routing-rule/order-routing-rule.doc.ts
@@ -7,10 +7,10 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/function-settings) component.',
+    'the [function settings](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/function-settings) component.',
   defaultExample: {
     description:
-      'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',
+      'Set preferred and fallback fulfillment locations with [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) inputs. This example applies two metafield changes in a single batch operation to configure location priority for order routing.',
     codeblock: {
       title: 'Configure location priority',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/print-action/print-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-print-action) component.',
+    'the [admin print action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-print-action) component.',
   defaultExample: {
     description:
       "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and setting the printable URL as the `src` prop to display the document.",

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
       'Open the product [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select up to five components for a [bundle](/docs/apps/build/product-merchandising/bundles). This example filters out draft and archived products, saves the bundle configuration to your backend, and tracks the selection count.',

--- a/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/product-configuration/product-variant-details-configuration.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-block) component.',
+    'the [admin block](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-block) component.',
   defaultExample: {
     description:
       'Use the product variant [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) to select component variants for a [bundle](/docs/apps/build/product-merchandising/bundles). This example picks product variants, tracks selections, and posts the product variant IDs to configure the bundle.',

--- a/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/purchase-options-card-action.doc.ts
@@ -7,7 +7,7 @@ const data: ReferenceEntityTemplateSchema = {
   isVisualComponent: false,
   type: 'API',
   requires:
-    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/settings-and-templates/admin-action) component.',
+    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.',
   defaultExample: {
     description:
       'Update a subscription by sending product and selling plan IDs to your backend. This example checks for selling plan presence, posts the update request, and shows a success banner before auto-closing the modal.',

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -5282,7 +5282,7 @@ export interface BoxProps
    *
    * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -5294,7 +5294,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5302,7 +5302,7 @@ export interface BoxProps
   /**
    * The block-start padding (top in horizontal writing modes).
    *
-   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5310,7 +5310,7 @@ export interface BoxProps
   /**
    * The block-end padding (bottom in horizontal writing modes).
    *
-   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5322,7 +5322,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5330,7 +5330,7 @@ export interface BoxProps
   /**
    * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5338,7 +5338,7 @@ export interface BoxProps
   /**
    * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -6664,9 +6664,9 @@ export interface GridProps
    * Adjusts spacing between elements.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`
    * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
@@ -6675,8 +6675,8 @@ export interface GridProps
    * s spacing between elements in the block axis. This overrides the row value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -6685,8 +6685,8 @@ export interface GridProps
    * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -6696,7 +6696,7 @@ export interface GridProps
    *
    * Accepts:
    * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
@@ -6706,7 +6706,7 @@ export interface GridProps
    *
    * Accepts:
    * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
@@ -8072,9 +8072,9 @@ export interface StackProps
    * Adjusts spacing between elements.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`
    * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
@@ -8083,8 +8083,8 @@ export interface StackProps
    * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -8093,8 +8093,8 @@ export interface StackProps
    * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -8104,7 +8104,7 @@ export interface StackProps
    *
    * Accepts:
    * - A single value, either `inline` or `block`
-   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value
+   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value
    *
    * @default 'block'
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminAction/AdminAction.ext.doc.ts
@@ -21,11 +21,11 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'AdminActionSlots',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Settings and templates',
   subSections: [
     {
@@ -42,7 +42,7 @@ const data: ReferenceEntityTemplateSchema = {
     image:
       '/assets/templated-apis-screenshots/admin/components/adminaction-example.png',
     description:
-      'Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.',
+      'Set up the modal header and action [buttons](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) for an admin action extension. This example shows a titled modal with primary and secondary action buttons.',
     codeblock: {
       title: 'Configure an admin action modal',
       tabs: [
@@ -62,7 +62,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+              'Show a loading indicator while data is being fetched or processed. This example sets the `loading` property to display a loading state and disables the primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
             codeblock: {
               title: 'Show a loading state',
               tabs: [
@@ -76,7 +76,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Collect merchant input inside the action modal using form fields. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) arranged in a [stack](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/stack).',
+              'Collect merchant input inside the action modal using form fields. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) arranged in a [stack](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/stack).',
             codeblock: {
               title: 'Add form fields to the modal',
               tabs: [
@@ -90,7 +90,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button) to confirm deletion.',
+              'Warn merchants before a permanent operation like deleting a resource. This example uses a critical [banner](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/banner) and a destructive primary [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button) to confirm deletion.',
             codeblock: {
               title: 'Confirm a destructive action',
               tabs: [
@@ -104,7 +104,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+              'Display read-only resource information inside a modal before the merchant takes action. This example shows an order summary with [badges](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge), [dividers](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/divider), and a fulfillment [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
             codeblock: {
               title: 'Show resource details in a modal',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminBlock/AdminBlock.ext.doc.ts
@@ -19,7 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'AdminBlockProps',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Settings and templates',
   subSections: [
     {
@@ -45,7 +45,7 @@ const data: ReferenceEntityTemplateSchema = {
     image:
       '/assets/templated-apis-screenshots/admin/components/adminblock-example.png',
     description:
-      'Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) content.',
+      'Display an inline block on an admin resource page. This example shows a simple block with a `heading` property and [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) content.',
     codeblock: {
       title: 'Display an inline admin block',
       tabs: [
@@ -65,7 +65,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/typography-and-content/text) summary in the block header.',
+              'Provide a preview of the block content when it is collapsed. This example uses the `collapsed-summary` attribute to show a short [text](/docs/api/admin-extensions/{API_VERSION}/web-components/typography-and-content/text) summary in the block header.',
             codeblock: {
               title: 'Show a collapsed summary',
               tabs: [
@@ -79,7 +79,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/table).',
+              'Present structured data in rows and columns within a block. This example displays inventory levels across locations using a [table](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/table).',
             codeblock: {
               title: 'Display a data table',
               tabs: [
@@ -93,7 +93,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge) and a list of risk factors.',
+              'Highlight key status information with visual indicators. This example shows an order risk assessment with a warning [badge](/docs/api/admin-extensions/{API_VERSION}/web-components/feedback-and-status-indicators/badge) and a list of risk factors.',
             codeblock: {
               title: 'Show status with badges',
               tabs: [
@@ -107,7 +107,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button-group) for pause and cancel actions.',
+              'Include interactive buttons so merchants can take action directly from the block. This example shows subscription details with a [button group](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button-group) for pause and cancel actions.',
             codeblock: {
               title: 'Add action buttons to a block',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AdminPrintAction/AdminPrintAction.ext.doc.ts
@@ -19,7 +19,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'AdminPrintActionProps',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Settings and templates',
   subSections: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Avatar/Avatar.doc.ts
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'AvatarEvents',
     },
   ],
@@ -137,7 +137,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text) components.',
+              'Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text) components.',
             codeblock: {
               title: 'Build a merchant profile card',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -230,7 +230,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'BadgeSlots',
     },
   ],
@@ -76,7 +76,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.',
+              'Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.',
             codeblock: {
               title: 'Display badges in a table',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Banner/Banner.doc.ts
@@ -36,13 +36,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'BannerEvents',
     },
     {
       title: 'Slots',
       description:
-        'The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'BannerSlots',
     },
   ],
@@ -69,7 +69,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.',
+              'Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.',
             codeblock: {
               title: 'Create a warning banner with buttons for next steps',
               tabs: [
@@ -83,7 +83,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to review order details and adjust settings.',
+              'Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to review order details and adjust settings.',
             codeblock: {
               title: 'Alert merchants to critical issues requiring action',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Box/Box.doc.ts
@@ -10,8 +10,8 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.
-- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.
+      sectionContent: `- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.
+- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.
 - **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.
 - **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.
 - **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components.`,
@@ -26,7 +26,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'BoxSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -44,7 +44,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button/Button.doc.ts
@@ -36,13 +36,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ButtonEvents',
     },
     {
       title: 'Slots',
       description:
-        'The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ButtonSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ButtonGroup/ButtonGroup.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ButtonGroupSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Checkbox/Checkbox.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'CheckboxEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Chip/Chip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Chip/Chip.doc.ts
@@ -10,7 +10,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip) instead.
+      sectionContent: `- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip) instead.
 - **Keep chip text concise and scannable:** Short labels like "Featured" or "On sale" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.
 - **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.
 - **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ChipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ChoiceList/ChoiceList.doc.ts
@@ -22,7 +22,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select) dropdown instead.
+      sectionContent: `- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select) dropdown instead.
 - Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.
 - The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.
 - Component types other than choice can't be used as options within the choice list.`,
@@ -38,7 +38,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ChoiceListEvents',
     },
     {
@@ -49,7 +49,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ChoiceSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -197,7 +197,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -209,7 +209,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -219,7 +219,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -229,7 +229,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -241,7 +241,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -251,7 +251,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -261,7 +261,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable/Clickable.doc.ts
@@ -26,20 +26,20 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ClickableEvents',
     },
     {
       title: 'Slots',
       description:
-        'The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ClickableSlots',
     },
   ],
   defaultExample: {
     image: 'clickable-default.png',
     description:
-      "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
+      "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
     codeblock: {
       title: 'Create a custom interactive element',
       tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/ClickableChip/ClickableChip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ClickableChip/ClickableChip.doc.ts
@@ -14,7 +14,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       sectionContent: `- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.
 - **Choose color variants by importance:** Use \`subdued\` for less important or secondary chips, \`base\` (default) for standard selections, and \`strong\` to emphasize primary or active selections.
 - **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.
-- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing.`,
+- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing.`,
     },
   ],
   definitions: [
@@ -27,13 +27,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ClickableChipEvents',
     },
     {
       title: 'Slots',
       description:
-        'The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ClickableChipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorField/ColorField.doc.ts
@@ -31,7 +31,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ColorFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/ColorPicker/ColorPicker.doc.ts
@@ -13,7 +13,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.
 - **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.
-- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control.`,
+- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control.`,
     },
     {
       title: 'Limitations',
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ColorPickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DateField/DateField.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'DateFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DatePicker/DatePicker.doc.ts
@@ -29,7 +29,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'DatePickerEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/DropZone/DropZone.doc.ts
@@ -3,7 +3,7 @@ import shared from '../../../../docs/shared/components/DropZone';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/dropzone.png',
   isVisualComponent: true,
   subSections: [
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'DropZoneEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/EmailField/EmailField.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'EmailFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Form/Form.ext.doc.ts
@@ -3,7 +3,7 @@ import shared from '../../../../docs/shared/components/Form';
 
 const data: ReferenceEntityTemplateSchema = {
   ...shared,
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/form.png',
   isVisualComponent: true,
   subSections: [
@@ -14,7 +14,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `- **Group related fields logically:** Organize fields by category or workflow step so merchants can complete forms efficiently.
 - **Validate with specific error messages:** Instead of **Invalid input**, provide actionable feedback like **Email must include @ symbol** or **Password must be at least 8 characters**.
 - **Mark required fields clearly:** Use the \`required\` property and show validation errors only after user interaction or submission attempt.
-- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.
+- **Choose field types that match data:** Use [email field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/email-field) for emails, [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for quantities, and [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) for dates to provide appropriate keyboards and pickers.
 - **Provide submission feedback:** Show loading states during processing and clear success or error messages after completion. Prevent duplicate submissions while processing.
 - **Handle unsaved changes:** For long or complex forms, consider auto-saving drafts or prompting before navigation when changes exist.`,
     },
@@ -29,13 +29,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'FormEvents',
     },
   ],
   defaultExample: {
     description:
-      'Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/actions/button).',
+      'Group input fields that submit together when a merchant presses Enter or clicks a submit button. This example shows a basic form with a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and submit [button](/docs/api/admin-extensions/{API_VERSION}/web-components/actions/button).',
     codeblock: {
       title: 'Submit a basic form',
       tabs: [
@@ -55,7 +55,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.',
+              'Use specialized field types like [date field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/date-field) and [money field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/money-field) to collect structured campaign data. This example includes a reset button alongside submit so merchants can clear and start over.',
             codeblock: {
               title: 'Build a campaign form with date and money fields',
               tabs: [
@@ -69,7 +69,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline validation errors.',
+              'Display specific error messages on individual fields to guide merchants toward valid input. This example shows a required [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline validation errors.',
             codeblock: {
               title: 'Show field validation errors',
               tabs: [
@@ -83,7 +83,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.',
+              'Mix text inputs with [selects](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) and [checkboxes](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/checkbox) to capture different kinds of merchant decisions. This example combines a text field, a select dropdown, and a checkbox for creating a discount.',
             codeblock: {
               title: 'Use select and checkbox fields',
               tabs: [
@@ -97,7 +97,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to separate contact information from shipping preferences.',
+              'Organize a longer form into labeled groups so merchants can scan and complete it more easily. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to separate contact information from shipping preferences.',
             codeblock: {
               title: 'Group fields into sections',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/FunctionSettings/FunctionSettings.ext.doc.ts
@@ -5,7 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   ...shared,
   requires:
     'the [Discount Function Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/discount-function-settings-api), [Validation Settings API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/validation-settings-api), or [Order Routing Rule API](/docs/api/admin-extensions/{API_VERSION}/target-apis/contextual-apis/order-routing-rule-api).',
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/form.png',
   isVisualComponent: true,
   subSections: [
@@ -15,7 +15,7 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `- **Label settings clearly:** Instead of technical names like **Max threshold**, use merchant-friendly labels like **Maximum discount amount** or **Order value limit**.
 - **Validate with specific feedback:** Check that percentages are between 0-100, that monetary values are positive, and that required fields are filled. Provide clear error messages when validation fails.
-- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.
+- **Explain impact with field details:** Use the \`details\` property on individual field components (for example, [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) or [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field)) to explain what each setting does and how it affects the user's workflow.
 - **Set appropriate defaults:** Pre-select the most common configuration to reduce setup friction for merchants.
 - **Group related settings:** Use sections to organize settings by function so merchants can find what they need quickly.`,
     },
@@ -24,13 +24,13 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'FormEvents',
     },
   ],
   defaultExample: {
     description:
-      'Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) for a discount percentage input inside a function settings component.',
+      'Configure a [Shopify Function](/docs/api/functions/) with a settings form that integrates with the native save bar. This example shows a [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) for a discount percentage input inside a function settings component.',
     codeblock: {
       title: 'Add a settings field for a function',
       tabs: [
@@ -50,7 +50,7 @@ const data: ReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.',
+              'Organize settings into repeating groups for tiered or multi-level configurations. This example uses [sections](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/section) to define two volume discount tiers, each with a quantity threshold and percentage.',
             codeblock: {
               title: 'Set up tiered discount rules',
               tabs: [
@@ -64,7 +64,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field) with inline error messages.',
+              'Display validation errors when settings values are out of range or missing. This example shows required [number fields](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) with inline error messages.',
             codeblock: {
               title: 'Show validation errors on settings',
               tabs: [
@@ -78,7 +78,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/text-field) for a filter value.',
+              'Let merchants choose from predefined options to control function behavior. This example uses a [select](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/select) dropdown to pick a discount target and a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) for a filter value.',
             codeblock: {
               title: 'Add a select dropdown to settings',
               tabs: [
@@ -92,7 +92,7 @@ const data: ReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/polaris-web-components/forms/number-field).',
+              'Let merchants enable or disable a feature with a [switch](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/switch) and configure its threshold. This example pairs a toggle for free shipping with a minimum order amount [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field).',
             codeblock: {
               title: 'Toggle a feature with a switch',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -175,7 +175,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -187,7 +187,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -197,7 +197,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -207,7 +207,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -219,7 +219,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -229,7 +229,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -239,7 +239,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -362,31 +362,31 @@ export interface GridProps
     | `${AlignContentKeyword} ${JustifyContentKeyword}`
     | AlignContentKeyword;
   /**
-   * The spacing between grid rows and columns. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for rows and columns. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between grid rows and columns. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for rows and columns. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gap: ResponsiveGridProps['gap'];
   /**
-   * The spacing between grid rows. This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between grid rows. This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveGridProps['rowGap'];
   /**
-   * The spacing between grid columns. This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between grid columns. This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveGridProps['columnGap'];
   /**
-   * The number of columns and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 1fr)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The number of columns and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 1fr)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];
   /**
-   * The number of rows and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 100px)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The number of rows and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 100px)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid/Grid.doc.ts
@@ -32,7 +32,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'GridSlots',
     },
     {
@@ -43,7 +43,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'GridItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -170,7 +170,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -182,7 +182,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -192,7 +192,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -202,7 +202,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -214,7 +214,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -224,7 +224,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -234,7 +234,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Heading/Heading.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'HeadingSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Icon/Icon.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.
-- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image) component instead.
+- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image) component instead.
 - Icon color is determined by the \`tone\` and \`color\` properties. Custom colors or gradients aren't available.`,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -205,7 +205,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -217,7 +217,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -227,7 +227,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -237,7 +237,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -249,7 +249,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -259,7 +259,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -269,7 +269,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image/Image.doc.ts
@@ -11,7 +11,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'best-practices',
       sectionContent: `- **Always provide descriptive alternative text:** Write alt text that describes what's in the image, not what the image is for. Use "Blue cotton t-shirt with crew neck" instead of "Product image." For decorative images that don't add information, use an empty alt attribute.
-- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [Icon](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/icon) component instead.
+- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [Icon](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/icon) component instead.
 - **Ensure images are accessible and performant:** Use appropriate image formats (WebP for photos, PNG for graphics with transparency, SVG for logos). Ensure images load from reliable sources with proper CORS configuration if cross-origin.
 - **Consider the image's purpose and context:** Use images to help merchants understand products, visualize data, or follow instructions. Every image should serve a clear purpose in your interface.`,
     },
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ImageEvents',
     },
   ],
@@ -116,7 +116,7 @@ const data: AdminReferenceEntityTemplateSchema = {
           },
           {
             description:
-              'Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.',
+              'Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.',
             codeblock: {
               title: 'Use in a grid layout',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Link/Link.doc.ts
@@ -31,13 +31,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'LinkEvents',
     },
     {
       title: 'Slots',
       description:
-        'The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'LinkSlots',
     },
   ],
@@ -64,7 +64,7 @@ const data: AdminReferenceEntityTemplateSchema = {
         examples: [
           {
             description:
-              'Embed links within a [Paragraph](/docs/api/app-home/polaris-web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.',
+              'Embed links within a [Paragraph](/docs/api/app-home/web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.',
             codeblock: {
               title: 'Embed links in paragraph text',
               tabs: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Menu/Menu.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Menu/Menu.doc.ts
@@ -36,7 +36,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'MenuSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/MoneyField/MoneyField.doc.ts
@@ -37,7 +37,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'MoneyFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/NumberField/NumberField.doc.ts
@@ -11,7 +11,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) instead.
+      sectionContent: `- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) instead.
 - **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.
 - **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.
 - **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter.`,
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'NumberFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/OrderedList/OrderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list) instead.
+      sectionContent: `- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'OrderedListSlots',
     },
     {
@@ -39,7 +39,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ListItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Paragraph/Paragraph.doc.ts
@@ -35,7 +35,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ParagraphSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/PasswordField/PasswordField.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'PasswordFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Popover/Popover.ab.doc.ts
@@ -3,7 +3,7 @@ import sharedContent from '../../../../docs/shared/components/Popover';
 
 const data: AdminReferenceEntityTemplateSchema = {
   ...sharedContent,
-  category: 'Polaris web components',
+  category: 'Web components',
   thumbnail: '/assets/templated-apis-screenshots/admin/components/popover.png',
   isVisualComponent: true,
   subSections: [

--- a/packages/ui-extensions/src/surfaces/admin/components/QueryContainer/QueryContainer.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/QueryContainer/QueryContainer.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'QueryContainerSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/SearchField/SearchField.doc.ts
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'SearchFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Section/Section.doc.ts
@@ -34,7 +34,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'SectionSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Select/Select.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.
+      sectionContent: `- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.
 - **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.
 - **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.
 - **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.
@@ -23,10 +23,10 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.
-- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list) with checkboxes or build a custom multi-select component.
+- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list) with checkboxes or build a custom multi-select component.
 - Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.
-- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).
-- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components.`,
+- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu).
+- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu) components.`,
     },
   ],
   definitions: [
@@ -39,13 +39,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'SelectEvents',
     },
     {
       title: 'Slots',
       description:
-        'The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'SelectSlots',
     },
     {
@@ -56,7 +56,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'OptionSlots',
     },
     {
@@ -67,7 +67,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'OptionGroupSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Spinner/Spinner.doc.ts
@@ -22,7 +22,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       sectionContent: `- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.
 - The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.
 - Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.
-- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) alongside the spinner.`,
+- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) alongside the spinner.`,
     },
   ],
   definitions: [

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -174,7 +174,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -186,7 +186,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -196,7 +196,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -206,7 +206,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -218,7 +218,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -228,7 +228,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -238,7 +238,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -340,25 +340,25 @@ export interface StackProps
    */
   alignContent: AlignContentKeyword;
   /**
-   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gap: ResponsiveStackProps['gap'];
   /**
-   * The spacing between children in the block axis (vertical in horizontal writing modes). This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the block axis (vertical in horizontal writing modes). This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveStackProps['rowGap'];
   /**
-   * The spacing between children in the inline axis (horizontal in left-to-right languages). This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the inline axis (horizontal in left-to-right languages). This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveStackProps['columnGap'];
   /**
-   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
+   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
    *
    * @default 'block'
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack/Stack.doc.ts
@@ -30,7 +30,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'StackSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Switch/Switch.doc.ts
@@ -27,7 +27,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'SwitchEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Table/Table.doc.ts
@@ -39,13 +39,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableSlots',
     },
     {
       title: 'Events',
       description:
-        'The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'TableEvents',
     },
     {
@@ -56,7 +56,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableBodySlots',
     },
     {
@@ -67,7 +67,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableCellSlots',
     },
     {
@@ -78,7 +78,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableHeaderSlots',
     },
     {
@@ -89,7 +89,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableHeaderRowSlots',
     },
     {
@@ -100,7 +100,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TableRowSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Text/Text.doc.ts
@@ -19,8 +19,8 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Limitations',
       type: 'Generic' as const,
       anchorLink: 'limitations',
-      sectionContent: `- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph) component or wrap in layout components.
-- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading) with line clamping if truncation is needed.
+      sectionContent: `- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph) component or wrap in layout components.
+- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading) with line clamping if truncation is needed.
 - Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements.`,
     },
   ],
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TextSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextArea/TextArea.doc.ts
@@ -33,7 +33,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'TextAreaEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -59,7 +59,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField/TextField.doc.ts
@@ -21,7 +21,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       type: 'Generic' as const,
       anchorLink: 'limitations',
       sectionContent: `- The \`maxLength\` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed \`maxLength\`. Always validate length server-side.
-- The \`accessory\` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable) components with text content.`,
+- The \`accessory\` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable) components with text content.`,
     },
   ],
   definitions: [
@@ -34,13 +34,13 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TextFieldSlots',
     },
     {
       title: 'Events',
       description:
-        'The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'TextFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Thumbnail/Thumbnail.doc.ts
@@ -35,7 +35,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'ThumbnailEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Tooltip/Tooltip.doc.ts
@@ -29,7 +29,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'TooltipSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/URLField/URLField.doc.ts
@@ -37,7 +37,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-polaris-web-components#handling-events).',
+        'The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).',
       type: 'URLFieldEvents',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/UnorderedList/UnorderedList.doc.ts
@@ -12,7 +12,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Best practices',
       type: 'Generic' as const,
       anchorLink: 'best-practices',
-      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list) instead.
+      sectionContent: `- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list) instead.
 - **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.
 - **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.
 - **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format.`,
@@ -28,7 +28,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'UnorderedListSlots',
     },
     {
@@ -39,7 +39,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       title: 'Slots',
       description:
-        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-polaris-web-components#slots).',
+        'The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).',
       type: 'ListItemSlots',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/patterns/indexTable.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/patterns/indexTable.ab.doc.ts
@@ -48,7 +48,7 @@ const data: AdminReferenceEntityTemplateSchema = {
     {
       name: 'Table',
       subtitle: 'Component',
-      url: '/docs/api/app-home/polaris-web-components/structure/table',
+      url: '/docs/api/app-home/web-components/structure/table',
       type: 'component',
     },
   ],


### PR DESCRIPTION
## This PR: 
- Revises the terminology from "Polaris web components" to "Web components", in response to Eytan's release feedback
- Relates to https://github.com/shop/world/pull/484742