### PR TITLE
[Checkout UI Ext] Platform API examples + descriptions

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/extension-meta.doc.ts
@@ -1,6 +1,7 @@
 import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 import {
+  getExample,
   getLinksByTag,
   STANDARD_API_PROPERTIES_DESCRIPTION,
 } from '../helper.docs';
@@ -46,6 +47,11 @@ const data: ReferenceEntityTemplateSchema = {
       type: 'UseExtensionEditorGeneratedType',
     },
   ],
+  defaultExample: getExample('extension/metadata', ['jsx']),
+  examples: {
+    description: '',
+    examples: [getExample('extension/capabilities', ['jsx'])],
+  },
   related: getLinksByTag('apis'),
 };
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/metafields.doc.ts
@@ -41,6 +41,10 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: getExample('metafields/default', ['jsx', 'toml']),
+  examples: {
+    description: '',
+    examples: [getExample('metafields/update-cart-metafield', ['jsx'])],
+  },
   related: getLinksByTag('apis'),
 };
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/apis/storage.doc.ts
@@ -27,6 +27,10 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   defaultExample: getExample('storage', ['jsx']),
+  examples: {
+    description: '',
+    examples: [getExample('storage/delete-entry', ['jsx'])],
+  },
   related: getLinksByTag('apis'),
 };
 

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/extension/capabilities.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/extension/capabilities.example.tsx
@@ -1,0 +1,29 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+import {
+  useExtensionCapability,
+  useExtensionEditor,
+} from '@shopify/ui-extensions/checkout/preact';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  const canBlockProgress =
+    useExtensionCapability('block_progress');
+  const editor = useExtensionEditor();
+
+  if (editor?.type === 'checkout' && !canBlockProgress) {
+    return (
+      <s-banner tone="warning" heading="Missing permission">
+        Enable "block checkout progress" in
+        the checkout editor to use this
+        extension.
+      </s-banner>
+    );
+  }
+
+  return null;
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/extension/metadata.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/extension/metadata.example.tsx
@@ -1,0 +1,29 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+import {useExtension} from '@shopify/ui-extensions/checkout/preact';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  const {target, apiVersion, version} =
+    useExtension();
+
+  return (
+    <s-stack>
+      <s-text>
+        Target: {target}
+      </s-text>
+      <s-text>
+        API version: {apiVersion}
+      </s-text>
+      {version && (
+        <s-text>
+          Extension version: {version}
+        </s-text>
+      )}
+    </s-stack>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/metafields/update-cart-metafield.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/metafields/update-cart-metafield.example.tsx
@@ -1,0 +1,31 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  async function savePreference() {
+    const result =
+      await shopify.applyMetafieldChange({
+        type: 'updateCartMetafield',
+        metafield: {
+          namespace: '$app:preferences',
+          key: 'gift-message',
+          type: 'single_line_text_field',
+          value: 'Happy birthday!',
+        },
+      });
+
+    if (result.type === 'error') {
+      console.error(result.message);
+    }
+  }
+
+  return (
+    <s-button onClick={savePreference}>
+      Save gift message
+    </s-button>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/examples/storage/delete-entry.example.tsx
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/examples/storage/delete-entry.example.tsx
@@ -1,0 +1,54 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+import {useEffect, useState} from 'preact/hooks';
+
+export default function extension() {
+  render(<Extension />, document.body);
+}
+
+function Extension() {
+  const {storage} = shopify;
+  const [dismissed, setDismissed] =
+    useState(true);
+
+  useEffect(() => {
+    async function checkDismissed() {
+      const value =
+        await storage.read('promo-dismissed');
+      setDismissed(Boolean(value));
+    }
+
+    checkDismissed();
+  }, [storage]);
+
+  async function dismiss() {
+    setDismissed(true);
+    await storage.write(
+      'promo-dismissed',
+      true,
+    );
+  }
+
+  async function reset() {
+    setDismissed(false);
+    await storage.delete('promo-dismissed');
+  }
+
+  if (dismissed) {
+    return (
+      <s-button onClick={reset}>
+        Show promotion again
+      </s-button>
+    );
+  }
+
+  return (
+    <s-banner
+      heading="Limited offer"
+      dismissible
+      onDismiss={dismiss}
+    >
+      Use code SAVE20 for 20% off today.
+    </s-banner>
+  );
+}

--- a/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
+++ b/packages/ui-extensions/docs/surfaces/checkout/reference/helper.docs.ts
@@ -122,17 +122,17 @@ export function getExamples(
     ...createExample('purchase.thank-you.announcement.render/default'),
     'analytics-publish': {
       description:
-        'You can publish analytics events to the Shopify analytics frameworks and they will be propagated to all web pixels on the page.',
+        'Use `shopify.analytics.publish()` to send custom events to all web pixels registered on the page. The event name and payload are forwarded to the Shopify analytics framework, where web pixels can listen and react.',
       codeblock: {
-        title: 'Publish',
+        title: 'Publish a custom analytics event',
         tabs: getExtensionCodeTabs('analytics-publish'),
       },
     },
     'analytics-visitor': {
       description:
-        'You can submit visitor information to Shopify, these will be sent to the shop backend and not be propagated to web pixels on the page.',
+        'Use `shopify.analytics.visitor()` to submit buyer contact details to the shop backend. Unlike published events, visitor data is not propagated to web pixels on the page.',
       codeblock: {
-        title: 'Visitor',
+        title: 'Submit visitor information',
         tabs: getExtensionCodeTabs('analytics-visitor'),
       },
     },
@@ -288,12 +288,10 @@ See [settings](/docs/api/checkout-ui-extensions/configuration#settings-definitio
       },
     },
     'settings-access': {
-      description: `
-You can retrieve settings values within your extension. In React, the \`useSettings()\` hook re-renders your extension with the latest values.
-In JavaScript, subscribe to changes and update your UI directly.
-      `,
+      description:
+        'Use `shopify.settings.value` to read merchant-configured values at runtime. The extension re-renders automatically when the merchant changes settings in the checkout editor.',
       codeblock: {
-        title: 'Accessing merchant settings',
+        title: 'Access merchant settings',
         tabs: getExtensionCodeTabs('settings-access'),
       },
     },
@@ -398,12 +396,12 @@ You can apply changes to customer consent by using the \`applyTrackingConsentCha
     },
     'session-token': {
       description: `
-You can request a session token from Shopify to use on your application server.  The contents of the token claims are signed using your shared app secret so you can trust the claims came from Shopify unaltered.
+Request a session token from Shopify and pass it to your application server as a Bearer token. The claims are signed with your app secret, so your server can trust they came from Shopify unaltered.
 
 > Note: You will need to [enable the \`network_access\` capability](/docs/api/checkout-ui-extensions/configuration#network-access) to use \`fetch()\`.
 `,
       codeblock: {
-        title: 'Using a session token with fetch()',
+        title: 'Use a session token with fetch()',
         tabs: getExtensionCodeTabs('session-token'),
       },
     },
@@ -426,9 +424,10 @@ The contents of the token are signed using your shared app secret.  The optional
       },
     },
     storage: {
-      description: '',
+      description:
+        'Use `shopify.storage` to persist data across page loads within the same checkout session. A terms-of-service checkbox is stored and restored so the buyer does not need to re-check it after navigating.',
       codeblock: {
-        title: 'Storage',
+        title: 'Read and write to storage',
         tabs: getExtensionCodeTabs('storage'),
       },
     },
@@ -498,9 +497,29 @@ The contents of the token are signed using your shared app secret.  The optional
       `,
     }),
     ...createExample('metafields/default', {
-      title: 'Use app owned metafields',
+      title: 'Read app-owned metafields',
       description:
-        'Use the `$app` format to request metafields that are owned by your app in your extension configuration file. Your app exclusively controls structure, data, permissions and optional features for this type of metafield. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.',
+        'Use the `$app` namespace to request metafields owned by your app in `shopify.extension.toml`. Your app exclusively controls structure, data, and permissions for these metafields. See [app-owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for configuration details.',
+    }),
+    ...createExample('metafields/update-cart-metafield', {
+      title: 'Write a cart metafield',
+      description:
+        'Use `shopify.applyMetafieldChange()` with the `updateCartMetafield` type to write a key-value pair to the cart. The metafield requires a namespace, key, type, and string value. Check [`instructions.metafields.canSetCartMetafields`](/docs/api/checkout-ui-extensions/apis/cart-instructions) before writing.',
+    }),
+    ...createExample('extension/metadata', {
+      title: 'Read extension metadata',
+      description:
+        'Use the `useExtension` hook to access the current target name, API version, and published version. The version is `undefined` for unpublished extensions in development.',
+    }),
+    ...createExample('extension/capabilities', {
+      title: 'Check extension capabilities',
+      description:
+        'Use `useExtensionCapability` to test whether a specific capability has been granted, and `useExtensionEditor` to detect if the extension is being previewed in the checkout editor. A warning banner renders when `block_progress` is required but not enabled.',
+    }),
+    ...createExample('storage/delete-entry', {
+      title: 'Delete a storage entry',
+      description:
+        'Use `shopify.storage.delete()` to remove a previously stored value. A dismissible promotion banner is persisted with `write()` and cleared with `delete()`, letting the buyer reset the dismissed state.',
     }),
   };
 }


### PR DESCRIPTION
⚠️ This PR will not be merged as is. The content will remain the same though. We're waiting on this PR: https://app.graphite.com/github/pr/shop/world/488122 , then I will remake this PR. ⚠️ 

Closes https://github.com/shop/issues-learn/issues/1043

## Summary

- Adds 4 new Preact code examples for Platform APIs that had fewer than two examples
- Improves titles and descriptions for all 6 existing Platform API examples to match conventions
- All examples follow established checkout extension patterns: identical boilerplate, verified TypeScript types, Polaris web components

### New examples

| API | Example | What it demonstrates |
|-----|---------|---------------------|
| **Extension** | Read extension metadata | `useExtension` to access target, API version, published version |
| **Extension** | Check extension capabilities | `useExtensionCapability` + `useExtensionEditor` to warn when `block_progress` is missing |
| **Metafields** | Write a cart metafield | `applyMetafieldChange` with `updateCartMetafield` to write a key-value pair |
| **Storage** | Delete a storage entry | `storage.delete()` to clear a persisted value, with read/write for a dismissible banner |

### Existing title and description improvements

| Before | After |
|--------|-------|
| "Publish" | "Publish a custom analytics event" |
| "Visitor" | "Submit visitor information" |
| "Accessing merchant settings" | "Access merchant settings" |
| "Using a session token with fetch()" | "Use a session token with fetch()" |
| "Storage" | "Read and write to storage" |
| "Use app owned metafields" | "Read app-owned metafields" |