### PR TITLE
[App Home]: Fix docs build script

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -431,8 +431,9 @@ const transformJson = async (filePath, isExtensions) => {
 
     const filteredDocs = shopifyDevDocsDocsParsed.filter(
       (entry) =>
-          entry.category !== 'Web components' &&
-        entry.category !== 'Patterns', // Don't include old patterns
+        entry.category !== 'Web components' &&
+        entry.category !== 'Polaris web components' &&
+        entry.category !== 'Patterns',
     );
 
     // Combine arrays with shopify dev docs first, followed by new data


### PR DESCRIPTION
## This PR: 
- Fixes duplicate Polaris web components in generated App Home docs: The `transformJson` merge filter was missing the "Polaris web components" category, causing entries from the Shopify Dev docs source to duplicate those already produced by the doc generator.
- Adds "Polaris web components" to the category exclusion list so only the freshly generated entries are included in the final output, matching the existing handling of "Web components" and "Patterns".