### PR TITLE
Fix missed Sheet.doc.ts category rename

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.doc.ts
@@ -34,7 +34,7 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'SheetElementMethods',
     },
   ],
-  category: 'Polaris web components',
+  category: 'Web components',
   subCategory: 'Overlays',
   defaultExample: {
     image: 'sheet-default.png',


### PR DESCRIPTION
Missed checkout-specific `Sheet.doc.ts` in #4143. The shared component was updated but this surface-specific override at `src/surfaces/checkout/components/Sheet/Sheet.doc.ts` still had `category: 'Polaris web components'`.