### PR TITLE
Add optional return and exchange fields to ReprintReceiptData

### DIFF
--- a/.changeset/silly-cheetahs-bake.md
+++ b/.changeset/silly-cheetahs-bake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add optional refundId, returnId, exchangeId, lineItemsAdded, and lineItemsRemoved fields to ReprintReceiptData to support reprinting return and exchange receipts.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
@@ -1,4 +1,5 @@
 import {BaseTransactionComplete} from '../../types/base-transaction-complete';
+import {LineItem} from '../../types/cart';
 import {OrderLineItem} from '../../types/order';
 
 /**
@@ -6,11 +7,31 @@ import {OrderLineItem} from '../../types/order';
  */
 export interface ReprintReceiptData extends BaseTransactionComplete {
   /**
-   * The transaction type identifier, always 'Sale' for sale transactions.
+   * The transaction type identifier, always 'Reprint' for reprint transactions.
    */
   transactionType: 'Reprint';
   /**
-   * An array of line items included in the sale transaction.
+   * An array of line items included in the transaction.
    */
   lineItems: OrderLineItem[];
+  /**
+   * The refund ID if a refund was issued for the return.
+   */
+  refundId?: number;
+  /**
+   * The return ID for the completed return transaction.
+   */
+  returnId?: number;
+  /**
+   * The exchange ID if the return is part of an exchange transaction.
+   */
+  exchangeId?: number;
+  /**
+   * An array of line items added to the customer in the exchange.
+   */
+  lineItemsAdded?: LineItem[];
+  /**
+   * An array of line items removed from the customer in the exchange.
+   */
+  lineItemsRemoved?: LineItem[];
 }


### PR DESCRIPTION
### Background

This pull request enhances the `ReprintReceiptData` interface to support reprinting receipts for return and exchange transactions in addition to the existing sale transaction support.

Also added to [2026-04-rc](https://github.com/Shopify/ui-extensions/pull/4178)

### Solution

Extended the `ReprintReceiptData` interface with five new optional fields:

- `refundId`: Tracks refund ID when a refund was issued for the return
- `returnId`: Identifies the completed return transaction
- `exchangeId`: Links the return to an exchange transaction when applicable
- `lineItemsAdded`: Captures items added to the customer during an exchange
- `lineItemsRemoved`: Captures items removed from the customer during an exchange

These fields are optional to maintain backward compatibility with existing sale transaction reprints while enabling comprehensive support for return and exchange receipt reprinting scenarios.

### 🎩

- Added optional `refundId`, `returnId`, and `exchangeId` fields to track transaction relationships
- Added `lineItemsAdded` and `lineItemsRemoved` arrays to support exchange transaction details
- Updated documentation comments to reflect broader transaction type support
- Imported `LineItem` type to support the new exchange-related fields

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
