### PR TITLE
Update subCategory for Tooltip component to Typography and content

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data.json
@@ -137,7 +137,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -1798,7 +1798,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -2134,7 +2134,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -2807,7 +2807,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -2907,7 +2907,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -3163,7 +3163,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -3319,7 +3319,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -3327,7 +3327,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -3491,7 +3491,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -3499,7 +3499,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -3507,7 +3507,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -3811,7 +3811,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -5175,7 +5175,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -5183,7 +5183,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -5191,7 +5191,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -5399,7 +5399,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -5647,7 +5647,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -6220,7 +6220,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -6515,7 +6515,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -6754,7 +6754,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -6762,7 +6762,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -6792,7 +6792,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -7347,7 +7347,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -7459,7 +7459,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -7467,7 +7467,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -7660,7 +7660,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -8225,7 +8225,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -8465,7 +8465,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -8616,7 +8616,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -8624,7 +8624,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -8632,7 +8632,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -8920,7 +8920,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -11768,7 +11768,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -14041,7 +14041,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -14377,7 +14377,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -15050,7 +15050,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -15150,7 +15150,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -15406,7 +15406,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -15562,7 +15562,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -15570,7 +15570,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -15734,7 +15734,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -15742,7 +15742,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -15750,7 +15750,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -16054,7 +16054,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -17418,7 +17418,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -17426,7 +17426,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -17434,7 +17434,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -17642,7 +17642,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -17890,7 +17890,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -18463,7 +18463,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -18758,7 +18758,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -18997,7 +18997,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -19005,7 +19005,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -19035,7 +19035,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -19590,7 +19590,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -19702,7 +19702,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -19710,7 +19710,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -19903,7 +19903,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -20468,7 +20468,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -20708,7 +20708,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -20859,7 +20859,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -20867,7 +20867,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -20875,7 +20875,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -21163,7 +21163,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -23710,7 +23710,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -25998,7 +25998,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -26334,7 +26334,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -27007,7 +27007,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -27107,7 +27107,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -27363,7 +27363,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -27519,7 +27519,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -27527,7 +27527,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -27691,7 +27691,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -27699,7 +27699,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -27707,7 +27707,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -28011,7 +28011,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -29375,7 +29375,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -29383,7 +29383,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -29391,7 +29391,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -29599,7 +29599,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -29847,7 +29847,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -30420,7 +30420,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -30715,7 +30715,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -30954,7 +30954,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -30962,7 +30962,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -30992,7 +30992,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -31547,7 +31547,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -31659,7 +31659,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -31667,7 +31667,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -31860,7 +31860,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -32425,7 +32425,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -32665,7 +32665,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -32816,7 +32816,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -32824,7 +32824,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -32832,7 +32832,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -33120,7 +33120,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -35555,7 +35555,7 @@
     "category": "Target APIs",
     "subCategory": "Utility APIs",
     "thumbnail": "intents.png",
-    "requires": "an Admin UI [block or action](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.",
+    "requires": "an admin UI [block or action](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.",
     "defaultExample": {
       "description": "Launch the article creation workflow from a button click. This example uses `shopify.intents.invoke()` to open the article editor, awaits the workflow completion, and displays success or cancellation feedback based on the response code.",
       "image": "intents.png",
@@ -36445,7 +36445,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -38718,7 +38718,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -39054,7 +39054,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -39727,7 +39727,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -39827,7 +39827,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -40083,7 +40083,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -40239,7 +40239,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -40247,7 +40247,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -40411,7 +40411,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -40419,7 +40419,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -40427,7 +40427,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -40731,7 +40731,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -42095,7 +42095,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -42103,7 +42103,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -42111,7 +42111,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -42319,7 +42319,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -42567,7 +42567,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -43140,7 +43140,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -43435,7 +43435,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -43674,7 +43674,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -43682,7 +43682,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -43712,7 +43712,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -44267,7 +44267,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -44379,7 +44379,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -44387,7 +44387,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -44580,7 +44580,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -45145,7 +45145,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -45385,7 +45385,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -45536,7 +45536,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -45544,7 +45544,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -45552,7 +45552,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -45840,7 +45840,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -47787,7 +47787,7 @@
     "category": "Target APIs",
     "subCategory": "Utility APIs",
     "thumbnail": "picker.png",
-    "requires": "an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.",
+    "requires": "an admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.",
     "defaultExample": {
       "description": "Build a custom picker for email templates with multiple columns and status badges. This example shows defining column headers, populating items with searchable data fields, adding visual status indicators, and handling the selection promise. Use this pattern for app-specific resources like templates, product reviews, or subscription options where you need custom data structures beyond standard Shopify resources.",
       "image": "picker.png",
@@ -48123,13 +48123,13 @@
     "type": "API",
     "requires": "the [admin print action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-print-action) component.",
     "defaultExample": {
-      "description": "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and returning the printable URL to display the document.",
+      "description": "Generate a packing slip PDF for selected orders by calling your app's backend service. This example shows extracting order IDs from the selected resources, making an API call to your backend to generate the PDF, and setting the printable URL as the `src` prop to display the document.",
       "codeblock": {
         "title": "Generate packing slip",
         "tabs": [
           {
             "title": "jsx",
-            "code": "import {render} from 'preact';\n\nexport default async () =&gt; {\n  render(&lt;Extension /&gt;, document.body);\n};\n\nfunction Extension() {\n  const {data} = shopify;\n\n  const handleGenerate = async () =&gt; {\n    const orderIds = data.selected.map((item) =&gt; item.id);\n\n    const response = await fetch('/api/generate-packing-slip', {\n      method: 'POST',\n      headers: {'Content-Type': 'application/json'},\n      body: JSON.stringify({orderIds}),\n    });\n\n    const {printUrl} = await response.json();\n    return printUrl;\n  };\n\n  return (\n    &lt;s-admin-print-action onPrint={handleGenerate}&gt;\n      &lt;s-text&gt;Generating packing slip for {data.selected.length} orders&lt;/s-text&gt;\n    &lt;/s-admin-print-action&gt;\n  );\n}\n",
+            "code": "import {render} from 'preact';\nimport {useState, useEffect} from 'preact/hooks';\n\nexport default async () =&gt; {\n  render(&lt;Extension /&gt;, document.body);\n};\n\nfunction Extension() {\n  const {data} = shopify;\n  const [printUrl, setPrintUrl] = useState(null);\n\n  useEffect(() =&gt; {\n    const generateSlip = async () =&gt; {\n      const orderIds = data.selected.map((item) =&gt; item.id);\n\n      const response = await fetch('/api/generate-packing-slip', {\n        method: 'POST',\n        headers: {'Content-Type': 'application/json'},\n        body: JSON.stringify({orderIds}),\n      });\n\n      const {printUrl: url} = await response.json();\n      setPrintUrl(url);\n    };\n\n    generateSlip();\n  }, [data]);\n\n  return (\n    &lt;s-admin-print-action src={printUrl}&gt;\n      &lt;s-text&gt;Packing slip for {data.selected.length} orders&lt;/s-text&gt;\n    &lt;/s-admin-print-action&gt;\n  );\n}\n",
             "language": "jsx"
           }
         ]
@@ -48247,7 +48247,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -50520,7 +50520,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -50856,7 +50856,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -51529,7 +51529,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -51629,7 +51629,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -51885,7 +51885,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -52041,7 +52041,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -52049,7 +52049,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -52213,7 +52213,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -52221,7 +52221,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -52229,7 +52229,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -52533,7 +52533,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -53897,7 +53897,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -53905,7 +53905,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -53913,7 +53913,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -54121,7 +54121,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -54369,7 +54369,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -54942,7 +54942,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -55237,7 +55237,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -55476,7 +55476,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -55484,7 +55484,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -55514,7 +55514,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -56069,7 +56069,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -56181,7 +56181,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -56189,7 +56189,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -56382,7 +56382,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -56947,7 +56947,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -57187,7 +57187,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -57338,7 +57338,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -57346,7 +57346,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -57354,7 +57354,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -57642,7 +57642,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -59708,7 +59708,7 @@
             "tabs": [
               {
                 "title": "jsx",
-                "code": "import {render} from 'preact';\nimport {useState} from 'preact/hooks';\n\nexport default async () =&gt; {\n  render(&lt;Extension /&gt;, document.body);\n};\n\nfunction Extension() {\n  const {data} = shopify;\n  const [additionalCount, setAdditionalCount] = useState(0);\n\n  const handleSelectMore = async () =&gt; {\n    const additionalProducts = await shopify.resourcePicker({\n      type: 'product',\n      multiple: 10,\n      action: 'add',\n    });\n\n    if (additionalProducts) {\n      setAdditionalCount(additionalProducts.length);\n    }\n  };\n\n  const handleGenerate = async () =&gt; {\n    const productIds = data.selected.map((item) =&gt; item.id);\n    \n    const response = await fetch('/api/generate-labels', {\n      method: 'POST',\n      headers: {'Content-Type': 'application/json'},\n      body: JSON.stringify({productIds}),\n    });\n\n    const {printUrl} = await response.json();\n    return printUrl;\n  };\n\n  return (\n    &lt;s-admin-print-action onPrint={handleGenerate}&gt;\n      &lt;s-text&gt;{data.selected.length} products selected&lt;/s-text&gt;\n      &lt;s-button onClick={handleSelectMore}&gt;Add More Products&lt;/s-button&gt;\n      {additionalCount &gt; 0 && &lt;s-text&gt;+{additionalCount} additional&lt;/s-text&gt;}\n    &lt;/s-admin-print-action&gt;\n  );\n}\n",
+                "code": "import {render} from 'preact';\nimport {useState, useCallback} from 'preact/hooks';\n\nexport default async () =&gt; {\n  render(&lt;Extension /&gt;, document.body);\n};\n\nfunction Extension() {\n  const {data} = shopify;\n  const [additionalProducts, setAdditionalProducts] = useState([]);\n  const [printUrl, setPrintUrl] = useState(null);\n\n  const handleSelectMore = async () =&gt; {\n    const picked = await shopify.resourcePicker({\n      type: 'product',\n      multiple: 10,\n      action: 'add',\n    });\n\n    if (picked) {\n      setAdditionalProducts((prev) =&gt; [...prev, ...picked]);\n    }\n  };\n\n  const handleGenerate = useCallback(async () =&gt; {\n    const selectedIds = data.selected.map((item) =&gt; item.id);\n    const additionalIds = additionalProducts.map((item) =&gt; item.id);\n    const productIds = [...selectedIds, ...additionalIds];\n\n    const response = await fetch('/api/generate-labels', {\n      method: 'POST',\n      headers: {'Content-Type': 'application/json'},\n      body: JSON.stringify({productIds}),\n    });\n\n    const {printUrl: url} = await response.json();\n    setPrintUrl(url);\n  }, [data, additionalProducts]);\n\n  return (\n    &lt;s-admin-print-action src={printUrl}&gt;\n      &lt;s-text&gt;{data.selected.length + additionalProducts.length} products selected&lt;/s-text&gt;\n      &lt;s-button onClick={handleSelectMore}&gt;Add More Products&lt;/s-button&gt;\n      &lt;s-button onClick={handleGenerate}&gt;Generate Labels&lt;/s-button&gt;\n    &lt;/s-admin-print-action&gt;\n  );\n}\n",
                 "language": "jsx"
               }
             ]
@@ -59721,7 +59721,7 @@
             "tabs": [
               {
                 "title": "jsx",
-                "code": "import {render} from 'preact';\nimport {useState, useEffect} from 'preact/hooks';\n\nexport default async () =&gt; {\n  render(&lt;Extension /&gt;, document.body);\n};\n\nfunction Extension() {\n  const {data} = shopify;\n  const [orders, setOrders] = useState([]);\n\n  useEffect(() =&gt; {\n    const fetchOrders = async () =&gt; {\n      const orderIds = data.selected.map((item) =&gt; item.id);\n\n      const {data: ordersData} = await shopify.query(\n        `query GetOrders($ids: [ID!]!) {\n          nodes(ids: $ids) {\n            ... on Order {\n              id\n              name\n              shippingAddress {\n                address1\n                city\n                country\n              }\n            }\n          }\n        }`,\n        {variables: {ids: orderIds}},\n      );\n\n      setOrders(ordersData.nodes);\n    };\n\n    fetchOrders();\n  }, [data]);\n\n  const handleGenerate = async () =&gt; {\n    const response = await fetch('/api/generate-shipping-manifest', {\n      method: 'POST',\n      headers: {'Content-Type': 'application/json'},\n      body: JSON.stringify({orders}),\n    });\n\n    const {printUrl} = await response.json();\n    return printUrl;\n  };\n\n  return (\n    &lt;s-admin-print-action onPrint={handleGenerate}&gt;\n      &lt;s-text&gt;Shipping manifest for {orders.length} orders&lt;/s-text&gt;\n      {orders.map((order) =&gt; (\n        &lt;s-text key={order.id}&gt;{order.name}&lt;/s-text&gt;\n      ))}\n    &lt;/s-admin-print-action&gt;\n  );\n}\n",
+                "code": "import {render} from 'preact';\nimport {useState, useEffect} from 'preact/hooks';\n\nexport default async () =&gt; {\n  render(&lt;Extension /&gt;, document.body);\n};\n\nfunction Extension() {\n  const {data} = shopify;\n  const [orders, setOrders] = useState([]);\n  const [printUrl, setPrintUrl] = useState(null);\n\n  useEffect(() =&gt; {\n    const fetchOrders = async () =&gt; {\n      const orderIds = data.selected.map((item) =&gt; item.id);\n\n      const {data: ordersData} = await shopify.query(\n        `query GetOrders($ids: [ID!]!) {\n          nodes(ids: $ids) {\n            ... on Order {\n              id\n              name\n              shippingAddress {\n                address1\n                city\n                country\n              }\n            }\n          }\n        }`,\n        {variables: {ids: orderIds}},\n      );\n\n      setOrders(ordersData.nodes);\n\n      const response = await fetch('/api/generate-shipping-manifest', {\n        method: 'POST',\n        headers: {'Content-Type': 'application/json'},\n        body: JSON.stringify({orders: ordersData.nodes}),\n      });\n\n      const {printUrl: url} = await response.json();\n      setPrintUrl(url);\n    };\n\n    fetchOrders();\n  }, [data]);\n\n  return (\n    &lt;s-admin-print-action src={printUrl}&gt;\n      &lt;s-text&gt;Shipping manifest for {orders.length} orders&lt;/s-text&gt;\n      {orders.map((order) =&gt; (\n        &lt;s-text key={order.id}&gt;{order.name}&lt;/s-text&gt;\n      ))}\n    &lt;/s-admin-print-action&gt;\n  );\n}\n",
                 "language": "jsx"
               }
             ]
@@ -59743,7 +59743,7 @@
         "type": "Generic",
         "anchorLink": "limitations",
         "title": "Limitations",
-        "sectionContent": "- Print action extensions must return a URL string. You can't render the print UI directly within the extension or control the print preview appearance.\n- URLs must be publicly accessible with CORS headers allowing the Shopify admin origin. Authentication tokens in URLs can expire while merchants have the preview open.\n- Extensions don't have access to printer settings. You can't configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs."
+        "sectionContent": "- Print action extensions must provide a URL string through the `src` prop. You can't render the print UI directly within the extension or control the print preview appearance.\n- URLs must be publicly accessible with CORS headers allowing the Shopify admin origin. Authentication tokens in URLs can expire while merchants have the preview open.\n- Extensions don't have access to printer settings. You can't configure print options like page orientation, margins, or paper size. Merchants control these through browser print dialogs."
       }
     ]
   },
@@ -60208,7 +60208,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -62429,7 +62429,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -62765,7 +62765,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -63438,7 +63438,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -63538,7 +63538,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -63794,7 +63794,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -63950,7 +63950,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -63958,7 +63958,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -64122,7 +64122,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -64130,7 +64130,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -64138,7 +64138,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -64442,7 +64442,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -65806,7 +65806,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -65814,7 +65814,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -65822,7 +65822,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -66030,7 +66030,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -66278,7 +66278,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -66851,7 +66851,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -67146,7 +67146,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -67385,7 +67385,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -67393,7 +67393,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -67423,7 +67423,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -67978,7 +67978,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -68090,7 +68090,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -68098,7 +68098,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -68291,7 +68291,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -68737,7 +68737,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -68977,7 +68977,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -69128,7 +69128,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -69136,7 +69136,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -69144,7 +69144,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -69432,7 +69432,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -71838,7 +71838,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -74059,7 +74059,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -74395,7 +74395,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -75068,7 +75068,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -75168,7 +75168,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -75424,7 +75424,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -75580,7 +75580,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -75588,7 +75588,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -75752,7 +75752,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -75760,7 +75760,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -75768,7 +75768,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -76072,7 +76072,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -77436,7 +77436,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -77444,7 +77444,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -77452,7 +77452,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -77660,7 +77660,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -77908,7 +77908,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -78481,7 +78481,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -78776,7 +78776,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -79015,7 +79015,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -79023,7 +79023,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -79053,7 +79053,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -79608,7 +79608,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -79720,7 +79720,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -79728,7 +79728,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -79921,7 +79921,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -80367,7 +80367,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -80607,7 +80607,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -80758,7 +80758,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -80766,7 +80766,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -80774,7 +80774,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -81062,7 +81062,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -83132,7 +83132,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -85420,7 +85420,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -85756,7 +85756,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -86429,7 +86429,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -86529,7 +86529,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -86785,7 +86785,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -86941,7 +86941,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -86949,7 +86949,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -87113,7 +87113,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -87121,7 +87121,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -87129,7 +87129,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -87433,7 +87433,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -88797,7 +88797,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -88805,7 +88805,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -88813,7 +88813,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -89021,7 +89021,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -89269,7 +89269,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -89842,7 +89842,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -90137,7 +90137,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -90376,7 +90376,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -90384,7 +90384,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -90414,7 +90414,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -90969,7 +90969,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -91081,7 +91081,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -91089,7 +91089,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -91282,7 +91282,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -91847,7 +91847,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -92087,7 +92087,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -92238,7 +92238,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -92246,7 +92246,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -92254,7 +92254,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -92542,7 +92542,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -94648,7 +94648,7 @@
     "category": "Target APIs",
     "subCategory": "Utility APIs",
     "thumbnail": "resource-picker.png",
-    "requires": "an Admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.",
+    "requires": "an admin UI [block, action, or print](/docs/api/admin-extensions/{API_VERSION}#building-your-extension) extension.",
     "defaultExample": {
       "description": "Open the product resource picker to select items from the store catalog. This example invokes `shopify.resourcePicker` with `type: \"product\"`, handles the async selection, and displays the count of selected products. When merchants confirm their selection, the resource picker returns an array of product objects with GIDs, titles, and handles for use in your extension.",
       "image": "resource-picker.png",
@@ -95079,7 +95079,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -97352,7 +97352,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -97688,7 +97688,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -98361,7 +98361,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -98461,7 +98461,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -98717,7 +98717,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -98873,7 +98873,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -98881,7 +98881,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -99045,7 +99045,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -99053,7 +99053,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -99061,7 +99061,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -99365,7 +99365,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -100729,7 +100729,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -100737,7 +100737,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -100745,7 +100745,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -100953,7 +100953,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -101201,7 +101201,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -101774,7 +101774,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -102069,7 +102069,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -102308,7 +102308,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -102316,7 +102316,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -102346,7 +102346,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -102901,7 +102901,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -103013,7 +103013,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -103021,7 +103021,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -103214,7 +103214,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -103779,7 +103779,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -104019,7 +104019,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -104170,7 +104170,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -104178,7 +104178,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -104186,7 +104186,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -104474,7 +104474,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -106595,7 +106595,7 @@
   },
   {
     "name": "Standard API",
-    "description": "The Standard API provides core functionality available to all Admin UI extension types. Use this API to authenticate with your app backend, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle navigation [intents](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api), and persist data in browser storage.",
+    "description": "The Standard API provides core functionality available to all admin UI extension types. Use this API to authenticate with your app backend, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle navigation [intents](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api), and persist data in browser storage.",
     "isVisualComponent": false,
     "type": "API",
     "defaultExample": {
@@ -106687,7 +106687,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ExtensionTarget",
             "value": "keyof ExtensionTargets",
-            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your Admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
+            "description": "A string literal union of all valid extension target identifiers. Use this type to specify where your admin UI extension should render, such as `admin.product-details.block.render` for a block on product details pages or `admin.order-details.action.render` for an action on order details pages. The target determines the extension's location, available APIs, and UI components."
           },
           "ExtensionTargets": {
             "filePath": "src/surfaces/admin/extension-targets.ts",
@@ -108975,7 +108975,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -109311,7 +109311,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -109984,7 +109984,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -110084,7 +110084,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -110340,7 +110340,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -110496,7 +110496,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -110504,7 +110504,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -110668,7 +110668,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true
@@ -110676,7 +110676,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true
@@ -110684,7 +110684,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -110988,7 +110988,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -112352,7 +112352,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -112360,7 +112360,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -112368,7 +112368,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -112576,7 +112576,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -112824,7 +112824,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -113397,7 +113397,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -113692,7 +113692,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -113931,7 +113931,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true
@@ -113939,7 +113939,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -113969,7 +113969,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -114524,7 +114524,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -114636,7 +114636,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true
@@ -114644,7 +114644,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true
@@ -114837,7 +114837,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true
@@ -115402,7 +115402,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -115642,7 +115642,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -115793,7 +115793,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true
@@ -115801,7 +115801,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true
@@ -115809,7 +115809,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true
@@ -116097,7 +116097,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true
@@ -118265,7 +118265,7 @@
       },
       {
         "title": "Slots",
-        "description": "The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The admin action component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "AdminActionSlots",
         "typeDefinitions": {
           "AdminActionSlots": {
@@ -118348,17 +118348,17 @@
               }
             },
             {
-              "description": "Embed a [form](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/form) inside the action modal to collect merchant input before saving. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) wrapped in a form component.",
+              "description": "Collect merchant input inside the action modal using form fields. This example includes a [text field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/text-field) and [number field](/docs/api/admin-extensions/{API_VERSION}/web-components/forms/number-field) arranged in a [stack](/docs/api/admin-extensions/{API_VERSION}/web-components/layout-and-structure/stack).",
               "codeblock": {
                 "title": "Add form fields to the modal",
                 "tabs": [
                   {
                     "title": "html",
-                    "code": "&lt;s-admin-action heading=\"Edit shipping settings\"&gt;\n  &lt;s-form&gt;\n    &lt;s-stack direction=\"block\" gap=\"base\"&gt;\n      &lt;s-text-field label=\"Shipping rate name\" value=\"Standard shipping\"&gt;&lt;/s-text-field&gt;\n      &lt;s-number-field label=\"Flat rate amount\" min=\"0\" step=\"0.01\" prefix=\"$\" value=\"5.99\"&gt;&lt;/s-number-field&gt;\n    &lt;/s-stack&gt;\n  &lt;/s-form&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;Save changes&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Discard&lt;/s-button&gt;\n&lt;/s-admin-action&gt;\n",
+                    "code": "&lt;s-admin-action heading=\"Edit shipping settings\"&gt;\n  &lt;s-stack direction=\"block\" gap=\"base\"&gt;\n    &lt;s-text-field label=\"Shipping rate name\" value=\"Standard shipping\"&gt;&lt;/s-text-field&gt;\n    &lt;s-number-field label=\"Flat rate amount\" prefix=\"$\" value=\"5.99\"&gt;&lt;/s-number-field&gt;\n  &lt;/s-stack&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;Save changes&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Discard&lt;/s-button&gt;\n&lt;/s-admin-action&gt;\n",
                     "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-admin-action heading=\"Edit shipping settings\">\n  <s-form>\n    <s-stack direction=\"block\" gap=\"base\">\n      <s-text-field label=\"Shipping rate name\" value=\"Standard shipping\"></s-text-field>\n      <s-number-field label=\"Flat rate amount\" min=\"0\" step=\"0.01\" prefix=\"$\" value=\"5.99\"></s-number-field>\n    </s-stack>\n  </s-form>\n  <s-button slot=\"primary-action\" variant=\"primary\">Save changes</s-button>\n  <s-button slot=\"secondary-actions\">Discard</s-button>\n</s-admin-action>\n</s-box></body></html>",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-admin-action heading=\"Edit shipping settings\">\n  <s-stack direction=\"block\" gap=\"base\">\n    <s-text-field label=\"Shipping rate name\" value=\"Standard shipping\"></s-text-field>\n    <s-number-field label=\"Flat rate amount\" prefix=\"$\" value=\"5.99\"></s-number-field>\n  </s-stack>\n  <s-button slot=\"primary-action\" variant=\"primary\">Save changes</s-button>\n  <s-button slot=\"secondary-actions\">Discard</s-button>\n</s-admin-action>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -118864,7 +118864,7 @@
       },
       {
         "title": "Events",
-        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "AvatarEvents",
         "typeDefinitions": {
           "AvatarEvents": {
@@ -119251,7 +119251,7 @@
       },
       {
         "title": "Slots",
-        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "BadgeSlots",
         "typeDefinitions": {
           "BadgeSlots": {
@@ -119549,7 +119549,7 @@
       },
       {
         "title": "Events",
-        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "BannerEvents",
         "typeDefinitions": {
           "BannerEvents": {
@@ -119594,7 +119594,7 @@
       },
       {
         "title": "Slots",
-        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "BannerSlots",
         "typeDefinitions": {
           "BannerSlots": {
@@ -120197,7 +120197,7 @@
       },
       {
         "title": "Slots",
-        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "BoxSlots",
         "typeDefinitions": {
           "BoxSlots": {
@@ -120319,7 +120319,7 @@
   },
   {
     "name": "Button",
-    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button-group).",
+    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use buttons to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button-group).",
     "category": "Web components",
     "subCategory": "Actions",
     "related": [],
@@ -120594,7 +120594,7 @@
       },
       {
         "title": "Events",
-        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ButtonEvents",
         "typeDefinitions": {
           "ButtonEvents": {
@@ -120647,7 +120647,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ButtonSlots",
         "typeDefinitions": {
           "ButtonSlots": {
@@ -121039,7 +121039,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ButtonGroupSlots",
         "typeDefinitions": {
           "ButtonGroupSlots": {
@@ -121078,24 +121078,19 @@
       }
     ],
     "defaultExample": {
-      "image": "button-default.png",
+      "image": "buttongroup-default.png",
+      "description": "Group related buttons together with a primary action and secondary options. This example shows a button group with a save button and a cancel button.",
       "codeblock": {
-        "title": "Code",
+        "title": "Group a primary and secondary action",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-            "language": "html",
-            "layout": "inline",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: flex; justify-content: center; align-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"primary-action\">Save</s-button>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"primary-action\">Save</s-button>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n</s-button-group>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -121105,141 +121100,71 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Standard button group with cancel and primary action for form workflows.",
+              "description": "Present multiple secondary actions for operating on selected items. This example shows archive, export, and delete buttons grouped together for bulk operations.",
               "codeblock": {
-                "title": "Basic usage",
+                "title": "Add bulk action buttons",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;\n    Save\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;Save&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"primary-action\" variant=\"primary\">\n    Save\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Action buttons for selected items with destructive option.",
-              "codeblock": {
-                "title": "Bulk action buttons",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Archive&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Export&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;\n    Delete\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Archive&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Export&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;Delete&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Archive</s-button>\n  <s-button slot=\"secondary-actions\">Export</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">\n    Delete\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"secondary-actions\">Archive</s-button>\n  <s-button slot=\"secondary-actions\">Export</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">Delete</s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Typical form completion actions with clear visual hierarchy.",
+              "description": "Add icons to grouped buttons to help merchants identify each action. This example shows duplicate, archive, and delete buttons with icons.",
               "codeblock": {
-                "title": "Form action buttons",
+                "title": "Add icons to grouped buttons",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;\n    Save product\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;Save product&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"primary-action\" variant=\"primary\">\n    Save product\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Icon-labeled buttons for common actions.",
-              "codeblock": {
-                "title": "Buttons with icons",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"duplicate\"&gt;\n    Duplicate\n  &lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"archive\"&gt;\n    Archive\n  &lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\"&gt;\n    Delete\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"duplicate\"&gt;Duplicate&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"archive\"&gt;Archive&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\"&gt;\n    Delete\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\" icon=\"duplicate\">\n    Duplicate\n  </s-button>\n  <s-button slot=\"secondary-actions\" icon=\"archive\">\n    Archive\n  </s-button>\n  <s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\">\n    Delete\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"secondary-actions\" icon=\"duplicate\">Duplicate</s-button>\n  <s-button slot=\"secondary-actions\" icon=\"archive\">Archive</s-button>\n  <s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\">\n    Delete\n  </s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Tightly grouped buttons for view switching and filter options.",
+              "description": "Remove the gap between buttons to create a segmented control for toggling between views or options. This example shows day, week, and month buttons joined together with no spacing.",
               "codeblock": {
-                "title": "Segmented appearance",
+                "title": "Create a segmented button group",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group gap=\"none\"&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Day&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Week&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Month&lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group gap=\"none\"&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Day&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Week&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Month&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group gap=\"none\">\n  <s-button slot=\"secondary-actions\">Day</s-button>\n  <s-button slot=\"secondary-actions\">Week</s-button>\n  <s-button slot=\"secondary-actions\">Month</s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group gap=\"none\">\n  <s-button slot=\"secondary-actions\">Day</s-button>\n  <s-button slot=\"secondary-actions\">Week</s-button>\n  <s-button slot=\"secondary-actions\">Month</s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Confirmation dialog style with cancel option and destructive action.",
+              "description": "Pair a cancel button with a critical action for destructive confirmation flows. This example shows a cancel and delete button grouped together for a confirmation dialog.",
               "codeblock": {
-                "title": "Destructive actions pattern",
+                "title": "Confirm a destructive action",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;\n    Delete product\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;Delete product&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">\n    Delete product\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">Delete product</s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -121280,7 +121205,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -121530,7 +121455,7 @@
       },
       {
         "title": "Events",
-        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "CheckboxEvents",
         "typeDefinitions": {
           "CheckboxEvents": {
@@ -121877,7 +121802,7 @@
       },
       {
         "title": "Slots",
-        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ChipSlots",
         "typeDefinitions": {
           "ChipSlots": {
@@ -122024,7 +121949,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -122232,7 +122157,7 @@
       },
       {
         "title": "Events",
-        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ChoiceListEvents",
         "typeDefinitions": {
           "ChoiceListEvents": {
@@ -122454,7 +122379,7 @@
       },
       {
         "title": "Slots",
-        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ChoiceSlots",
         "typeDefinitions": {
           "ChoiceSlots": {
@@ -123156,7 +123081,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ClickableEvents",
         "typeDefinitions": {
           "ClickableEvents": {
@@ -123209,7 +123134,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ClickableSlots",
         "typeDefinitions": {
           "ClickableSlots": {
@@ -123233,22 +123158,18 @@
     ],
     "defaultExample": {
       "image": "clickable-default.png",
+      "description": "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
       "codeblock": {
-        "title": "Code",
+        "title": "Create a custom interactive element",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;&gt;\n  &lt;s-clickable padding=\"base\"&gt;Create Store&lt;/s-clickable&gt;\n\n  &lt;s-clickable\n    border=\"base\"\n    padding=\"base\"\n    background=\"subdued\"\n    borderRadius=\"base\"\n  &gt;\n    View Shipping Settings\n  &lt;/s-clickable&gt;\n&lt;/&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-clickable padding=\"base\"&gt;Create Store&lt;/s-clickable&gt;\n\n&lt;s-clickable\n  border=\"base\"\n  padding=\"base\"\n  background=\"subdued\"\n  borderRadius=\"base\"\n&gt;\n  View Shipping Settings\n&lt;/s-clickable&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-clickable padding=\"base\"&gt;Create Store&lt;/s-clickable&gt;\n\n&lt;s-clickable\n  border=\"base\"\n  padding=\"base\"\n  background=\"subdued\"\n  borderRadius=\"base\"\n&gt;\n  View Shipping Settings\n&lt;/s-clickable&gt;\n",
-            "language": "html",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-clickable padding=\"base\">Create Store</s-clickable>\n\n  <s-clickable\n    border=\"base\"\n    padding=\"base\"\n    background=\"subdued\"\n    borderRadius=\"base\"\n  >\n    View Shipping Settings\n  </s-clickable>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-clickable padding=\"base\">Create Store</s-clickable>\n\n<s-clickable\n  border=\"base\"\n  padding=\"base\"\n  background=\"subdued\"\n  borderRadius=\"base\"\n>\n  View Shipping Settings\n</s-clickable>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -123258,141 +123179,88 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "A simple clickable button with a base border and padding, demonstrating the default button behavior of the clickable component.",
+              "description": "Set the `href` property to make a clickable element navigate like a link. This example shows a clickable component that opens a URL in a new browser tab.",
               "codeblock": {
-                "title": "Basic Button Usage",
+                "title": "Navigate to a URL",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable border=\"base\" padding=\"base\"&gt;\n  Click me\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-clickable border=\"base\" padding=\"base\"&gt;Click me&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable border=\"base\" padding=\"base\">\n  Click me\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates the clickable component's ability to function as a link, opening the specified URL in a new browser tab when clicked.",
-              "codeblock": {
-                "title": "Link Mode",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable href=\"javascript:void(0)\" target=\"_blank\"&gt;\n  Visit Shopify\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable href=\"javascript:void(0)\" target=\"_blank\"&gt;\n  Visit Shopify\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable href=\"javascript:void(0)\" target=\"_blank\">\n  Visit Shopify\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable href=\"javascript:void(0)\" target=\"_blank\">\n  Visit Shopify\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "A disabled submit button that can be used within a form, showing the component's form integration capabilities and disabled state.",
+              "description": "Use a clickable component as a form submit button with a disabled state to prevent premature submission. This example shows a disabled submit-type clickable component with a border and padding.",
               "codeblock": {
-                "title": "Form Submit Button",
+                "title": "Create a form submit button",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\"&gt;\n  Save changes\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\"&gt;\n  Save changes\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\">\n  Save changes\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\">\n  Save changes\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates how the clickable component can be integrated into a section layout to provide an interactive action button.",
+              "description": "Add a clickable button alongside descriptive content in a section. This example shows a styled clickable button inside a box with a heading and description.",
               "codeblock": {
-                "title": "Section with Clickable Action",
+                "title": "Add a clickable action to a section",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\"&gt;\n  &lt;s-stack gap=\"large-300\"&gt;\n    &lt;s-heading&gt;Product settings&lt;/s-heading&gt;\n    &lt;s-text&gt;Configure your product inventory and pricing settings.&lt;/s-text&gt;\n    &lt;s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\"&gt;\n      &lt;s-text type=\"strong\"&gt;Configure settings&lt;/s-text&gt;\n    &lt;/s-clickable&gt;\n  &lt;/s-stack&gt;\n&lt;/s-box&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\"&gt;\n  &lt;s-stack gap=\"large-300\"&gt;\n    &lt;s-heading&gt;Product settings&lt;/s-heading&gt;\n    &lt;s-text&gt;Configure your product inventory and pricing settings.&lt;/s-text&gt;\n    &lt;s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\"&gt;\n      &lt;s-text type=\"strong\"&gt;Configure settings&lt;/s-text&gt;\n    &lt;/s-clickable&gt;\n  &lt;/s-stack&gt;\n&lt;/s-box&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\">\n  <s-stack gap=\"large-300\">\n    <s-heading>Product settings</s-heading>\n    <s-text>Configure your product inventory and pricing settings.</s-text>\n    <s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\">\n      <s-text type=\"strong\">Configure settings</s-text>\n    </s-clickable>\n  </s-stack>\n</s-box>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\">\n  <s-stack gap=\"large-300\">\n    <s-heading>Product settings</s-heading>\n    <s-text>Configure your product inventory and pricing settings.</s-text>\n    <s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\">\n      <s-text type=\"strong\">Configure settings</s-text>\n    </s-clickable>\n  </s-stack>\n</s-box>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates the use of an accessibility label to provide context for screen readers, enhancing the component's usability for users with assistive technologies.",
+              "description": "Add an accessibility label to provide screen readers with more context than the visible text alone. This example shows a clickable delete button with a descriptive label for assistive technologies.",
               "codeblock": {
-                "title": "Accessibility with ARIA Attributes",
+                "title": "Add an accessibility label",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n&gt;\n  &lt;s-text&gt;Delete&lt;/s-text&gt;\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n&gt;\n  &lt;s-text&gt;Delete&lt;/s-text&gt;\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n>\n  <s-text>Delete</s-text>\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n>\n  <s-text>Delete</s-text>\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Shows a disabled link with an accessibility label, explaining the unavailability of a feature to users of assistive technologies.",
+              "description": "Disable a clickable link while providing an accessibility label that explains why the feature is unavailable. This example shows a disabled navigation element with a descriptive label for screen readers.",
               "codeblock": {
-                "title": "Disabled Link with ARIA",
+                "title": "Describe a disabled link with an accessibility label",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n&gt;\n  &lt;s-text&gt;Unavailable feature&lt;/s-text&gt;\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n&gt;\n  &lt;s-text&gt;Unavailable feature&lt;/s-text&gt;\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n>\n  <s-text>Unavailable feature</s-text>\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n>\n  <s-text>Unavailable feature</s-text>\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -123640,7 +123508,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ClickableChipEvents",
         "typeDefinitions": {
           "ClickableChipEvents": {
@@ -123693,7 +123561,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ClickableChipSlots",
         "typeDefinitions": {
           "ClickableChipSlots": {
@@ -123724,23 +123592,19 @@
       }
     ],
     "defaultExample": {
-      "image": "clickable-chip-default.png",
+      "image": "clickablechip-default.png",
+      "description": "Create an interactive chip that merchants can click to trigger an action. This example shows a clickable chip component with default styling.",
       "codeblock": {
-        "title": "Code",
+        "title": "Add a clickable chip with default styling",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;s-clickable-chip&gt;Clickable chip&lt;/s-clickable-chip&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-clickable-chip&gt;Clickable chip&lt;/s-clickable-chip&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-clickable-chip&gt;Clickable chip&lt;/s-clickable-chip&gt;\n",
-            "language": "html",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip>Clickable chip</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-clickable-chip>Clickable chip</s-clickable-chip>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -123750,118 +123614,71 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Demonstrates a simple clickable chip with a base color and interactive functionality.",
+              "description": "Use the `color` property to visually distinguish chips by importance or category. This example shows three chips with `base`, `subdued`, and `strong` color variants.",
               "codeblock": {
-                "title": "Basic Usage",
+                "title": "Apply color variants to chips",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  &gt;\n    Draft\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  &gt;\n    Archived\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  &gt;\n    Draft\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  &gt;\n    Archived\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-stack direction=\"inline\" gap=\"base\">\n  <s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\">\n    Active\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  >\n    Draft\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  >\n    Archived\n  </s-clickable-chip>\n</s-stack>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-stack direction=\"inline\" gap=\"base\">\n  <s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\">\n    Active\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  >\n    Draft\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  >\n    Archived\n  </s-clickable-chip>\n</s-stack>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Showcases a strong-colored clickable chip with a check circle icon and a removable state.",
+              "description": "Add an icon and a remove button so merchants can see the status and dismiss the chip. This example shows a removable chip with a check circle icon in the graphic slot.",
               "codeblock": {
-                "title": "With Icon and Remove Button",
+                "title": "Add an icon and a remove button to a chip",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"check-circle\" /&gt;\n  In progress\n&lt;/s-clickable-chip&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"check-circle\"&gt;&lt;/s-icon&gt;\n  In progress\n&lt;/s-clickable-chip&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n>\n  <s-icon slot=\"graphic\" type=\"check-circle\" />\n  In progress\n</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n>\n  <s-icon slot=\"graphic\" type=\"check-circle\"></s-icon>\n  In progress\n</s-clickable-chip>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates a subdued clickable chip configured as a link with a product icon.",
+              "description": "Set the `href` property to make a chip link to another page when clicked. This example shows a subdued chip with a product icon that acts as a link.",
               "codeblock": {
-                "title": "As a Link",
+                "title": "Use a chip as a link",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"product\" /&gt;\n  T-shirt\n&lt;/s-clickable-chip&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"product\"&gt;&lt;/s-icon&gt;\n  T-shirt\n&lt;/s-clickable-chip&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n>\n  <s-icon slot=\"graphic\" type=\"product\" />\n  T-shirt\n</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n>\n  <s-icon slot=\"graphic\" type=\"product\"></s-icon>\n  T-shirt\n</s-clickable-chip>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates a clickable chip in a disabled state, preventing interaction while displaying an inactive status.",
+              "description": "Disable a chip to prevent interaction while keeping it visible. This example shows a disabled chip with an accessibility label explaining the inactive state.",
               "codeblock": {
-                "title": "Disabled State",
+                "title": "Disable a clickable chip",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n&gt;\n  Inactive\n&lt;/s-clickable-chip&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n&gt;\n  Inactive\n&lt;/s-clickable-chip&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n>\n  Inactive\n</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates how multiple clickable chips with different colors, icons, and states can be arranged using an inline stack for consistent layout and spacing.",
-              "codeblock": {
-                "title": "Multiple Chips with Proper Spacing",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip accessibilityLabel=\"Filter by status\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Remove status filter\"\n    removable\n  &gt;\n    &lt;s-icon slot=\"graphic\" type=\"check-circle\" /&gt;\n    In progress\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip color=\"subdued\" accessibilityLabel=\"Filter by category\"&gt;\n    &lt;s-icon slot=\"graphic\" type=\"filter\" /&gt;\n    Category\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip accessibilityLabel=\"Filter by status\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Remove status filter\"\n    removable\n  &gt;\n    &lt;s-icon slot=\"graphic\" type=\"check-circle\"&gt;&lt;/s-icon&gt;\n    In progress\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip color=\"subdued\" accessibilityLabel=\"Filter by category\"&gt;\n    &lt;s-icon slot=\"graphic\" type=\"filter\"&gt;&lt;/s-icon&gt;\n    Category\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-stack direction=\"inline\" gap=\"base\">\n  <s-clickable-chip accessibilityLabel=\"Filter by status\">\n    Active\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Remove status filter\"\n    removable\n  >\n    <s-icon slot=\"graphic\" type=\"check-circle\" />\n    In progress\n  </s-clickable-chip>\n  <s-clickable-chip color=\"subdued\" accessibilityLabel=\"Filter by category\">\n    <s-icon slot=\"graphic\" type=\"filter\" />\n    Category\n  </s-clickable-chip>\n</s-stack>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n>\n  Inactive\n</s-clickable-chip>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -123908,7 +123725,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -124203,7 +124020,7 @@
       },
       {
         "title": "Events",
-        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ColorFieldEvents",
         "typeDefinitions": {
           "ColorFieldEvents": {
@@ -124470,7 +124287,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -124643,7 +124460,7 @@
       },
       {
         "title": "Events",
-        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ColorPickerEvents",
         "typeDefinitions": {
           "ColorPickerEvents": {
@@ -124764,7 +124581,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -125102,7 +124919,7 @@
       },
       {
         "title": "Events",
-        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "DateFieldEvents",
         "typeDefinitions": {
           "DateFieldEvents": {
@@ -125379,7 +125196,7 @@
     ],
     "definitions": [
       {
-        "title": "DatePicker",
+        "title": "Properties",
         "description": "Configure the following properties on the date picker component.",
         "type": "DatePicker",
         "typeDefinitions": {
@@ -125391,7 +125208,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -125400,7 +125217,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -125628,7 +125445,7 @@
       },
       {
         "title": "Events",
-        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "DatePickerEvents",
         "typeDefinitions": {
           "DatePickerEvents": {
@@ -126058,7 +125875,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- Set clear file type and size restrictions using the `accept` property.\n- Use the `droprejected` event to display meaningful error messages when uploads fail validation.\n- Consider using `disabled` to prevent uploads during processing."
+        "sectionContent": "- **Define file restrictions**: Set clear file type and size restrictions using the `accept` property.\n- **Provide meaningful error messages**: Use the `droprejected` event to display meaningful error messages when uploads fail validation.\n- **Prevent duplicate uploads**: Consider using `disabled` to prevent uploads during processing."
       },
       {
         "title": "Limitations",
@@ -126081,7 +125898,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true,
@@ -126090,7 +125907,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -126099,7 +125916,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true,
@@ -126335,7 +126152,7 @@
       },
       {
         "title": "Events",
-        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "DropZoneEvents",
         "typeDefinitions": {
           "DropZoneEvents": {
@@ -126593,7 +126410,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -126895,7 +126712,7 @@
       },
       {
         "title": "Events",
-        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "EmailFieldEvents",
         "typeDefinitions": {
           "EmailFieldEvents": {
@@ -127078,7 +126895,7 @@
     "definitions": [
       {
         "title": "Events",
-        "description": "The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "FormEvents",
         "typeDefinitions": {
           "FormEvents": {
@@ -127442,7 +127259,7 @@
     "definitions": [
       {
         "title": "Events",
-        "description": "The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The function settings component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "FormEvents",
         "typeDefinitions": {
           "FormEvents": {
@@ -128446,7 +128263,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "GridSlots",
         "typeDefinitions": {
           "GridSlots": {
@@ -128960,7 +128777,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "GridItemSlots",
         "typeDefinitions": {
           "GridItemSlots": {
@@ -129249,7 +129066,7 @@
       },
       {
         "title": "Slots",
-        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "HeadingSlots",
         "typeDefinitions": {
           "HeadingSlots": {
@@ -129718,28 +129535,22 @@
     "isVisualComponent": true,
     "subSections": [
       {
-        "title": "Useful for",
-        "type": "Generic",
-        "anchorLink": "useful-for",
-        "sectionContent": "- Adding illustrations and photos."
-      },
-      {
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- Use high-resolution, optimized images.\n- Use intentionally to add clarity and guide users."
+        "sectionContent": "- **Always provide descriptive alternative text:** Write alt text that describes what's in the image, not what the image is for. Use \"Blue cotton t-shirt with crew neck\" instead of \"Product image.\" For decorative images that don't add information, use an empty alt attribute.\n- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [Icon](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/icon) component instead.\n- **Ensure images are accessible and performant:** Use appropriate image formats (WebP for photos, PNG for graphics with transparency, SVG for logos). Ensure images load from reliable sources with proper CORS configuration if cross-origin.\n- **Consider the image's purpose and context:** Use images to help merchants understand products, visualize data, or follow instructions. Every image should serve a clear purpose in your interface."
       },
       {
-        "title": "Content guidelines",
+        "title": "Limitations",
         "type": "Generic",
-        "anchorLink": "content-guidelines",
-        "sectionContent": "Alt text should be accurate, concise, and descriptive:\n- Indicate it's an image: \"Image of\", \"Photo of\".\n- Focus on description: \"Image of a woman with curly brown hair smiling\"."
+        "anchorLink": "limitations",
+        "sectionContent": "- Images can be loaded from remote URLs or local file resources. Cross-origin images require proper CORS headers from the image host.\n- The component displays images at their intrinsic aspect ratio. Use `aspectRatio` (for example, `'16/9'`) to set a fixed ratio, and `objectFit` (`'cover'` or `'contain'`) to control how the image resizes within its container.\n- The component provides a basic placeholder while images load but doesn't include built-in loading skeletons or progressive loading features."
       }
     ],
     "definitions": [
       {
         "title": "Properties",
-        "description": "",
+        "description": "Configure the following properties on the image component.",
         "type": "Image",
         "typeDefinitions": {
           "Image": {
@@ -130064,7 +129875,7 @@
       },
       {
         "title": "Events",
-        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ImageEvents",
         "typeDefinitions": {
           "ImageEvents": {
@@ -130464,7 +130275,7 @@
       },
       {
         "title": "Events",
-        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "LinkEvents",
         "typeDefinitions": {
           "LinkEvents": {
@@ -130501,7 +130312,7 @@
       },
       {
         "title": "Slots",
-        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "LinkSlots",
         "typeDefinitions": {
           "LinkSlots": {
@@ -130525,22 +130336,18 @@
     ],
     "defaultExample": {
       "image": "link-default.png",
+      "description": "Add an inline link to let merchants navigate to another page. This example shows a basic text link with an `href` property.",
       "codeblock": {
-        "title": "Code",
+        "title": "Add a basic link",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;s-link href=\"javascript:void(0)\"&gt;fufilling orders&lt;/s-link&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-link href=\"#beep\"&gt;fulfilling orders&lt;/s-link&gt;",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-link href=\"#beep\"&gt;fufilling orders&lt;/s-link&gt;\n",
-            "language": "html",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-link href=\"javascript:void(0)\">fufilling orders</s-link>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-link href=\"#beep\">fulfilling orders</s-link></div></body></html>",
             "language": "preview"
           }
         ]
@@ -130550,256 +130357,122 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Links automatically inherit the tone from their surrounding paragraph context.",
+              "description": "Embed links within a [Paragraph](/docs/api/app-home/web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.",
               "codeblock": {
-                "title": "Basic Links in Paragraph",
+                "title": "Embed links in paragraph text",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  Your product catalog is empty. Start by &lt;s-link href=\"javascript:void(0)\"&gt;adding your first product&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;importing existing inventory&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-paragraph&gt;\n  Your product catalog is empty. Start by &lt;s-link href=\"javascript:void(0)\"&gt;adding your first product&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;importing existing inventory&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  Your product catalog is empty. Start by <s-link href=\"javascript:void(0)\">adding your first product</s-link> or <s-link href=\"javascript:void(0)\">importing existing inventory</s-link>.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-paragraph>\n  Your product catalog is empty. Start by <s-link href=\"javascript:void(0)\">adding your first product</s-link> or <s-link href=\"javascript:void(0)\">importing existing inventory</s-link>.\n</s-paragraph>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates links within subdued paragraph, showing how links can be used in less prominent paragraph contexts for additional guidance or support.",
+              "description": "Place links inside banners to provide direct actions alongside important notifications. This example shows a link inside an info banner prompting merchants to create a campaign.",
               "codeblock": {
-                "title": "Links in Subdued Paragraph",
+                "title": "Add links inside a banner",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph color=\"subdued\"&gt;\n  Need help setting up shipping rates? &lt;s-link&gt;View shipping guide&lt;/s-link&gt; or &lt;s-link&gt;contact merchant support&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-paragraph color=\"subdued\"&gt;\n  Need help setting up shipping rates? &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;View shipping guide&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;contact merchant support&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph color=\"subdued\">\n  Need help setting up shipping rates? <s-link>View shipping guide</s-link> or <s-link>contact merchant support</s-link>.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Illustrates how links can be used in critical or urgent text contexts, drawing attention to important actions that require immediate user intervention.",
-              "codeblock": {
-                "title": "Critical Context Links",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph tone=\"critical\"&gt;\n  Your store will be suspended in 24 hours due to unpaid balance. &lt;s-link href=\"javascript:void(0)\"&gt;Update payment method&lt;/s-link&gt; to avoid service interruption.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-paragraph tone=\"critical\"&gt;\n  Your store will be suspended in 24 hours due to unpaid balance. &lt;s-link href=\"javascript:void(0)\"&gt;Update payment method&lt;/s-link&gt; to avoid service interruption.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph tone=\"critical\">\n  Your store will be suspended in 24 hours due to unpaid balance. <s-link href=\"javascript:void(0)\">Update payment method</s-link> to avoid service interruption.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Shows how links automatically adapt their tone to the surrounding text context, maintaining visual consistency while providing navigation.",
-              "codeblock": {
-                "title": "Links with Auto Tone",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  You have 15 pending orders to fulfill. &lt;s-link href=\"javascript:void(0)\"&gt;Review unfulfilled orders&lt;/s-link&gt; to keep customers happy.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-paragraph&gt;\n  You have 15 pending orders to fulfill. &lt;s-link href=\"javascript:void(0)\"&gt;Review unfulfilled orders&lt;/s-link&gt; to keep customers happy.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  You have 15 pending orders to fulfill. <s-link href=\"javascript:void(0)\">Review unfulfilled orders</s-link> to keep customers happy.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates how links can be integrated within banner components to highlight important information and provide direct action paths.",
-              "codeblock": {
-                "title": "Links in Banner",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-banner tone=\"info\"&gt;\n  &lt;s-paragraph&gt;\n    Black Friday campaigns are now available!  &lt;s-link href=\"javascript:void(0)\"&gt;Create your campaign&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-banner tone=\"info\"&gt;\n  &lt;s-paragraph&gt;\n    Black Friday campaigns are now available!\n    &lt;s-link href=\"javascript:void(0)\"&gt;Create your campaign&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-banner tone=\"info\">\n  <s-paragraph>\n    Black Friday campaigns are now available!  <s-link href=\"javascript:void(0)\">Create your campaign</s-link>\n  </s-paragraph>\n</s-banner>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-banner tone=\"info\">\n  <s-paragraph>\n    Black Friday campaigns are now available!\n    <s-link href=\"javascript:void(0)\">Create your campaign</s-link>\n  </s-paragraph>\n</s-banner>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates using links within a box container to provide contextual navigation and additional information in a visually contained area.",
+              "description": "Place links inside a box container to provide navigation within a visually distinct content area. This example shows two links inside a bordered box with background and padding.",
               "codeblock": {
-                "title": "Links in Box Container",
+                "title": "Add links inside a box container",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Boost your store's conversion with professional themes. &lt;s-link href=\"javascript:void(0)\"&gt;Browse theme store&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;customize your current theme&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Boost your store's conversion with professional themes. &lt;s-link href=\"javascript:void(0)\"&gt;Browse theme store&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;customize your current theme&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\">\n  <s-paragraph>\n    Boost your store's conversion with professional themes. <s-link href=\"javascript:void(0)\">Browse theme store</s-link> or <s-link href=\"javascript:void(0)\">customize your current theme</s-link>.\n  </s-paragraph>\n</s-box>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\">\n  <s-paragraph>\n    Boost your store's conversion with professional themes. <s-link href=\"javascript:void(0)\">Browse theme store</s-link> or <s-link href=\"javascript:void(0)\">customize your current theme</s-link>.\n  </s-paragraph>\n</s-box>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Shows how links can be used within warning banners to provide immediate actions related to critical notifications.",
+              "description": "Use the `download` property to trigger a file download when the link is clicked. This example shows a link that downloads a CSV file for customer data export.",
               "codeblock": {
-                "title": "Links in Banner Context",
+                "title": "Trigger a file download",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-banner tone=\"warning\"&gt;\n  &lt;s-paragraph&gt;\n    Your inventory for \"Vintage t-shirt\" is running low (3 remaining).  &lt;s-link&gt;Restock inventory&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-banner tone=\"warning\"&gt;\n  &lt;s-paragraph&gt;\n    Your inventory for \"Vintage t-shirt\" is running low (3 remaining). &lt;s-link&gt;Restock inventory&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-banner tone=\"warning\">\n  <s-paragraph>\n    Your inventory for \"Vintage t-shirt\" is running low (3 remaining).  <s-link>Restock inventory</s-link>\n  </s-paragraph>\n</s-banner>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates how to create links that trigger file downloads, useful for exporting data or providing downloadable resources.",
-              "codeblock": {
-                "title": "Download Links",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  Export your customer data for marketing analysis. &lt;s-link href=\"javascript:void(0)\" download=\"customer-export.csv\"&gt;Download customer list&lt;/s-link&gt;\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-paragraph&gt;\n  Export your customer data for marketing analysis. &lt;s-link href=\"javascript:void(0)\" download=\"customer-export.csv\"&gt;Download customer list&lt;/s-link&gt;\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  Export your customer data for marketing analysis. <s-link href=\"javascript:void(0)\" download=\"customer-export.csv\">Download customer list</s-link>\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-paragraph>\n  Export your customer data for marketing analysis. <s-link href=\"javascript:void(0)\" download=\"customer-export.csv\">Download customer list</s-link>\n</s-paragraph>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates linking to external resources with different targets, showing how to open links in new tabs and provide navigation to external documentation.",
+              "description": "Open external URLs in a new tab so merchants stay on the current page. This example shows two links with `target=\"_blank\"` pointing to external documentation.",
               "codeblock": {
-                "title": "External Links",
+                "title": "Open external links in a new tab",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-box padding=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Need help with policies? Read our &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;billing docs&lt;/s-link&gt; or review the &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;terms of service&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-box padding=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Need help with policies? Read our &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;billing docs&lt;/s-link&gt; or review the &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;terms of service&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-box padding=\"base\">\n  <s-paragraph>\n    Need help with policies? Read our <s-link href=\"javascript:void(0)\" target=\"_blank\">billing docs</s-link> or review the <s-link href=\"javascript:void(0)\" target=\"_blank\">terms of service</s-link>.\n  </s-paragraph>\n</s-box>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-box padding=\"base\">\n  <s-paragraph>\n    Need help with policies? Read our <s-link href=\"javascript:void(0)\" target=\"_blank\">billing docs</s-link> or review the <s-link href=\"javascript:void(0)\" target=\"_blank\">terms of service</s-link>.\n  </s-paragraph>\n</s-box>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Shows how to use the `lang` attribute to specify the language of a link, supporting internationalization and proper screen reader pronunciation.",
+              "description": "Set the `lang` property so screen readers pronounce the link text correctly. This example shows a French-language link with the `lang` attribute set.",
               "codeblock": {
-                "title": "Links with Language Attribute",
+                "title": "Set the language for a link",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  Voir en français: &lt;s-link lang=\"fr\"&gt;Gérer les produits&lt;/s-link&gt;\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-paragraph&gt;\n  Voir en français: &lt;s-link lang=\"fr\"&gt;Gérer les produits&lt;/s-link&gt;\n&lt;/s-paragraph&gt;",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  Voir en français: <s-link lang=\"fr\">Gérer les produits</s-link>\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-paragraph>\n  Voir en français: <s-link lang=\"fr\">Gérer les produits</s-link>\n</s-paragraph></s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates how links can have different visual tones, including default, neutral, and critical, allowing for varied contextual styling.",
+              "description": "Configure links that inherit the tone of their parent paragraph and match the surrounding context. This example shows links inside paragraphs with six different tones.",
               "codeblock": {
-                "title": "Links with Different Tones",
+                "title": "Match link tone to surrounding context",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-stack gap=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Default tone: &lt;s-link&gt;View orders&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"success\"&gt;\n    Success tone: &lt;s-link&gt;Inventory help&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"critical\"&gt;\n    Critical tone: &lt;s-link&gt;Close store&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"warning\"&gt;\n    Warning tone: &lt;s-link&gt;Update billing info&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"info\"&gt;\n    Info tone: &lt;s-link&gt;Learn more about reports&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"caution\"&gt;\n    Caution tone: &lt;s-link&gt;View archived products&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-stack&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-stack gap=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Default tone: &lt;s-link&gt;View orders&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"success\"&gt;\n    Neutral tone: &lt;s-link&gt;Inventory help&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"critical\"&gt;\n    Critical tone: &lt;s-link&gt;Close store&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"warning\"&gt;\n    Warning tone: &lt;s-link&gt;Update billing info&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"info\"&gt;\n    Info tone: &lt;s-link&gt;Learn more about reports&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"caution\"&gt;\n    Subdued tone: &lt;s-link&gt;View archived products&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-stack&gt;",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-stack gap=\"base\">\n  <s-paragraph>\n    Default tone: <s-link>View orders</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"success\">\n    Success tone: <s-link>Inventory help</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"critical\">\n    Critical tone: <s-link>Close store</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"warning\">\n    Warning tone: <s-link>Update billing info</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"info\">\n    Info tone: <s-link>Learn more about reports</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"caution\">\n    Caution tone: <s-link>View archived products</s-link>\n  </s-paragraph>\n</s-stack>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-stack gap=\"base\">\n  <s-paragraph>\n    Default tone: <s-link>View orders</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"success\">\n    Neutral tone: <s-link>Inventory help</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"critical\">\n    Critical tone: <s-link>Close store</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"warning\">\n    Warning tone: <s-link>Update billing info</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"info\">\n    Info tone: <s-link>Learn more about reports</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"caution\">\n    Subdued tone: <s-link>View archived products</s-link>\n  </s-paragraph>\n</s-stack></s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -130846,7 +130519,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -130855,7 +130528,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -130864,7 +130537,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true,
@@ -131004,7 +130677,7 @@
       },
       {
         "title": "Slots",
-        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "MenuSlots",
         "typeDefinitions": {
           "MenuSlots": {
@@ -131027,26 +130700,19 @@
       }
     ],
     "defaultExample": {
+      "image": "menu-default.png",
+      "description": "Add a dropdown menu of actions triggered by a button. This example shows a menu with three icon buttons including a critical delete action.",
       "codeblock": {
-        "title": "Code",
+        "title": "Add a basic actions menu",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;&gt;\n  &lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n  &lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n    &lt;s-button icon=\"merge\"&gt;Merge customer&lt;/s-button&gt;\n    &lt;s-button icon=\"incoming\"&gt;Request customer data&lt;/s-button&gt;\n    &lt;s-button icon=\"delete\" tone=\"critical\"&gt;\n      Delete customer\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n&lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n  &lt;s-button icon=\"merge\"&gt;Merge customer&lt;/s-button&gt;\n  &lt;s-button icon=\"incoming\"&gt;Request customer data&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete customer&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n&lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n  &lt;s-button icon=\"merge\"&gt;Merge customer&lt;/s-button&gt;\n  &lt;s-button icon=\"incoming\"&gt;Request customer data&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete customer&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-            "language": "html",
-            "layout": "alignStart",
-            "customStyles": {
-              "minHeight": "300px"
-            },
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n  <s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n    <s-button icon=\"merge\">Merge customer</s-button>\n    <s-button icon=\"incoming\">Request customer data</s-button>\n    <s-button icon=\"delete\" tone=\"critical\">\n      Delete customer\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n<s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n  <s-button icon=\"merge\">Merge customer</s-button>\n  <s-button icon=\"incoming\">Request customer data</s-button>\n  <s-button icon=\"delete\" tone=\"critical\">Delete customer</s-button>\n</s-menu>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -131056,141 +130722,88 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Demonstrates a simple menu with basic action buttons and shows how to link it to a trigger button.",
+              "description": "Organize menu items into labeled groups so merchants can find related actions. This example shows two sections with headings separating product actions from export options.",
               "codeblock": {
-                "title": "Basic Menu",
+                "title": "Organize items into sections",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"product-menu\"&gt;Product actions&lt;/s-button&gt;\n\n  &lt;s-menu id=\"product-menu\" accessibilityLabel=\"Product actions\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button commandFor=\"product-menu\"&gt;Product actions&lt;/s-button&gt;\n\n&lt;s-menu id=\"product-menu\" accessibilityLabel=\"Product actions\"&gt;\n  &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n  &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n  &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"product-menu\">Product actions</s-button>\n\n  <s-menu id=\"product-menu\" accessibilityLabel=\"Product actions\">\n    <s-button icon=\"edit\">Edit product</s-button>\n    <s-button icon=\"duplicate\">Duplicate product</s-button>\n    <s-button icon=\"archive\">Archive product</s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Illustrates a menu with icons for each action, providing visual context for different menu items and showing how to use the caret-down icon on the trigger button.",
-              "codeblock": {
-                "title": "Menu with Icons",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button icon=\"caret-down\" commandFor=\"actions-menu\"&gt;\n    More actions\n  &lt;/s-button&gt;\n\n  &lt;s-menu id=\"actions-menu\" accessibilityLabel=\"Product actions menu\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n    &lt;s-button icon=\"delete\" tone=\"critical\"&gt;\n      Delete product\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button icon=\"caret-down\" commandFor=\"actions-menu\"&gt;More actions&lt;/s-button&gt;\n\n&lt;s-menu id=\"actions-menu\" accessibilityLabel=\"Product actions menu\"&gt;\n  &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n  &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n  &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete product&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button icon=\"caret-down\" commandFor=\"actions-menu\">\n    More actions\n  </s-button>\n\n  <s-menu id=\"actions-menu\" accessibilityLabel=\"Product actions menu\">\n    <s-button icon=\"edit\">Edit product</s-button>\n    <s-button icon=\"duplicate\">Duplicate product</s-button>\n    <s-button icon=\"archive\">Archive product</s-button>\n    <s-button icon=\"delete\" tone=\"critical\">\n      Delete product\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Shows how to organize menu items into logical sections with headings, helping to group related actions and improve menu readability.",
-              "codeblock": {
-                "title": "Menu with Sections",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"organized-menu\"&gt;Bulk actions&lt;/s-button&gt;\n\n  &lt;s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\"&gt;\n    &lt;s-section heading=\"Product actions\"&gt;\n      &lt;s-button icon=\"edit\"&gt;Edit selected&lt;/s-button&gt;\n      &lt;s-button icon=\"duplicate\"&gt;Duplicate selected&lt;/s-button&gt;\n      &lt;s-button icon=\"archive\"&gt;Archive selected&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-section heading=\"Export options\"&gt;\n      &lt;s-button icon=\"export\"&gt;Export as CSV&lt;/s-button&gt;\n      &lt;s-button icon=\"print\"&gt;Print barcodes&lt;/s-button&gt;\n    &lt;/s-section&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button commandFor=\"organized-menu\"&gt;Bulk actions&lt;/s-button&gt;\n\n&lt;s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\"&gt;\n  &lt;s-section heading=\"Product actions\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit selected&lt;/s-button&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate selected&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive selected&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-section heading=\"Export options\"&gt;\n    &lt;s-button icon=\"export\"&gt;Export as CSV&lt;/s-button&gt;\n    &lt;s-button icon=\"print\"&gt;Print barcodes&lt;/s-button&gt;\n  &lt;/s-section&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 400px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"organized-menu\">Bulk actions</s-button>\n\n  <s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\">\n    <s-section heading=\"Product actions\">\n      <s-button icon=\"edit\">Edit selected</s-button>\n      <s-button icon=\"duplicate\">Duplicate selected</s-button>\n      <s-button icon=\"archive\">Archive selected</s-button>\n    </s-section>\n    <s-section heading=\"Export options\">\n      <s-button icon=\"export\">Export as CSV</s-button>\n      <s-button icon=\"print\">Print barcodes</s-button>\n    </s-section>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button commandFor=\"organized-menu\">Bulk actions</s-button>\n\n<s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\">\n  <s-section heading=\"Product actions\">\n    <s-button icon=\"edit\">Edit selected</s-button>\n    <s-button icon=\"duplicate\">Duplicate selected</s-button>\n    <s-button icon=\"archive\">Archive selected</s-button>\n  </s-section>\n  <s-section heading=\"Export options\">\n    <s-button icon=\"export\">Export as CSV</s-button>\n    <s-button icon=\"print\">Print barcodes</s-button>\n  </s-section>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates a menu with a mix of link-based buttons, standard buttons, and a disabled button, showcasing the menu's flexibility in handling different interaction states.",
+              "description": "Mix link-based, standard, and disabled buttons in a single menu. This example shows a menu with a link that opens in a new tab, a disabled action, and a download link.",
               "codeblock": {
-                "title": "Menu with Links and Disabled Items",
+                "title": "Add links and disabled items to a menu",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"mixed-menu\"&gt;Options&lt;/s-button&gt;\n\n  &lt;s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\"&gt;\n    &lt;s-button href=\"javascript:void(0)\" target=\"_blank\"&gt;\n      View product page\n    &lt;/s-button&gt;\n    &lt;s-button disabled&gt;Unavailable action&lt;/s-button&gt;\n    &lt;s-button download=\"sales-report.csv\" href=\"/reports/sales-report.csv\"&gt;\n      Download report\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button commandFor=\"mixed-menu\"&gt;Options&lt;/s-button&gt;\n\n&lt;s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\"&gt;\n  &lt;s-button href=\"javascript:void(0)\" target=\"_blank\"&gt;\n    View product page\n  &lt;/s-button&gt;\n  &lt;s-button disabled&gt;Unavailable action&lt;/s-button&gt;\n  &lt;s-button download href=\"javascript:void(0)\"&gt;Download report&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"mixed-menu\">Options</s-button>\n\n  <s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\">\n    <s-button href=\"javascript:void(0)\" target=\"_blank\">\n      View product page\n    </s-button>\n    <s-button disabled>Unavailable action</s-button>\n    <s-button download=\"sales-report.csv\" href=\"/reports/sales-report.csv\">\n      Download report\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button commandFor=\"mixed-menu\">Options</s-button>\n\n<s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\">\n  <s-button href=\"javascript:void(0)\" target=\"_blank\">\n    View product page\n  </s-button>\n  <s-button disabled>Unavailable action</s-button>\n  <s-button download href=\"javascript:void(0)\">Download report</s-button>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Presents a comprehensive menu showing how to create sections with different action groups and include a critical action at the menu's root level.",
+              "description": "Combine sections with root-level items to separate grouped actions from standalone ones like a destructive action. This example shows two sections for customer management alongside a root-level delete button.",
               "codeblock": {
-                "title": "Actions menu with sections",
+                "title": "Mix sections with root-level actions",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n  &lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n    &lt;s-section heading=\"Customer management\"&gt;\n      &lt;s-button icon=\"edit\"&gt;Edit customer&lt;/s-button&gt;\n      &lt;s-button icon=\"email\"&gt;Send email&lt;/s-button&gt;\n      &lt;s-button icon=\"order\"&gt;View orders&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-section heading=\"Account actions\"&gt;\n      &lt;s-button icon=\"reset\"&gt;Reset password&lt;/s-button&gt;\n      &lt;s-button icon=\"lock\"&gt;Disable account&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-button tone=\"critical\" icon=\"delete\"&gt;\n      Delete customer\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n&lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n  &lt;s-section heading=\"Customer management\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit customer&lt;/s-button&gt;\n    &lt;s-button icon=\"email\"&gt;Send email&lt;/s-button&gt;\n    &lt;s-button icon=\"order\"&gt;View orders&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-section heading=\"Account actions\"&gt;\n    &lt;s-button icon=\"reset\"&gt;Reset password&lt;/s-button&gt;\n    &lt;s-button icon=\"lock\"&gt;Disable account&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-button tone=\"critical\" icon=\"delete\"&gt;Delete customer&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n  <s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n    <s-section heading=\"Customer management\">\n      <s-button icon=\"edit\">Edit customer</s-button>\n      <s-button icon=\"email\">Send email</s-button>\n      <s-button icon=\"order\">View orders</s-button>\n    </s-section>\n    <s-section heading=\"Account actions\">\n      <s-button icon=\"reset\">Reset password</s-button>\n      <s-button icon=\"lock\">Disable account</s-button>\n    </s-section>\n    <s-button tone=\"critical\" icon=\"delete\">\n      Delete customer\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n<s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n  <s-section heading=\"Customer management\">\n    <s-button icon=\"edit\">Edit customer</s-button>\n    <s-button icon=\"email\">Send email</s-button>\n    <s-button icon=\"order\">View orders</s-button>\n  </s-section>\n  <s-section heading=\"Account actions\">\n    <s-button icon=\"reset\">Reset password</s-button>\n    <s-button icon=\"lock\">Disable account</s-button>\n  </s-section>\n  <s-button tone=\"critical\" icon=\"delete\">Delete customer</s-button>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates a complex menu with nested sections, demonstrating how to organize multiple related actions with icons.",
+              "description": "Build a settings-style menu with multiple sections and a standalone action at the bottom. This example shows account and store settings sections with a root-level sign-out link.",
               "codeblock": {
-                "title": "Menu with nested sections",
+                "title": "Build a settings menu with sections",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button icon=\"settings\" commandFor=\"admin-settings\"&gt;\n    Settings\n  &lt;/s-button&gt;\n\n  &lt;s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\"&gt;\n    &lt;s-section heading=\"Account\"&gt;\n      &lt;s-button icon=\"profile\"&gt;Profile settings&lt;/s-button&gt;\n      &lt;s-button icon=\"lock\"&gt;Security&lt;/s-button&gt;\n      &lt;s-button&gt;Billing information&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-section heading=\"Store\"&gt;\n      &lt;s-button icon=\"store\"&gt;Store settings&lt;/s-button&gt;\n      &lt;s-button&gt;Payment providers&lt;/s-button&gt;\n      &lt;s-button icon=\"delivery\"&gt;Shipping rates&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-button href=\"javascript:void(0)\" icon=\"person-exit\"&gt;Sign out&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button icon=\"settings\" commandFor=\"admin-settings\"&gt;Settings&lt;/s-button&gt;\n\n&lt;s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\"&gt;\n  &lt;s-section heading=\"Account\"&gt;\n    &lt;s-button icon=\"profile\"&gt;Profile settings&lt;/s-button&gt;\n    &lt;s-button icon=\"lock\"&gt;Security&lt;/s-button&gt;\n    &lt;s-button&gt;Billing information&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-section heading=\"Store\"&gt;\n    &lt;s-button icon=\"store\"&gt;Store settings&lt;/s-button&gt;\n    &lt;s-button&gt;Payment providers&lt;/s-button&gt;\n    &lt;s-button icon=\"delivery\"&gt;Shipping rates&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-button href=\"javascript:void(0)\" icon=\"person-exit\"&gt;Sign out&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 350px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button icon=\"settings\" commandFor=\"admin-settings\">\n    Settings\n  </s-button>\n\n  <s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\">\n    <s-section heading=\"Account\">\n      <s-button icon=\"profile\">Profile settings</s-button>\n      <s-button icon=\"lock\">Security</s-button>\n      <s-button>Billing information</s-button>\n    </s-section>\n    <s-section heading=\"Store\">\n      <s-button icon=\"store\">Store settings</s-button>\n      <s-button>Payment providers</s-button>\n      <s-button icon=\"delivery\">Shipping rates</s-button>\n    </s-section>\n    <s-button href=\"javascript:void(0)\" icon=\"person-exit\">Sign out</s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button icon=\"settings\" commandFor=\"admin-settings\">Settings</s-button>\n\n<s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\">\n  <s-section heading=\"Account\">\n    <s-button icon=\"profile\">Profile settings</s-button>\n    <s-button icon=\"lock\">Security</s-button>\n    <s-button>Billing information</s-button>\n  </s-section>\n  <s-section heading=\"Store\">\n    <s-button icon=\"store\">Store settings</s-button>\n    <s-button>Payment providers</s-button>\n    <s-button icon=\"delivery\">Shipping rates</s-button>\n  </s-section>\n  <s-button href=\"javascript:void(0)\" icon=\"person-exit\">Sign out</s-button>\n</s-menu>\n</s-box></body></html>",
+                    "language": "preview"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Use an icon-only button as the menu trigger for a compact \"more actions\" pattern. This example shows a three-dot icon button that opens a menu with common product actions.",
+              "codeblock": {
+                "title": "Trigger a menu from an icon-only button",
+                "tabs": [
+                  {
+                    "title": "html",
+                    "code": "&lt;s-button\n  icon=\"menu-horizontal\"\n  variant=\"tertiary\"\n  accessibilityLabel=\"More actions\"\n  commandFor=\"more-actions-menu\"\n&gt;&lt;/s-button&gt;\n\n&lt;s-menu id=\"more-actions-menu\" accessibilityLabel=\"More actions\"&gt;\n  &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n  &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n  &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete product&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
+                    "language": "html"
+                  },
+                  {
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button\n  icon=\"menu-horizontal\"\n  variant=\"tertiary\"\n  accessibilityLabel=\"More actions\"\n  commandFor=\"more-actions-menu\"\n></s-button>\n\n<s-menu id=\"more-actions-menu\" accessibilityLabel=\"More actions\">\n  <s-button icon=\"edit\">Edit product</s-button>\n  <s-button icon=\"duplicate\">Duplicate product</s-button>\n  <s-button icon=\"archive\">Archive product</s-button>\n  <s-button icon=\"delete\" tone=\"critical\">Delete product</s-button>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -131237,7 +130850,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -131532,7 +131145,7 @@
       },
       {
         "title": "Events",
-        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "MoneyFieldEvents",
         "typeDefinitions": {
           "MoneyFieldEvents": {
@@ -131708,7 +131321,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -132046,7 +131659,7 @@
       },
       {
         "title": "Events",
-        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "NumberFieldEvents",
         "typeDefinitions": {
           "NumberFieldEvents": {
@@ -132191,7 +131804,7 @@
     "name": "Ordered list",
     "description": "The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list).",
     "category": "Web components",
-    "subCategory": "Layout and structure",
+    "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/ordered-list.png",
     "isVisualComponent": true,
@@ -132212,7 +131825,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "OrderedListSlots",
         "typeDefinitions": {
           "OrderedListSlots": {
@@ -132369,7 +131982,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {
@@ -132651,7 +132264,7 @@
       },
       {
         "title": "Slots",
-        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ParagraphSlots",
         "typeDefinitions": {
           "ParagraphSlots": {
@@ -132841,7 +132454,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -133143,7 +132756,7 @@
       },
       {
         "title": "Events",
-        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "PasswordFieldEvents",
         "typeDefinitions": {
           "PasswordFieldEvents": {
@@ -133486,7 +133099,7 @@
       },
       {
         "title": "Slots",
-        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "QueryContainerSlots",
         "typeDefinitions": {
           "QueryContainerSlots": {
@@ -133573,7 +133186,7 @@
     ],
     "definitions": [
       {
-        "title": "SearchField",
+        "title": "Properties",
         "description": "Configure the following properties on the search field component.",
         "type": "SearchField",
         "typeDefinitions": {
@@ -133585,7 +133198,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -133887,7 +133500,7 @@
       },
       {
         "title": "Events",
-        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "SearchFieldEvents",
         "typeDefinitions": {
           "SearchFieldEvents": {
@@ -134212,7 +133825,7 @@
       },
       {
         "title": "Slots",
-        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "SectionSlots",
         "typeDefinitions": {
           "SectionSlots": {
@@ -134368,7 +133981,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -134377,7 +133990,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -134386,7 +133999,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true,
@@ -134618,7 +134231,7 @@
       },
       {
         "title": "Events",
-        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "SelectEvents",
         "typeDefinitions": {
           "SelectEvents": {
@@ -134663,7 +134276,7 @@
       },
       {
         "title": "Slots",
-        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "SelectSlots",
         "typeDefinitions": {
           "SelectSlots": {
@@ -134855,7 +134468,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "OptionSlots",
         "typeDefinitions": {
           "OptionSlots": {
@@ -134877,7 +134490,7 @@
         }
       },
       {
-        "title": "OptionGroup",
+        "title": "Option group",
         "description": "Represents a group of options within a select component. Use only as a child of `s-select` components.",
         "type": "OptionGroup",
         "typeDefinitions": {
@@ -135029,7 +134642,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "OptionGroupSlots",
         "typeDefinitions": {
           "OptionGroupSlots": {
@@ -136055,7 +135668,7 @@
       },
       {
         "title": "Slots",
-        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "StackSlots",
         "typeDefinitions": {
           "StackSlots": {
@@ -136205,7 +135818,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -136447,7 +136060,7 @@
       },
       {
         "title": "Events",
-        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "SwitchEvents",
         "typeDefinitions": {
           "SwitchEvents": {
@@ -136658,7 +136271,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true,
@@ -136667,7 +136280,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true,
@@ -136905,7 +136518,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableSlots",
         "typeDefinitions": {
           "TableSlots": {
@@ -136936,7 +136549,7 @@
       },
       {
         "title": "Events",
-        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "TableEvents",
         "typeDefinitions": {
           "TableEvents": {
@@ -137115,7 +136728,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableBodySlots",
         "typeDefinitions": {
           "TableBodySlots": {
@@ -137149,7 +136762,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true,
@@ -137288,7 +136901,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableCellSlots",
         "typeDefinitions": {
           "TableCellSlots": {
@@ -137476,7 +137089,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableHeaderSlots",
         "typeDefinitions": {
           "TableHeaderSlots": {
@@ -137633,7 +137246,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableHeaderRowSlots",
         "typeDefinitions": {
           "TableHeaderRowSlots": {
@@ -137798,7 +137411,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableRowSlots",
         "typeDefinitions": {
           "TableRowSlots": {
@@ -138156,7 +137769,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TextSlots",
         "typeDefinitions": {
           "TextSlots": {
@@ -138363,7 +137976,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -138674,7 +138287,7 @@
       },
       {
         "title": "Events",
-        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "TextAreaEvents",
         "typeDefinitions": {
           "TextAreaEvents": {
@@ -138868,7 +138481,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -139204,7 +138817,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TextFieldSlots",
         "typeDefinitions": {
           "TextFieldSlots": {
@@ -139227,7 +138840,7 @@
       },
       {
         "title": "Events",
-        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "TextFieldEvents",
         "typeDefinitions": {
           "TextFieldEvents": {
@@ -139412,28 +139025,22 @@
     "isVisualComponent": true,
     "subSections": [
       {
-        "title": "Useful for",
-        "type": "Generic",
-        "anchorLink": "useful-for",
-        "sectionContent": "- Identifying items visually in lists, tables, or cards.\n- Seeing a preview of images before uploading or publishing.\n- Distinguishing between similar items by their appearance.\n- Confirming the correct item is selected."
-      },
-      {
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- `small-200`: use in very small areas.\n- `small`: use in small areas.\n- `base`: use as the default size.\n- `large`: use when thumbnail is a focal point."
+        "sectionContent": "- **Design for square cropping:** Thumbnails automatically crop images to a 1:1 aspect ratio from the center. If your images aren't square, important content near the edges might be cut off.\n- **Maintain visual consistency in groups:** Use the same thumbnail size throughout a single list, table, or grid. Mixing sizes creates visual chaos and makes interfaces harder to scan.\n- **Always provide descriptive alternative text:** Write alt text that describes the image content, not generic labels like \"thumbnail\" or \"product image.\" Good alt text helps all merchants understand what they're looking at.\n- **Choose appropriate sizes for your context:** Smaller thumbnails work better in dense layouts like tables, while larger sizes suit product-focused interfaces. Consider the merchant's task and the information density when choosing a size."
       },
       {
-        "title": "Content guidelines",
+        "title": "Limitations",
         "type": "Generic",
-        "anchorLink": "content-guidelines",
-        "sectionContent": "Alternative text should be accurate, concise, and descriptive:\n- Use \"Image of\", \"Photo of\" prefix.\n- Be primary visual content: \"Image of a woman with curly brown hair smiling\".\n- Include relevant emotions: \"Image of a woman laughing with her hand on her face\"."
+        "anchorLink": "limitations",
+        "sectionContent": "- Thumbnails always render as 1:1 squares and will crop non-square images to fit. The component uses center cropping, which might cut off important image details.\n- Images can be loaded from remote URLs or local file resources. Cross-origin images require proper CORS headers from the image host.\n- The component shows a generic placeholder icon when images fail to load or no source is provided. Custom placeholder graphics or branded fallbacks aren't available.\n- Thumbnails don't include built-in lazy loading. In long lists with many thumbnails, all images load immediately, which might impact performance."
       }
     ],
     "definitions": [
       {
         "title": "Properties",
-        "description": "",
+        "description": "Configure the following properties on the thumbnail component.",
         "type": "Thumbnail",
         "typeDefinitions": {
           "Thumbnail": {
@@ -139593,7 +139200,7 @@
       },
       {
         "title": "Events",
-        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ThumbnailEvents",
         "typeDefinitions": {
           "ThumbnailEvents": {
@@ -139743,7 +139350,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TooltipSlots",
         "typeDefinitions": {
           "TooltipSlots": {
@@ -139881,7 +139488,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -140183,7 +139790,7 @@
       },
       {
         "title": "Events",
-        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
+        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "URLFieldEvents",
         "typeDefinitions": {
           "URLFieldEvents": {
@@ -140327,7 +139934,7 @@
     "name": "Unordered list",
     "description": "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list).",
     "category": "Web components",
-    "subCategory": "Layout and structure",
+    "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/unordered-list.png",
     "isVisualComponent": true,
@@ -140348,7 +139955,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "UnorderedListSlots",
         "typeDefinitions": {
           "UnorderedListSlots": {
@@ -140505,7 +140112,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data.json
@@ -1,51 +1,98 @@
 [
   {
-    "name": "App Nav",
+    "name": "App nav",
     "overviewPreviewDescription": "Creates a navigation menu for your app.",
-    "description": "The `s-app-nav` component creates a navigation menu for your app. On desktop web browsers, the navigation menu appears as part of the app nav, on the left of the screen. On Shopify mobile, the navigation menu appears in a dropdown from the TitleBar. This is modeled after the [HTML nav element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav). Note that nested navigation items are not supported.",
+    "description": "The app nav component creates a navigation menu for your app. On desktop, the navigation appears in the app nav on the left side of the screen. On Shopify mobile, it appears in a dropdown from the title bar.\n\nAdd links to define navigation items. You can designate a home route with `rel=\"home\"` to set the default landing page. To trigger navigation from JavaScript code, use the [Navigation API](/docs/api/app-home/apis/navigation).",
     "isVisualComponent": true,
     "category": "App Bridge web components",
     "thumbnail": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/navigation-menu.png",
     "definitions": [
       {
-        "title": "s-app-nav element",
-        "description": "The `s-app-nav` element is available for use in your app. It configures the app nav in the Shopify admin.\n\n You may configure the home route of the app by adding the `rel=\"home\"` attribute to a child element. If it is provided, it will not be rendered as a link in the app nav. It needs to have `rel=\"home\"` set along with the `href` set to the root path.",
+        "title": "Properties",
+        "description": "Properties for the app nav element. This element configures the app nav in the Shopify admin.",
         "type": "SAppNavAttributes",
         "typeDefinitions": {
           "SAppNavAttributes": {
             "filePath": "src/features/s-app-nav.ts",
             "name": "SAppNavAttributes",
-            "description": "",
+            "description": "Attributes for the app nav element. It creates a navigation menu for your app that appears in the app nav sidebar on desktop or in a dropdown from the title bar on Shopify mobile. Commonly used to provide consistent navigation across all pages of your app.",
             "members": [
               {
                 "filePath": "src/features/s-app-nav.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "children",
                 "value": "any",
-                "description": "",
+                "description": "The navigation items to display, provided as link child elements. Each link creates a navigation item in the app's navigation menu. Include one link with `rel=\"home\"` to set the default landing page. Commonly used to organize your app into logical sections (like \"Products\", \"Orders\", or \"Settings\").",
                 "isOptional": true
               }
             ],
-            "value": "export interface SAppNavAttributes {\n  children?: any;\n}"
+            "value": "export interface SAppNavAttributes {\n  /**\n   * The navigation items to display, provided as link child elements. Each link creates a navigation item in the app's navigation menu. Include one link with `rel=\"home\"` to set the default landing page. Commonly used to organize your app into logical sections (like \"Products\", \"Orders\", or \"Settings\").\n   */\n  children?: any;\n}"
+          }
+        }
+      },
+      {
+        "title": "Link properties",
+        "description": "Properties for links used as children.",
+        "type": "SAppNavLinkAttributes",
+        "typeDefinitions": {
+          "SAppNavLinkAttributes": {
+            "filePath": "src/features/s-app-nav.ts",
+            "name": "SAppNavLinkAttributes",
+            "description": "Attributes for link elements used as children of app nav. Each link defines a navigation destination in your app's menu.",
+            "members": [
+              {
+                "filePath": "src/features/s-app-nav.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "children",
+                "value": "string",
+                "description": "The visible label text for the navigation item. Keep labels short (1-2 words) and use nouns that describe the destination (such as \"Products\", \"Settings\", or \"Reports\"). Avoid verbs like \"Manage\" or \"View\" to maintain consistency with Shopify admin navigation patterns.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/features/s-app-nav.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "href",
+                "value": "string",
+                "description": "The URL path for the navigation item. Must be a relative path within your app, such as `/products` or `/settings`. When clicked, it navigates the app to this route without a full page reload. The path should match a route defined in your app's routing configuration."
+              },
+              {
+                "filePath": "src/features/s-app-nav.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rel",
+                "value": "'home'",
+                "description": "Set to `\"home\"` to designate this link as the app's default landing page. When set, the link is hidden from the navigation menu. Only one link should have `rel=\"home\"`.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface SAppNavLinkAttributes {\n  /**\n   * The URL path for the navigation item. Must be a relative path within your app, such as `/products` or `/settings`. When clicked, it navigates the app to this route without a full page reload. The path should match a route defined in your app's routing configuration.\n   */\n  href: string;\n  /**\n   * Set to `\"home\"` to designate this link as the app's default landing page. When set, the link is hidden from the navigation menu. Only one link should have `rel=\"home\"`.\n   */\n  rel?: 'home';\n  /**\n   * The visible label text for the navigation item. Keep labels short (1-2 words) and use nouns that describe the destination (such as \"Products\", \"Settings\", or \"Reports\"). Avoid verbs like \"Manage\" or \"View\" to maintain consistency with Shopify admin navigation patterns.\n   */\n  children?: string;\n}"
           }
         }
       }
     ],
-    "related": [
+    "subSections": [
       {
-        "name": "Navigation API",
-        "subtitle": "React components",
-        "url": "/docs/api/app-home/apis/navigation",
-        "type": "component"
+        "type": "Generic",
+        "anchorLink": "best-practices",
+        "title": "Best practices",
+        "sectionContent": "\n- **Keep navigation concise**: Too many items makes navigation harder to scan. Group related pages or use subpages if you have many sections.\n- **Use clear, concise labels**: Navigation labels should be 1-2 words using nouns, such as \"Settings\", \"Templates\", or \"Reports\".\n- **Order by importance**: Place the most frequently used sections first in the navigation.\n- **Match labels to page titles**: Keep navigation labels consistent with the destination page titles.\n"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "limitations",
+        "title": "Limitations",
+        "sectionContent": "You can't nest navigation items inside other navigation items. Structure your app with a single level of navigation."
       }
     ],
+    "related": [],
     "defaultExample": {
       "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/navigation-menu.png",
+      "description": "Add consistent navigation to your app. This example creates a navigation menu with links and a designated home route using `rel=\"home\"`.",
       "codeblock": {
-        "title": "Navigation Menu",
+        "title": "Navigation menu",
         "tabs": [
           {
-            "code": "&lt;s-app-nav&gt;\n  &lt;s-link href=\"/\" rel=\"home\"&gt;Home&lt;/s-link&gt;\n  &lt;s-link href=\"/templates\"&gt;Templates&lt;/s-link&gt;\n  &lt;s-link href=\"/settings\"&gt;Settings&lt;/s-link&gt;\n&lt;/s-app-nav&gt;\n",
+            "title": "html",
+            "code": "&lt;s-app-nav&gt;\n    &lt;s-link href=\"/\" rel=\"home\"&gt;Home&lt;/s-link&gt;\n    &lt;s-link href=\"/templates\"&gt;Templates&lt;/s-link&gt;\n    &lt;s-link href=\"/settings\"&gt;Settings&lt;/s-link&gt;\n&lt;/s-app-nav&gt;\n",
             "language": "html"
           }
         ]
@@ -53,29 +100,29 @@
     }
   },
   {
-    "name": "App Window",
+    "name": "App window",
     "overviewPreviewDescription": "Displays a fullscreen modal window.",
-    "description": "The `s-app-window` component displays a fullscreen modal window. It allows you to open up a page in your app specified by the `src` property. You can use this when you have larger or complex workflows that you want to display. The app window covers the entirety of the screen. The top bar of the app window is controlled by the admin and allows the user to exit if needed.",
+    "description": "The app window component displays a fullscreen modal window for complex workflows that need dedicated screen space. The content is specified by the `src` property and should point to a route within your app. The app window covers the entire screen, with a top bar controlled by the Shopify admin that allows users to exit.\n\nFor most dialogs, we recommend using the [Polaris modal component](/docs/api/app-home/polaris-web-components/overlays/modal), which automatically determines whether the modal should display inside your app or as a fullscreen overlay and removes the need for separate App Bridge API control.",
     "isVisualComponent": true,
     "category": "App Bridge web components",
     "thumbnail": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/s-app-window.png",
     "definitions": [
       {
-        "title": "s-app-window element",
-        "description": "The `s-app-window` element is available for use in your app. It configures a App Window to display in the Shopify Admin.\n\nThe content of the app window is specified by the src property and should point to a route within your app.",
+        "title": "Properties",
+        "description": "Attributes for the app window element. This element displays a fullscreen modal window in the Shopify admin.",
         "type": "SAppWindowAttributes",
         "typeDefinitions": {
           "SAppWindowAttributes": {
             "filePath": "src/features/s-app-window.ts",
             "name": "SAppWindowAttributes",
-            "description": "",
+            "description": "Attributes for the app window element. Displays a fullscreen modal window for complex workflows that need dedicated screen space.",
             "members": [
               {
                 "filePath": "src/features/s-app-window.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": "A unique identifier for the S-App-Window",
+                "description": "A unique identifier you assign to the app window element. Used when connecting buttons via `commandFor` or accessing the element with `document.getElementById()`. Choose a descriptive name like `\"settings-window\"` or `\"edit-modal\"`.",
                 "isOptional": true
               },
               {
@@ -83,44 +130,37 @@
                 "syntaxKind": "PropertySignature",
                 "name": "src",
                 "value": "string",
-                "description": "The URL of the content to display within the S-App-Window. S-App-Window only supports src-based content (required)."
+                "description": "The URL of the content to display within the app window. Must point to a route within your app that renders the window content. The URL is loaded in an iframe when the window opens. Commonly used for multi-step workflows, bulk editors, or detailed views that need full-screen space."
               }
             ],
-            "value": "export interface SAppWindowAttributes {\n  /**\n   * A unique identifier for the S-App-Window\n   */\n  id?: string;\n  /**\n   * The URL of the content to display within the S-App-Window.\n   * S-App-Window only supports src-based content (required).\n   */\n  src: string;\n}"
+            "value": "export interface SAppWindowAttributes {\n  /**\n   * A unique identifier you assign to the app window element. Used when connecting buttons via `commandFor` or accessing the element with `document.getElementById()`. Choose a descriptive name like `\"settings-window\"` or `\"edit-modal\"`.\n   */\n  id?: string;\n  /**\n   * The URL of the content to display within the app window. Must point to a route within your app that renders the window content. The URL is loaded in an iframe when the window opens. Commonly used for multi-step workflows, bulk editors, or detailed views that need full-screen space.\n   */\n  src: string;\n}"
           }
         }
       },
       {
-        "title": "s-app-window instance",
-        "description": "The `s-app-window` element provides instance properties and methods to control the App Window.",
+        "title": "Instance methods",
+        "description": "Instance properties and methods available on the app window element for programmatic control.",
         "type": "_SAppWindowElement",
         "typeDefinitions": {
           "_SAppWindowElement": {
             "filePath": "src/features/s-app-window.ts",
             "name": "_SAppWindowElement",
-            "description": "",
+            "description": "Instance properties and methods for the app window element. Use these to programmatically control the app window.",
             "members": [
               {
                 "filePath": "src/features/s-app-window.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "addEventListener",
                 "value": "(type: \"show\" | \"hide\", listener: EventListenerOrEventListenerObject) => void",
-                "description": "Add 'show' | 'hide' event listeners.",
+                "description": "Adds an event listener for app window lifecycle events. Supported events: `show` fires when the window opens, `hide` fires when the window closes. Commonly used for tracking analytics, updating UI state, or cleaning up resources when the window closes.",
                 "isOptional": true
-              },
-              {
-                "filePath": "src/features/s-app-window.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "content",
-                "value": "undefined",
-                "description": "Always returns undefined for s-app-window (src-only)"
               },
               {
                 "filePath": "src/features/s-app-window.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "contentWindow",
                 "value": "Window | null",
-                "description": "A getter for the Window object of the s-app-window iframe. Only accessible when the s-app-window is open.",
+                "description": "Returns the Window object of the app window iframe, or `null` if the window is closed. Use this to communicate with the iframe content via `postMessage()` or access its document. Only accessible when the app window is open.",
                 "isOptional": true
               },
               {
@@ -128,7 +168,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "hide",
                 "value": "() => Promise<void>",
-                "description": "Hides the s-app-window element",
+                "description": "Closes the app window. Returns a Promise that resolves when the window is fully hidden. Any unsaved changes in forms with `data-save-bar` will prompt the user before closing. Commonly used for programmatic close after completing a workflow.",
                 "isOptional": true
               },
               {
@@ -136,7 +176,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "removeEventListener",
                 "value": "(type: \"show\" | \"hide\", listener: EventListenerOrEventListenerObject) => void",
-                "description": "Remove 'show' | 'hide' event listeners.",
+                "description": "Removes a previously added event listener. Pass the same event type and listener function that was used with `addEventListener()`. Commonly used for cleanup when a component unmounts to prevent memory leaks.",
                 "isOptional": true
               },
               {
@@ -144,7 +184,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "show",
                 "value": "() => Promise<void>",
-                "description": "Shows the s-app-window element",
+                "description": "Opens the app window and displays the content from the `src` URL. Returns a Promise that resolves when the window is fully visible. Use `await` or `.then()` to run code after the window opens. Commonly used for launching workflows triggered by user actions.",
                 "isOptional": true
               },
               {
@@ -152,7 +192,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "src",
                 "value": "string",
-                "description": "A getter/setter for the s-app-window src URL",
+                "description": "Gets or sets the URL of the content displayed in the app window. Changing this value while the window is open navigates to the new URL. Commonly used for dynamic navigation within an open window.",
                 "isOptional": true
               },
               {
@@ -160,64 +200,79 @@
                 "syntaxKind": "MethodSignature",
                 "name": "toggle",
                 "value": "() => Promise<void>",
-                "description": "Toggles the s-app-window element between showing and hidden states",
+                "description": "Toggles the app window between open and closed states. Returns a Promise that resolves when the transition completes. Opens the window if closed, closes it if open. Commonly used for toggle buttons that control window visibility.",
                 "isOptional": true
               }
             ],
-            "value": "interface _SAppWindowElement {\n  /**\n   * Always returns undefined for s-app-window (src-only)\n   */\n  readonly content: undefined;\n  /**\n   * A getter/setter for the s-app-window src URL\n   */\n  src?: string;\n  /**\n   * A getter for the Window object of the s-app-window iframe.\n   * Only accessible when the s-app-window is open.\n   */\n  readonly contentWindow?: Window | null;\n  /**\n   * Shows the s-app-window element\n   */\n  show?(): Promise<void>;\n  /**\n   * Hides the s-app-window element\n   */\n  hide?(): Promise<void>;\n  /**\n   * Toggles the s-app-window element between showing and hidden states\n   */\n  toggle?(): Promise<void>;\n  /**\n   * Add 'show' | 'hide' event listeners.\n   */\n  addEventListener?(\n    type: 'show' | 'hide',\n    listener: EventListenerOrEventListenerObject,\n  ): void;\n  /**\n   * Remove 'show' | 'hide' event listeners.\n   */\n  removeEventListener?(\n    type: 'show' | 'hide',\n    listener: EventListenerOrEventListenerObject,\n  ): void;\n}"
+            "value": "interface _SAppWindowElement {\n  /**\n   * Gets or sets the URL of the content displayed in the app window. Changing this value while the window is open navigates to the new URL. Commonly used for dynamic navigation within an open window.\n   */\n  src?: string;\n  /**\n   * Returns the Window object of the app window iframe, or `null` if the window is closed. Use this to communicate with the iframe content via `postMessage()` or access its document. Only accessible when the app window is open.\n   */\n  readonly contentWindow?: Window | null;\n  /**\n   * Opens the app window and displays the content from the `src` URL. Returns a Promise that resolves when the window is fully visible. Use `await` or `.then()` to run code after the window opens. Commonly used for launching workflows triggered by user actions.\n   */\n  show?(): Promise<void>;\n  /**\n   * Closes the app window. Returns a Promise that resolves when the window is fully hidden. Any unsaved changes in forms with `data-save-bar` will prompt the user before closing. Commonly used for programmatic close after completing a workflow.\n   */\n  hide?(): Promise<void>;\n  /**\n   * Toggles the app window between open and closed states. Returns a Promise that resolves when the transition completes. Opens the window if closed, closes it if open. Commonly used for toggle buttons that control window visibility.\n   */\n  toggle?(): Promise<void>;\n  /**\n   * Adds an event listener for app window lifecycle events. Supported events: `show` fires when the window opens, `hide` fires when the window closes. Commonly used for tracking analytics, updating UI state, or cleaning up resources when the window closes.\n   */\n  addEventListener?(\n    type: 'show' | 'hide',\n    listener: EventListenerOrEventListenerObject,\n  ): void;\n  /**\n   * Removes a previously added event listener. Pass the same event type and listener function that was used with `addEventListener()`. Commonly used for cleanup when a component unmounts to prevent memory leaks.\n   */\n  removeEventListener?(\n    type: 'show' | 'hide',\n    listener: EventListenerOrEventListenerObject,\n  ): void;\n}"
           }
         }
       }
     ],
+    "subSections": [
+      {
+        "type": "Generic",
+        "anchorLink": "best-practices",
+        "title": "Best practices",
+        "sectionContent": "\n- **Open only via explicit user action**: Launch app windows from buttons that clearly indicate a fullscreen experience will open. Never open automatically on page load.\n- **Set descriptive titles**: Use the [page component](/docs/api/app-home/app-bridge-web-components/title-bar) inside your app window content to set a heading that clearly describes the current task.\n- **Handle unsaved changes**: Add `data-save-bar` to forms to automatically prompt merchants before they exit with unsaved changes. See [Save Bar API](/docs/api/app-home/apis/save-bar).\n- **Return to context on close**: Ensure closing the app window returns merchants to where they started. Don't navigate them elsewhere unexpectedly.\n"
+      }
+    ],
     "defaultExample": {
-      "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/s-app-window.png",
+      "description": "Open a fullscreen modal for complex workflows. This example uses the [`command`](/docs/api/app-home/polaris-web-components/actions/button#properties-propertydetail-command) attribute on a button to toggle the app window.",
+      "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-show-hide.png",
       "codeblock": {
-        "title": "App Window",
+        "title": "Show and hide",
         "tabs": [
           {
-            "title": "App Window",
-            "code": "&lt;s-app-window id=\"app-window\" src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n&lt;s-button command=\"--show\" commandFor=\"app-window\"&gt;Open App Window&lt;/s-button&gt;\n\n",
+            "title": "html",
+            "code": "&lt;s-app-window id=\"app-window\" src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n&lt;s-button command=\"--show\" commandFor=\"app-window\"&gt;Open App Window&lt;/s-button&gt;\n&lt;s-button command=\"--hide\" commandFor=\"app-window\"&gt;Close App Window&lt;/s-button&gt;\n\n",
             "language": "html"
           }
         ]
       }
     },
     "examples": {
-      "description": "App Window title bar options",
+      "description": "",
       "exampleGroups": [
         {
-          "title": "App Window title bar options",
+          "title": "",
           "examples": [
             {
-              "description": "App Window title",
+              "description": "Add context to fullscreen workflows. This example sets a title using the page component with the `heading` attribute.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-title-bar-heading.png",
               "codeblock": {
                 "title": "Title bar heading",
                 "tabs": [
                   {
-                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"App Window Title\"&gt;&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"Product editor\"&gt;&lt;/s-page&gt;\n",
                     "language": "html"
                   }
                 ]
               }
             },
             {
-              "description": "App Window title bar actions",
+              "description": "Provide actions in fullscreen workflows. This example adds primary and secondary action buttons to the title bar using page slots.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-title-bar-actions.png",
               "codeblock": {
                 "title": "Title bar actions",
                 "tabs": [
                   {
-                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"App Window Title\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Close')\"&gt;Close&lt;/s-button&gt;\n&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"Product editor\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Preview')\"&gt;Preview&lt;/s-button&gt;\n&lt;/s-page&gt;",
                     "language": "html"
                   }
                 ]
               }
             },
             {
-              "description": "Display a status badge in the title bar using the accessory slot. The `tone` attribute controls the badge color (`info`, `success`, `warning`, or `critical`).",
+              "description": "Show status in fullscreen workflows. This example displays a status badge using the `accessory` slot with `tone` for color.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-title-bar-accessory-badge.png",
               "codeblock": {
                 "title": "Title bar accessory badge",
                 "tabs": [
                   {
+                    "title": "html",
                     "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"Edit Product\"&gt;\n  &lt;s-badge slot=\"accessory\" tone=\"warning\"&gt;Draft&lt;/s-badge&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
@@ -225,12 +280,14 @@
               }
             },
             {
-              "description": "Add icons to action buttons and use `commandfor` to create dropdown menus. Menu buttons support the `tone` attribute for destructive actions.",
+              "description": "Add icons and dropdown menus to actions. This example pairs icon buttons with [`commandFor`](/docs/api/app-home/polaris-web-components/actions/button#properties-propertydetail-commandFor) to create dropdown menus.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-title-bar-icons-menus.png",
               "codeblock": {
-                "title": "Icons and menu actions",
+                "title": "Title bar icons and menus",
                 "tabs": [
                   {
-                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"Product Details\"&gt;\n  &lt;s-button slot=\"primary-action\" icon=\"save\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"view\"&gt;Preview&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" commandfor=\"actions-menu\" icon=\"menu\"&gt;More&lt;/s-button&gt;\n  &lt;s-menu id=\"actions-menu\"&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive&lt;/s-button&gt;\n    &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"Product Details\"&gt;\n  &lt;s-button slot=\"primary-action\" icon=\"save\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" commandFor=\"actions-menu\" icon=\"menu\"&gt;More actions&lt;/s-button&gt;\n  &lt;s-menu id=\"actions-menu\"&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive&lt;/s-button&gt;\n    &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
                 ]
@@ -239,14 +296,16 @@
           ]
         },
         {
-          "title": "Controlling the App Window",
+          "title": "",
           "examples": [
             {
-              "description": "Controlling the App Window with the show and hide methods",
+              "description": "Control the app window programmatically. This example calls the `show()`, `hide()`, and `toggle()` methods.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-instance-methods.png",
               "codeblock": {
                 "title": "Instance methods",
                 "tabs": [
                   {
+                    "title": "html",
                     "code": "&lt;s-app-window id=\"app-window\" src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n&lt;s-button onclick=\"document.getElementById('app-window').show()\"&gt;Show App Window&lt;/s-button&gt;\n&lt;s-button onclick=\"document.getElementById('app-window').hide()\"&gt;Hide App Window&lt;/s-button&gt;\n",
                     "language": "html"
                   }
@@ -254,11 +313,13 @@
               }
             },
             {
-              "description": "Controlling the App Window with the command attribute",
+              "description": "Control the app window declaratively. This example uses the [`command`](/docs/api/app-home/polaris-web-components/actions/button#properties-propertydetail-command) and [`commandFor`](/docs/api/app-home/polaris-web-components/actions/button#properties-propertydetail-commandFor) attributes on buttons.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-command-attribute.png",
               "codeblock": {
                 "title": "Command attribute",
                 "tabs": [
                   {
+                    "title": "html",
                     "code": "&lt;s-app-window id=\"app-window\" src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n&lt;s-button command=\"--show\" commandFor=\"app-window\"&gt;Open App Window&lt;/s-button&gt;\n&lt;s-button command=\"--hide\" commandFor=\"app-window\"&gt;Hide App Window&lt;/s-button&gt;\n&lt;s-button command=\"--toggle\" commandFor=\"app-window\"&gt;Toggle App Window&lt;/s-button&gt;\n",
                     "language": "html"
                   }
@@ -268,15 +329,17 @@
           ]
         },
         {
-          "title": "Forms and Save Bar",
+          "title": "",
           "examples": [
             {
-              "description": "Forms with the `data-save-bar` attribute automatically integrate with the save bar. Changes to form inputs are tracked and the save bar appears when there are unsaved changes.",
+              "description": "Prevent data loss in fullscreen forms. This example integrates the save bar using `data-save-bar` to track unsaved changes.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/app-window-form-with-save-bar.png",
               "codeblock": {
                 "title": "Form with save bar",
                 "tabs": [
                   {
-                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"Edit Settings\"&gt;\n  &lt;s-button slot=\"primary-action\" type=\"submit\" form=\"settings-form\"&gt;Save&lt;/s-button&gt;\n  &lt;form id=\"settings-form\" data-save-bar&gt;\n    &lt;s-text-field label=\"Store Name\" name=\"storeName\"&gt;&lt;/s-text-field&gt;\n    &lt;s-checkbox label=\"Enable Notifications\" name=\"notifications\"&gt;&lt;/s-checkbox&gt;\n  &lt;/form&gt;\n&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-app-window src=\"/app-window-content.html\"&gt;&lt;/s-app-window&gt;\n\n// app-window-content.html\n&lt;s-page heading=\"Product editor\"&gt;\n  &lt;form id=\"settings-form\" data-save-bar&gt;\n    &lt;s-text-field label=\"Product title\" name=\"productTitle\"&gt;&lt;/s-text-field&gt;\n    &lt;s-text-area label=\"Description\" name=\"description\"&gt;&lt;/s-checkbox&gt;\n  &lt;/form&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
                 ]
@@ -286,39 +349,46 @@
         }
       ]
     },
-    "related": [
-      {
-        "name": "Modal",
-        "subtitle": "API",
-        "url": "/docs/api/app-home/apis/modal-api",
-        "type": "api"
-      }
-    ]
+    "related": []
   },
   {
-    "name": "Forms",
+    "name": "Save bar",
     "overviewPreviewDescription": "Automatically manage save state for forms in your app.",
-    "description": "Enable automatic save bar integration for HTML forms by adding the `data-save-bar` attribute to your form element. When form data changes, a save bar automatically appears, prompting users to save or discard their changes.\n\nAlternatively, use the global `shopify.saveBar` API for programmatic control over the save bar behavior. Programmatic control of the save bar is available as `shopify.saveBar.show()`, `shopify.saveBar.hide()`, and `shopify.saveBar.toggle()`.\n\n**Note:** The save bar functionality requires the full App Bridge UI library to be loaded via a [script tag](/docs/api/app-home/using-polaris-components).",
-    "isVisualComponent": false,
+    "description": "Enable automatic save bar integration for HTML forms by adding the `data-save-bar` attribute to your form element. When form data changes, a save bar automatically appears, prompting users to save or discard their changes.\n\nAlternatively, use the [Save Bar API](/docs/api/app-home/apis/save-bar) for programmatic control over the save bar behavior. Programmatic control is available as `shopify.saveBar.show()`, `shopify.saveBar.hide()`, and `shopify.saveBar.toggle()`.\n\n**Note:** The save bar functionality requires the full App Bridge UI library to be loaded via a [script tag](/docs/api/app-home/using-polaris-components).",
+    "isVisualComponent": true,
     "category": "App Bridge web components",
     "thumbnail": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/forms.png",
+    "subSections": [
+      {
+        "type": "Generic",
+        "anchorLink": "best-practices",
+        "title": "Best practices",
+        "sectionContent": "\n- **Always provide discard functionality**: Allow merchants to revert changes by handling the discard action or using form reset.\n- **Show loading states during save**: Use the [Loading API](/docs/api/app-home/apis/loading) to indicate when an async save operation is in progress.\n- **Use `data-discard-confirmation` for destructive forms**: Add a confirmation dialog when discarding changes would result in significant data loss.\n"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "limitations",
+        "title": "Limitations",
+        "sectionContent": "`data-save-bar` isn't supported inside modals. Forms inside modals should use the [Save Bar API](/docs/api/app-home/apis/save-bar) programmatically if save or discard functionality is needed."
+      }
+    ],
     "definitions": [
       {
-        "title": "Enable save bar on forms",
-        "description": "Simply add `data-save-bar` to your `<form>` element:\n```html\n<form data-save-bar>\n  <!-- Your form fields -->\n</form>\n```\n",
+        "title": "Attributes",
+        "description": "Add these attributes to your `<form>` element to enable save bar integration.",
         "type": "_FormElement",
         "typeDefinitions": {
           "_FormElement": {
             "filePath": "src/features/save-bar.ts",
             "name": "_FormElement",
-            "description": "",
+            "description": "Attributes for HTML form elements that integrate with the save bar.",
             "members": [
               {
                 "filePath": "src/features/save-bar.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "data-discard-confirmation",
                 "value": "boolean",
-                "description": "",
+                "description": "Shows a confirmation dialog when the discard button is clicked, requiring merchants to confirm before losing their changes. The dialog prevents accidental data loss by adding a second step before reset. Commonly used for forms with significant data entry, multi-step workflows, or when changes cannot be easily recreated.",
                 "isOptional": true
               },
               {
@@ -326,7 +396,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "data-save-bar",
                 "value": "boolean",
-                "description": "",
+                "description": "Enables automatic save bar integration. When present, the save bar appears whenever any form input value changes from its initial state. The save bar automatically hides when the form is submitted or reset. Commonly used for settings pages, product editors, or any form where merchants need visual feedback about unsaved changes.",
                 "isOptional": true
               },
               {
@@ -334,7 +404,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onreset",
                 "value": "(event: Event) => void",
-                "description": "",
+                "description": "Handler called when the form is reset via the save bar's discard button. Receives a standard `Event` that can be prevented with `event.preventDefault()` for custom discard logic. Commonly used for reverting form fields to their original values, clearing temporary state, or confirming discard actions programmatically.",
                 "isOptional": true
               },
               {
@@ -342,78 +412,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onsubmit",
                 "value": "(event: SubmitEvent) => void",
-                "description": "",
+                "description": "Handler called when the form is submitted via the save bar's save button. Receives a standard `SubmitEvent` that can be prevented with `event.preventDefault()` for custom async save logic. Commonly used for API calls to persist data, form validation before save, or showing success/error toasts after the operation completes.",
                 "isOptional": true
               }
             ],
-            "value": "export interface _FormElement {\n  'data-save-bar'?: boolean;\n  'data-discard-confirmation'?: boolean;\n  onsubmit?: (event: SubmitEvent) => void;\n  onreset?: (event: Event) => void;\n}"
+            "value": "export interface _FormElement {\n  /**\n   * Enables automatic save bar integration. When present, the save bar appears whenever any form input value changes from its initial state. The save bar automatically hides when the form is submitted or reset. Commonly used for settings pages, product editors, or any form where merchants need visual feedback about unsaved changes.\n   */\n  'data-save-bar'?: boolean;\n  /**\n   * Shows a confirmation dialog when the discard button is clicked, requiring merchants to confirm before losing their changes. The dialog prevents accidental data loss by adding a second step before reset. Commonly used for forms with significant data entry, multi-step workflows, or when changes cannot be easily recreated.\n   */\n  'data-discard-confirmation'?: boolean;\n  /**\n   * Handler called when the form is submitted via the save bar's save button. Receives a standard `SubmitEvent` that can be prevented with `event.preventDefault()` for custom async save logic. Commonly used for API calls to persist data, form validation before save, or showing success/error toasts after the operation completes.\n   */\n  onsubmit?: (event: SubmitEvent) => void;\n  /**\n   * Handler called when the form is reset via the save bar's discard button. Receives a standard `Event` that can be prevented with `event.preventDefault()` for custom discard logic. Commonly used for reverting form fields to their original values, clearing temporary state, or confirming discard actions programmatically.\n   */\n  onreset?: (event: Event) => void;\n}"
           }
         }
       }
     ],
-    "related": [
-      {
-        "name": "Save Bar",
-        "subtitle": "API",
-        "url": "/docs/api/app-home/apis/save-bar",
-        "type": "api"
-      }
-    ],
+    "related": [],
     "defaultExample": {
-      "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/forms-alt.png",
+      "description": "Add the `data-save-bar` attribute to a form to automatically show a save bar when form data changes.",
+      "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/save-bar-form.png",
       "codeblock": {
         "title": "Form with automatic save bar",
         "tabs": [
           {
-            "code": "&lt;form data-save-bar&gt;\n  &lt;s-text-field\n    label=\"Product Title\"\n    name=\"title\"\n    required\n  &gt;&lt;/s-text-field&gt;\n\n  &lt;s-text-area\n    label=\"Description\"\n    name=\"description\"\n    rows=\"4\"\n  &gt;&lt;/s-text-area&gt;\n\n  &lt;s-text-field\n    label=\"Price\"\n    name=\"price\"\n    type=\"number\"\n    step=\"0.01\"\n    min=\"0\"\n  &gt;&lt;/s-text-field&gt;\n&lt;/form&gt;\n",
+            "title": "html",
+            "code": "&lt;form data-save-bar&gt;\n  &lt;s-text-field\n    label=\"Product Title\"\n    name=\"title\"\n    required\n  &gt;&lt;/s-text-field&gt;\n\n  &lt;s-text-area\n    label=\"Description\"\n    name=\"description\"\n    rows=\"4\"\n  &gt;&lt;/s-text-area&gt;\n\n  &lt;s-text-field\n    label=\"Price\"\n    name=\"price\"\n    type=\"number\"\n    step=\"0.01\"\n    min=\"0\"\n  &gt;&lt;/s-text-field&gt;\n&lt;/form&gt;",
             "language": "html"
           }
         ]
       }
     },
     "examples": {
-      "description": "Quick examples of using the save bar with forms.",
-      "exampleGroups": [
+      "description": "Examples of save bar integration with forms.",
+      "examples": [
         {
-          "title": "Form integration examples",
-          "examples": [
-            {
-              "description": "Basic form with automatic save bar functionality.",
-              "codeblock": {
-                "title": "Simple form with save bar",
-                "tabs": [
-                  {
-                    "code": "&lt;form data-save-bar&gt;\n  &lt;s-text-field\n    label=\"Product Title\"\n    name=\"title\"\n    required\n  &gt;&lt;/s-text-field&gt;\n\n  &lt;s-text-area\n    label=\"Description\"\n    name=\"description\"\n    rows=\"4\"\n  &gt;&lt;/s-text-area&gt;\n\n  &lt;s-text-field\n    label=\"Price\"\n    name=\"price\"\n    type=\"number\"\n    step=\"0.01\"\n    min=\"0\"\n  &gt;&lt;/s-text-field&gt;\n&lt;/form&gt;\n",
-                    "language": "html"
-                  }
-                ]
+          "description": "Handle form submission and reset using standard HTML form events.",
+          "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/save-bar-reset-handlers.png",
+          "codeblock": {
+            "title": "Submit and reset handlers",
+            "tabs": [
+              {
+                "title": "html",
+                "code": "&lt;form\n  data-save-bar\n  onsubmit=\"console.log('submit');\"\n  onreset=\"console.log('reset');\"\n&gt;\n  &lt;s-text-field label=\"Name\" name=\"name\"&gt;&lt;/s-text-field&gt;\n  &lt;s-button type=\"submit\"&gt;Submit&lt;/s-button&gt;\n  &lt;s-button type=\"reset\"&gt;Reset&lt;/s-button&gt;\n&lt;/form&gt;",
+                "language": "html"
               }
-            },
-            {
-              "description": "Using the programmatic API for custom save logic.",
-              "codeblock": {
-                "title": "Programmatic save bar control",
-                "tabs": [
-                  {
-                    "code": "&lt;form id=\"custom-form\"&gt;\n  &lt;s-text-field\n    id=\"settings-name\"\n    label=\"Store Name\"\n  &gt;&lt;/s-text-field&gt;\n\n  &lt;s-checkbox\n    id=\"settings-notifications\"\n    label=\"Enable email notifications\"\n  &gt;&lt;/s-checkbox&gt;\n&lt;/form&gt;\n\n&lt;script&gt;\n  // Track form changes manually\n  const form = document.getElementById('custom-form');\n  let hasChanges = false;\n\n  form.addEventListener('input', () =&gt; {\n    if (!hasChanges) {\n      hasChanges = true;\n      // Show save bar programmatically\n      shopify.saveBar.show({\n        onSave: async () =&gt; {\n          // Custom save logic\n          console.log('Saving form data...');\n          // Simulate API call\n          await new Promise(resolve =&gt; setTimeout(resolve, 1000));\n          hasChanges = false;\n          shopify.saveBar.hide();\n        },\n        onDiscard: () =&gt; {\n          // Reset form\n          form.reset();\n          hasChanges = false;\n          shopify.saveBar.hide();\n        }\n      });\n    }\n  });\n&lt;/script&gt;\n",
-                    "language": "html"
-                  }
-                ]
+            ]
+          }
+        },
+        {
+          "description": "Add `data-discard-confirmation` to show a confirmation dialog when the discard button is clicked, preventing accidental data loss.",
+          "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/save-bar-discard-confirmation.png",
+          "codeblock": {
+            "title": "Discard confirmation",
+            "tabs": [
+              {
+                "title": "html",
+                "code": "&lt;form data-save-bar data-discard-confirmation&gt;\n  &lt;s-text-field\n    label=\"Store Name\"\n    name=\"storeName\"\n    required\n  &gt;&lt;/s-text-field&gt;\n\n  &lt;s-text-area\n    label=\"Store Description\"\n    name=\"description\"\n    rows=\"4\"\n  &gt;&lt;/s-text-area&gt;\n\n  &lt;s-checkbox\n    label=\"Enable notifications\"\n    name=\"notifications\"\n  &gt;&lt;/s-checkbox&gt;\n&lt;/form&gt;\n",
+                "language": "html"
               }
-            },
-            {
-              "description": "Using the onsubmit and onreset events to handle form submission and reset.",
-              "codeblock": {
-                "title": "Form with onsubmit and onreset events",
-                "tabs": [
-                  {
-                    "code": "&lt;form\n  data-save-bar\n  onsubmit=\"console.log('submit');\"\n  onreset=\"console.log('reset');\"\n&gt;\n  &lt;s-text-field label=\"Name\" name=\"name\"&gt;&lt;/s-text-field&gt;\n  &lt;s-button type=\"submit\"&gt;Submit&lt;/s-button&gt;\n  &lt;s-button type=\"reset\"&gt;Reset&lt;/s-button&gt;\n&lt;/form&gt;\n",
-                    "language": "html"
-                  }
-                ]
-              }
-            }
-          ]
+            ]
+          }
         }
       ]
     }
@@ -421,27 +473,41 @@
   {
     "name": "Title bar",
     "overviewPreviewDescription": "Manage the title bar for your app.",
-    "description": "The admin title bar is a critical part of the Shopify Admin experience. It provides a way to display the current page title and actions for the user to take. This guide will show you how to work with the admin title bar using the App Bridge UI library.",
+    "description": "The page component lets you customize the title bar that appears at the top of your embedded app. Use it to display the current page context, provide action buttons for saving or canceling changes, and add breadcrumb links for navigation. The title bar helps merchants understand where they are in your app and what actions they can take.\n\nUse this component when you need to set the admin's native title bar (title, breadcrumbs, actions) without a styled page layout. For apps that need a complete page layout with Polaris styling, use the [Polaris page component](/docs/api/app-home/polaris-web-components/layout-and-structure/page) instead.\n\nTo trigger navigation programmatically (such as navigating after a user action), use the [Navigation API](/docs/api/app-home/apis/navigation).",
     "isVisualComponent": true,
     "category": "App Bridge web components",
     "thumbnail": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/title-bar-app-home-alt.png",
+    "subSections": [
+      {
+        "type": "Generic",
+        "anchorLink": "best-practices",
+        "title": "Best practices",
+        "sectionContent": "\n- **Use descriptive headings**: The page heading should clearly describe the current context.\n- **Limit primary actions**: Only one primary action per page for clear hierarchy.\n- **Group related secondary actions**: Use `s-menu` with [`commandfor`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/commandForElement) to group related actions in dropdowns.\n- **Use breadcrumbs for navigation**: Help users understand where they are and how to go back.\n- **Add status badges when relevant**: Use the `accessory` slot with `s-badge` to show page status.\n"
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "limitations",
+        "title": "Limitations",
+        "sectionContent": "Anchor tags (`<a>`) aren't supported in Remix apps. Use Remix's `<Link>` component instead."
+      }
+    ],
     "definitions": [
       {
-        "title": "Use the s-page component",
-        "description": "The `s-page` component is available for use in your app. It configures the title bar in the Shopify admin in addition to managing the page layout.\n      Note that you do not need the full App Bridge UI library to use this component. You can still use `s-page` (and its required child components) in your app.",
+        "title": "Properties",
+        "description": "Properties for the page element. This element configures the title bar in the Shopify admin.",
         "type": "SPageElement",
         "typeDefinitions": {
           "SPageElement": {
             "filePath": "src/features/title-bar.ts",
             "name": "SPageElement",
-            "description": "",
+            "description": "The page component configures the title bar in the Shopify admin. Use it to display page context, provide action buttons, and add navigation breadcrumbs.",
             "members": [
               {
                 "filePath": "src/features/title-bar.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "children",
                 "value": "SPageChildren",
-                "description": "",
+                "description": "Child elements that populate the title bar slots. Use slots to add action buttons, breadcrumb navigation, and status badges to the title bar.",
                 "isOptional": true
               },
               {
@@ -449,23 +515,31 @@
                 "syntaxKind": "PropertySignature",
                 "name": "heading",
                 "value": "string",
-                "description": "",
+                "description": "The page title displayed in the title bar. Use a clear, descriptive heading that helps merchants understand the current context, such as \"Edit Product\" or \"Order #1234\".",
                 "isOptional": true
               }
             ],
-            "value": "export interface SPageElement {\n  heading?: string;\n  children?: SPageChildren;\n}"
+            "value": "export interface SPageElement {\n  /**\n   * The page title displayed in the title bar. Use a clear, descriptive heading that\n   * helps merchants understand the current context, such as \"Edit Product\" or \"Order #1234\".\n   */\n  heading?: string;\n  /**\n   * Child elements that populate the title bar slots. Use slots to add action buttons,\n   * breadcrumb navigation, and status badges to the title bar.\n   */\n  children?: SPageChildren;\n}"
           },
           "SPageChildren": {
             "filePath": "src/features/title-bar.ts",
             "name": "SPageChildren",
-            "description": "",
+            "description": "Available slots for the page component. Each slot accepts specific elements that appear in designated areas of the title bar.",
             "members": [
+              {
+                "filePath": "src/features/title-bar.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "accessory",
+                "value": "HTMLElement",
+                "description": "A status badge displayed next to the page heading. Use to indicate page state such as \"Draft\", \"Published\", or \"Archived\". Use `slot=\"accessory\"` on an `s-badge` element with a `tone` attribute (`info`, `success`, `warning`, or `critical`) to convey status.",
+                "isOptional": true
+              },
               {
                 "filePath": "src/features/title-bar.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "breadcrumbActions",
                 "value": "HTMLElement",
-                "description": "",
+                "description": "A navigation link that appears before the page heading, typically used for \"Back\" navigation. Helps merchants understand their location and return to parent pages. Use `slot=\"breadcrumb-actions\"` on a Link element with an `href` attribute.",
                 "isOptional": true
               },
               {
@@ -473,7 +547,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "primaryAction",
                 "value": "HTMLElement",
-                "description": "",
+                "description": "The main call-to-action button, typically \"Save\" or \"Create\". Appears prominently on the right side of the title bar. Only one primary action should be used per page to maintain clear visual hierarchy. Use `slot=\"primary-action\"` on an `s-button` element.",
                 "isOptional": true
               },
               {
@@ -481,48 +555,31 @@
                 "syntaxKind": "PropertySignature",
                 "name": "secondaryActions",
                 "value": "HTMLElement[]",
-                "description": "",
+                "description": "Additional action buttons that appear next to the primary action. Use for secondary operations like \"Cancel\", \"Delete\", or grouped actions using `s-menu`. Multiple buttons can be added. Use `slot=\"secondary-actions\"` on `s-button` elements. For dropdown menus, combine with [`commandFor`](/docs/api/app-home/polaris-web-components/actions/button#properties-propertydetail-commandFor) attribute and an `s-menu` element.",
                 "isOptional": true
               }
             ],
-            "value": "interface SPageChildren {\n  primaryAction?: HTMLElement;\n  secondaryActions?: HTMLElement[];\n  breadcrumbActions?: HTMLElement;\n}"
+            "value": "interface SPageChildren {\n  /**\n   * The main call-to-action button, typically \"Save\" or \"Create\". Appears prominently\n   * on the right side of the title bar. Only one primary action should be used per page\n   * to maintain clear visual hierarchy. Use `slot=\"primary-action\"` on an `s-button` element.\n   */\n  primaryAction?: HTMLElement;\n  /**\n   * Additional action buttons that appear next to the primary action. Use for secondary\n   * operations like \"Cancel\", \"Delete\", or grouped actions using `s-menu`. Multiple buttons\n   * can be added. Use `slot=\"secondary-actions\"` on `s-button` elements. For dropdown menus,\n   * combine with [`commandFor`](/docs/api/app-home/polaris-web-components/actions/button#properties-propertydetail-commandFor) attribute and an `s-menu` element.\n   */\n  secondaryActions?: HTMLElement[];\n  /**\n   * A navigation link that appears before the page heading, typically used for \"Back\"\n   * navigation. Helps merchants understand their location and return to parent pages.\n   * Use `slot=\"breadcrumb-actions\"` on a Link element with an `href` attribute.\n   */\n  breadcrumbActions?: HTMLElement;\n  /**\n   * A status badge displayed next to the page heading. Use to indicate page state such as\n   * \"Draft\", \"Published\", or \"Archived\". Use `slot=\"accessory\"` on an `s-badge` element\n   * with a `tone` attribute (`info`, `success`, `warning`, or `critical`) to convey status.\n   */\n  accessory?: HTMLElement;\n}"
           }
         }
       }
     ],
-    "related": [
-      {
-        "name": "Navigation",
-        "subtitle": "API",
-        "url": "/docs/api/app-home/apis/navigation",
-        "type": "api"
-      }
-    ],
-    "defaultExample": {
-      "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/title-bar-app-home.png",
-      "codeblock": {
-        "title": "Simple s-page component",
-        "tabs": [
-          {
-            "code": "&lt;s-page heading=\"Page Title\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Close')\"&gt;Close&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Cancel')\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-page&gt;\n",
-            "language": "html"
-          }
-        ]
-      }
-    },
+    "related": [],
     "examples": {
-      "description": "Learn how to use the s-page component to configure the admin title bar with various actions and breadcrumbs.",
+      "description": "Learn how to use the page component to configure the admin title bar with various actions and breadcrumbs.",
       "exampleGroups": [
         {
-          "title": "Basic title bar configuration",
+          "title": "",
           "examples": [
             {
-              "description": "The `s-page` component accepts the following properties:\n- `heading`: The heading for the page. This is the title of the page.\n\nAnd the following slots:\n- `primary-action`: The primary action for the page. This is the main action for the page.\n- `secondary-actions`: The secondary actions for the page. This is a group of actions that are related to the page.\n- `breadcrumb-actions`: The breadcrumb actions for the page. This is a link to the home page or the previous page.\n- `accessory`: A status badge displayed next to the title. Use with `s-badge` and the `tone` attribute (`info`, `success`, `warning`, or `critical`).",
+              "description": "Configure the title bar for your page. This example sets a heading and adds primary and secondary action buttons.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/title-bar-primary-and-secondary.png",
               "codeblock": {
-                "title": "Simple s-page component",
+                "title": "Primary and secondary actions",
                 "tabs": [
                   {
-                    "code": "&lt;s-page heading=\"Page Title\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Close')\"&gt;Close&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Cancel')\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-page heading=\"Edit Product\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Add product')\"&gt;Add product&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Import')\"&gt;Import&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Export')\"&gt;Export&lt;/s-button&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
                 ]
@@ -531,14 +588,16 @@
           ]
         },
         {
-          "title": "Advanced title bar features",
+          "title": "",
           "examples": [
             {
-              "description": "Display a status badge next to the page title using the `accessory` slot. Use `s-badge` with the `tone` attribute to indicate status (`info`, `success`, `warning`, or `critical`).",
+              "description": "Show page status in the title bar. This example displays a status badge using the `accessory` slot with `s-badge` and `tone`.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/title-bar-accessory-badge.png",
               "codeblock": {
                 "title": "Accessory badge",
                 "tabs": [
                   {
+                    "title": "html",
                     "code": "&lt;s-page heading=\"Edit Product\"&gt;\n  &lt;s-badge slot=\"accessory\" tone=\"warning\"&gt;Draft&lt;/s-badge&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
@@ -546,36 +605,42 @@
               }
             },
             {
-              "description": "You can group secondary actions together using `s-menu` and the `commandfor` attribute. This will create a dropdown menu with the actions. The text content of the `s-button` used with the `commandfor` attribute will display a label for the group of actions.",
+              "description": "Organize multiple actions in a dropdown menu. This example groups secondary actions using `s-menu` with the [`commandFor`](/docs/api/app-home/polaris-web-components/actions/button#properties-propertydetail-commandFor) attribute.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/title-bar-grouped-secondary.png",
               "codeblock": {
                 "title": "Grouped secondary actions",
                 "tabs": [
                   {
-                    "code": "&lt;s-page heading=\"Page Title\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" commandfor=\"more-actions-id\"&gt;More actions&lt;/s-button&gt;\n  &lt;s-menu id=\"more-actions-id\"&gt;\n    &lt;s-button onclick=\"shopify.toast.show('Action 1')\"&gt;Action 1&lt;/s-button&gt;\n    &lt;s-button onclick=\"shopify.toast.show('Action 2')\"&gt;Action 2&lt;/s-button&gt;\n    &lt;s-button onclick=\"shopify.toast.show('Action 3')\"&gt;Action 3&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-page heading=\"Edit Product\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" commandFor=\"more-actions-id\"&gt;More actions&lt;/s-button&gt;\n  &lt;s-menu id=\"more-actions-id\"&gt;\n    &lt;s-button icon=\"preview\" onclick=\"shopify.toast.show('Action 1')\"&gt;Preview&lt;/s-button&gt;\n    &lt;s-button icon=\"import\" onclick=\"shopify.toast.show('Action 2')\"&gt;Import&lt;/s-button&gt;\n    &lt;s-button icon=\"export\" onclick=\"shopify.toast.show('Action 3')\"&gt;Export&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
                 ]
               }
             },
             {
-              "description": "You can add breadcrumb actions using the `breadcrumb-actions` slot. This will add a link to the breadcrumb actions. You can use this to add a link to the home page or to add a link to the previous page.",
+              "description": "Help users navigate back to previous pages. This example adds breadcrumb navigation using the `breadcrumb-actions` slot.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/title-bar-breadcrumb.png",
               "codeblock": {
                 "title": "Breadcrumb actions",
                 "tabs": [
                   {
-                    "code": "&lt;s-page heading=\"Page Title\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Cancel')\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-link slot=\"breadcrumb-actions\" href=\"/\"&gt;Home&lt;/s-link&gt;\n&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-page heading=\"Edit Product\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Add product')\"&gt;Add product&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Import')\"&gt;Import&lt;/s-button&gt;\n  &lt;s-link slot=\"breadcrumb-actions\" href=\"/\"&gt;Home&lt;/s-link&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
                 ]
               }
             },
             {
-              "description": "Here is a complete example of how to use the `s-page` component to interact with the admin title bar.",
+              "description": "Build a complete title bar configuration. This example combines heading, actions, badges, and breadcrumbs.",
+              "image": "/assets/templated-apis-screenshots/admin/app-bridge-web-components/title-bar-complete-example.png",
               "codeblock": {
                 "title": "Complete example",
                 "tabs": [
                   {
-                    "code": "&lt;s-page heading=\"Page Title\"&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" onclick=\"shopify.toast.show('Close')\"&gt;Close&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" commandfor=\"more-actions-id\"&gt;More actions&lt;/s-button&gt;\n  &lt;s-menu id=\"more-actions-id\"&gt;\n    &lt;s-button onclick=\"shopify.toast.show('Action 1')\"&gt;Action 1&lt;/s-button&gt;\n    &lt;s-button onclick=\"shopify.toast.show('Action 2')\"&gt;Action 2&lt;/s-button&gt;\n    &lt;s-button onclick=\"shopify.toast.show('Action 3')\"&gt;Action 3&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n  &lt;s-link slot=\"breadcrumb-actions\" href=\"/\"&gt;Home&lt;/s-link&gt;\n&lt;/s-page&gt;\n",
+                    "title": "html",
+                    "code": "&lt;s-page heading=\"Edit Product\"&gt;\n  &lt;s-badge slot=\"accessory\" tone=\"warning\"&gt;Draft&lt;/s-badge&gt;\n  &lt;s-button slot=\"primary-action\" onclick=\"shopify.toast.show('Save')\"&gt;Add product&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" commandFor=\"more-actions-id\"&gt;More actions&lt;/s-button&gt;\n  &lt;s-menu id=\"more-actions-id\"&gt;\n    &lt;s-button icon=\"preview\" onclick=\"shopify.toast.show('Preview')\"&gt;Preview&lt;/s-button&gt;\n    &lt;s-button icon=\"import\" onclick=\"shopify.toast.show('Import')\"&gt;Import&lt;/s-button&gt;\n    &lt;s-button icon=\"export\" onclick=\"shopify.toast.show('Export')\"&gt;Export&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n  &lt;s-link slot=\"breadcrumb-actions\" href=\"/\"&gt;Home&lt;/s-link&gt;\n&lt;/s-page&gt;\n",
                     "language": "html"
                   }
                 ]
@@ -588,14 +653,16 @@
   },
   {
     "name": "App",
-    "overviewPreviewDescription": "Access information about the app",
-    "description": "The App API provides information about the app and the status of its extensions.\n\nThe API returns information about two types of extensions:\n- **UI extensions** (`ui_extension`): Admin, Checkout, Customer Account and Point of Sale extensions\n- **Theme app extensions** (`theme_app_extension`): Theme app blocks and embeds",
+    "overviewPreviewDescription": "Retrieve extension status and activation details",
+    "description": "The App API provides read-only access to extension information, enabling discovery of installed extensions and their activation status. This API returns extension details including handles, types, and activations across different surfaces.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Authentication and data",
     "related": [],
     "defaultExample": {
+      "description": "Retrieve extension information. This example fetches all installed extensions, returning an array with UI and theme app extension data.",
       "codeblock": {
-        "title": "Get Extensions Status",
+        "title": "Get extension status",
         "tabs": [
           {
             "code": "const extensions = await shopify.app.extensions();\n\n// Example response:\n// [\n//   // UI extension\n//   {\n//     handle: 'checkout-extension-1',\n//     type: 'ui_extension',\n//     activations: [\n//       {target: 'purchase.thank-you.block.render'},\n//       {target: 'customer-account.order-status.block.render'},\n//     ],\n//   },\n//   // Theme app extension with nested blocks/embeds\n//   {\n//     handle: 'my-theme-app-extension',\n//     type: 'theme_app_extension',\n//     activations: [\n//       {\n//         target: 'section',\n//         handle: 'product-rating',\n//         name: 'Product Rating',\n//         status: 'active',\n//         activations: [\n//           {\n//             target: 'template--product.custom/main/my_app_product_rating_GPzUYy',\n//             themeId: 'gid://shopify/OnlineStoreTheme/123',\n//           },\n//         ],\n//       },\n//       {\n//         target: 'head',\n//         handle: 'analytics-widget',\n//         name: 'Analytics Widget',\n//         status: 'active',\n//         activations: [\n//           {target: 'theme', themeId: 'gid://shopify/OnlineStoreTheme/123'},\n//         ],\n//       },\n//     ],\n//   },\n// ];\n",
@@ -604,10 +671,32 @@
         ]
       }
     },
+    "examples": {
+      "description": "Examples for working with extension data.",
+      "exampleGroups": [
+        {
+          "title": "",
+          "examples": [
+            {
+              "description": "Filter extensions by type. This example separates UI extensions from theme app extensions, which have different activation structures. Useful for checking admin targets vs storefront placements.",
+              "codeblock": {
+                "title": "Get extension status and filter by type",
+                "tabs": [
+                  {
+                    "code": "const extensions = await shopify.app.extensions();\n\n// Get only UI extensions\nconst uiExtensions = extensions.filter(ext =&gt; ext.type === 'ui_extension');\n\n// Get only theme app extensions\nconst themeExtensions = extensions.filter(ext =&gt; ext.type === 'theme_app_extension');\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
     "definitions": [
       {
         "title": "Extensions method",
-        "description": "The `app.extensions()` method asynchronously retrieves detailed information about the app's extensions, including which targets they are activated on.\n\nIt returns a Promise that resolves to an array of `ExtensionInfo` objects. Each object contains:\n- `handle`: The unique identifier for the extension\n- `type`: Either `'ui_extension'` or `'theme_app_extension'`\n- `activations`: Activation records (shape varies by extension type)\n\n**UI Extensions** have activations with a `target` field indicating the admin, checkout, customer account or point of sale target.\n\n**Theme App Extensions** have activations representing individual blocks/embeds, each with:\n- `handle`: Block/embed filename\n- `name`: Display name from block schema\n- `target`: Location type (`'section'`, `'head'`, `'body'`, or `'compliance_head'`)\n- `status`: Availability status (`'active'`, `'available'`, or `'unavailable'`)\n- `activations`: Array of theme-specific placements with `target` and `themeId`\n\nThe array may be empty if the app has no extensions.",
+        "description": "The `app.extensions()` method asynchronously retrieves detailed information about the app's extensions, including which targets they are activated on.\n\nIt returns a Promise that resolves to an array of `ExtensionInfo` objects. Each object contains:\n- `handle`: The unique identifier for the extension\n- `type`: Either `'ui_extension'` or `'theme_app_extension'`\n- `activations`: Activation records (shape varies by extension type)\n\n**UI Extensions** have activations with a `target` field indicating the admin, checkout, customer account or point of sale target.\n\n**Theme App Extensions** have activations representing individual blocks/embeds, each with:\n- `handle`: Block/embed filename\n- `name`: Display name from block schema\n- `target`: Location type (`'section'`, `'head'`, `'body'`, or `'compliance_head'`)\n- `status`: Availability status (`'active'`, `'available'`, or `'unavailable'`)\n- `activations`: Array of theme-specific placements with `target` and `themeId`\n\n> Note: For Theme App Extensions, activation data is sourced from the store's published theme only.\n\nThe array may be empty if the app has no extensions.",
         "type": "ExtensionInfo",
         "typeDefinitions": {
           "ExtensionInfo": {
@@ -637,7 +726,7 @@
                 "description": "The type of the extension."
               }
             ],
-            "value": "export interface ExtensionInfo<Type extends ExtensionType = ExtensionType> {\n  /**\n   * The unique identifier for the extension.\n   */\n  handle: string;\n\n  /**\n   * List of activation records for the extension.\n   * The shape depends on the extension type:\n   * - UI extensions have activations with only `target`\n   * - Theme app extensions have nested activations representing blocks/embeds\n   */\n  activations: Type extends 'ui_extension'\n  ? UiExtensionActivation[]\n  : Type extends 'theme_app_extension'\n  ? ThemeExtensionActivation[]\n  : never;\n\n  /**\n   * The type of the extension.\n   */\n  type: Type;\n}"
+            "value": "export interface ExtensionInfo<Type extends ExtensionType = ExtensionType> {\n  /**\n   * The unique identifier for the extension.\n   */\n  handle: string;\n\n  /**\n   * List of activation records for the extension.\n   * The shape depends on the extension type:\n   * - UI extensions have activations with only `target`\n   * - Theme app extensions have nested activations representing blocks/embeds\n   */\n  activations: Type extends 'ui_extension'\n    ? UiExtensionActivation[]\n    : Type extends 'theme_app_extension'\n    ? ThemeExtensionActivation[]\n    : never;\n\n  /**\n   * The type of the extension.\n   */\n  type: Type;\n}"
           },
           "UiExtensionActivation": {
             "filePath": "src/types.ts",
@@ -649,10 +738,10 @@
                 "syntaxKind": "PropertySignature",
                 "name": "target",
                 "value": "string",
-                "description": "The target identifier for the extension activation. Example: 'purchase.thank-you.block.render'"
+                "description": "The target identifier for the extension activation. For example, `purchase.thank-you.block.render`."
               }
             ],
-            "value": "export interface UiExtensionActivation {\n  /**\n   * The target identifier for the extension activation.\n   * Example: 'purchase.thank-you.block.render'\n   */\n  target: string;\n}"
+            "value": "export interface UiExtensionActivation {\n  /**\n   * The target identifier for the extension activation.\n   * For example, `purchase.thank-you.block.render`.\n   */\n  target: string;\n}"
           },
           "ThemeExtensionActivation": {
             "filePath": "src/types.ts",
@@ -692,10 +781,10 @@
                 "syntaxKind": "PropertySignature",
                 "name": "target",
                 "value": "ThemeAppBlockTarget | ThemeAppEmbedTarget",
-                "description": "The target location type for this block/embed.\n- 'section' for blocks\n- 'head', 'body', or 'compliance_head' for embeds"
+                "description": "The target location type for this block/embed.\n- `section` for blocks\n- `head`, `body`, or `compliance_head` for embeds"
               }
             ],
-            "value": "export interface ThemeExtensionActivation {\n  /**\n   * The target location type for this block/embed.\n   * - 'section' for blocks\n   * - 'head', 'body', or 'compliance_head' for embeds\n   */\n  target: ThemeAppBlockTarget | ThemeAppEmbedTarget;\n\n  /**\n   * The filename of the block/embed within the theme app extension (without extension).\n   * This is configured by the developer when creating the block file.\n   */\n  handle: string;\n\n  /**\n   * The developer-configured display name of this block/embed, defined in the block's schema.\n   * @see https://shopify.dev/docs/apps/build/online-store/theme-app-extensions/configuration#schema\n   */\n  name: string;\n\n  /**\n   * The availability status of this block/embed.\n   */\n  status: ActivationStatus;\n\n  /**\n   * List of theme-specific activations for this block/embed.\n   * Contains where the block is actually placed within themes.\n   */\n  activations: ThemeAppBlockActivation[];\n}"
+            "value": "export interface ThemeExtensionActivation {\n  /**\n   * The target location type for this block/embed.\n   * - `section` for blocks\n   * - `head`, `body`, or `compliance_head` for embeds\n   */\n  target: ThemeAppBlockTarget | ThemeAppEmbedTarget;\n\n  /**\n   * The filename of the block/embed within the theme app extension (without extension).\n   * This is configured by the developer when creating the block file.\n   */\n  handle: string;\n\n  /**\n   * The developer-configured display name of this block/embed, defined in the block's schema.\n   * @see https://shopify.dev/docs/apps/build/online-store/theme-app-extensions/configuration#schema\n   */\n  name: string;\n\n  /**\n   * The availability status of this block/embed.\n   */\n  status: ActivationStatus;\n\n  /**\n   * List of theme-specific activations for this block/embed.\n   * Contains where the block is actually placed within themes.\n   */\n  activations: ThemeAppBlockActivation[];\n}"
           },
           "ThemeAppBlockActivation": {
             "filePath": "src/types.ts",
@@ -707,24 +796,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "target",
                 "value": "string",
-                "description": "The target identifier for the block/embed placement within the theme. Example: 'template--product.alternate/main/my_app_product_rating_GPzUYy'"
+                "description": "The target identifier for the block/embed placement within the theme. For example, `template--product.alternate/main/my_app_product_rating_GPzUYy`."
               },
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "themeId",
                 "value": "string",
-                "description": "The theme ID where this block/embed is activated. Format: gid://shopify/OnlineStoreTheme/{id}"
+                "description": "The theme ID where this block/embed is activated. Format: `gid://shopify/OnlineStoreTheme/{id}`"
               }
             ],
-            "value": "export interface ThemeAppBlockActivation {\n  /**\n   * The target identifier for the block/embed placement within the theme.\n   * Example: 'template--product.alternate/main/my_app_product_rating_GPzUYy'\n   */\n  target: string;\n\n  /**\n   * The theme ID where this block/embed is activated.\n   * Format: gid://shopify/OnlineStoreTheme/{id}\n   */\n  themeId: string;\n}"
+            "value": "export interface ThemeAppBlockActivation {\n  /**\n   * The target identifier for the block/embed placement within the theme.\n   * For example, `template--product.alternate/main/my_app_product_rating_GPzUYy`.\n   */\n  target: string;\n\n  /**\n   * The theme ID where this block/embed is activated.\n   * Format: `gid://shopify/OnlineStoreTheme/{id}`\n   */\n  themeId: string;\n}"
           },
           "ActivationStatus": {
             "filePath": "src/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ActivationStatus",
             "value": "'active' | 'available' | 'unavailable'",
-            "description": "The availability status of a theme app block or embed.\n- 'active': Block/embed is currently present in a theme.\n- 'available': Block/embed exists but is not currently active\n- 'unavailable': Block/embed exists but is disabled (e.g., via available_if condition)\n\nNote that if a block is present in a theme but is not available, its status will be 'unavailable'."
+            "description": "The availability status of a theme app block or embed.\n- `active`: Block/embed is currently present in a theme.\n- `available`: Block/embed exists but is not currently active.\n- `unavailable`: Block/embed exists but is disabled (e.g., via available_if condition).\n\nNote that if a block is present in a theme but is not available, its status will be `unavailable`."
           },
           "ThemeAppBlockTarget": {
             "filePath": "src/types.ts",
@@ -1020,18 +1109,21 @@
       ]
     },
     "category": "APIs",
+    "subCategory": "Authentication and data",
     "related": []
   },
   {
     "name": "Environment",
-    "overviewPreviewDescription": "Platform information for App Home",
-    "description": "The Environment API provides utilities for information regarding the environment an App Home is running on.",
+    "overviewPreviewDescription": "Detect the platform your app is running on",
+    "description": "The Environment API provides access to information about the platform your app is running on. Use it to detect whether the app is embedded in the Shopify admin, running on Shopify Mobile, or running on Shopify POS.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Authentication and data",
     "related": [],
     "defaultExample": {
+      "description": "Read the environment object to see which platform your app is running on. Each property is a boolean that indicates whether a specific condition is true.",
       "codeblock": {
-        "title": "Environment",
+        "title": "Detect the current platform",
         "tabs": [
           {
             "code": "shopify.environment;\n// =&gt; { mobile: false, embedded: true, pos: false }\n",
@@ -1042,8 +1134,8 @@
     },
     "definitions": [
       {
-        "title": "Environment",
-        "description": "The `environment` API is available on the `shopify` global. It contains information about the current environment an App Home is running on.",
+        "title": "Properties",
+        "description": "The `environment` API is available on the `shopify` global. All properties are synchronous booleans.",
         "type": "_EnvironmentApi",
         "typeDefinitions": {
           "_EnvironmentApi": {
@@ -1064,7 +1156,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "mobile",
                 "value": "boolean",
-                "description": "Whether the app is running on Shopify Mobile.",
+                "description": "Whether the app is running inside the Shopify Mobile app.",
                 "isOptional": true
               },
               {
@@ -1072,15 +1164,37 @@
                 "syntaxKind": "PropertySignature",
                 "name": "pos",
                 "value": "boolean",
-                "description": "Whether the app is running on Shopify POS.",
+                "description": "Whether the app is running inside the Shopify POS app.",
                 "isOptional": true
               }
             ],
-            "value": "interface _EnvironmentApi {\n  /**\n   * Whether the app is running on Shopify Mobile.\n   */\n  mobile?: boolean;\n  /**\n   * Whether the app is embedded in the Shopify admin.\n   */\n  embedded?: boolean;\n  /**\n   * Whether the app is running on Shopify POS.\n   */\n  pos?: boolean;\n}"
+            "value": "interface _EnvironmentApi {\n  /**\n   * Whether the app is running inside the Shopify Mobile app.\n   */\n  mobile?: boolean;\n  /**\n   * Whether the app is embedded in the Shopify admin.\n   */\n  embedded?: boolean;\n  /**\n   * Whether the app is running inside the Shopify POS app.\n   */\n  pos?: boolean;\n}"
           }
         }
       }
-    ]
+    ],
+    "examples": {
+      "description": "",
+      "exampleGroups": [
+        {
+          "title": "",
+          "examples": [
+            {
+              "description": "Check individual environment properties to adapt your app's behaviour to the current platform. In this example, your app shows a print button only on mobile devices where App Bridge handles printing through the native app.",
+              "codeblock": {
+                "title": "Adapt your UI based on the platform",
+                "tabs": [
+                  {
+                    "code": "const mobile = shopify.environment.mobile;\n\nif (mobile) {\n  document.getElementById('print-button').style.display = 'block';\n} else {\n  document.getElementById('print-button').style.display = 'none';\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "Resource Fetching",
@@ -1129,18 +1243,20 @@
     },
     "definitions": [],
     "category": "APIs",
+    "subCategory": "Authentication and data",
     "related": []
   },
   {
     "name": "ID Token",
-    "overviewPreviewDescription": "Retrieves an ID token from Shopify",
-    "description": "The ID token API asynchronously retrieves an [OpenID Connect ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken%5C) from Shopify that can be used to ensure that requests came from a Shopify authenticated user. See the [ID Token documentation](/docs/apps/auth/oauth/session-tokens) from more information.",
+    "overviewPreviewDescription": "Retrieve a Shopify ID token for authenticating requests",
+    "description": "The ID Token API retrieves an <a href='https://openid.net/specs/openid-connect-core-1_0.html#IDToken'>OpenID Connect ID Token</a> from Shopify as a <a href='https://jwt.io/introduction'>JWT string</a>. Your backend can verify this token to confirm that a request came from an authenticated Shopify user.\n\nIn most cases, you don't need to call this method directly. App Bridge's <a href='/docs/api/app-bridge-library/apis/resource-fetching'>fetch interceptor</a> automatically includes the ID token in the <code>Authorization</code> header for requests to your app's domain. Use <code>shopify.idToken()</code> directly when you need the token for something other than a standard fetch request, such as a WebSocket connection or a third-party API call.\n\nFor more information, see the <a href='/docs/apps/auth/oauth/session-tokens'>ID Token documentation</a>.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Authentication and data",
     "definitions": [
       {
         "title": "ID Token",
-        "description": "The `idToken` API is available on the `shopify` global. It asynchronously retrieves an OpenID Connect ID Token from Shopify.",
+        "description": "The `idToken` API is available on the `shopify` global. It returns a Promise that resolves to a JWT string.",
         "type": "IdTokenApi",
         "typeDefinitions": {
           "IdTokenApi": {
@@ -1161,31 +1277,56 @@
     ],
     "related": [],
     "defaultExample": {
+      "description": "Retrieve an ID token from Shopify. The returned value is a JWT string that your backend can verify to authenticate the request.",
       "codeblock": {
-        "title": "ID Token",
+        "title": "Retrieve an ID token",
         "tabs": [
           {
-            "code": "await shopify.idToken();\n",
+            "code": "const token = await shopify.idToken();\n// =&gt; 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...'\n",
             "language": "js"
           }
         ]
       }
+    },
+    "examples": {
+      "description": "",
+      "exampleGroups": [
+        {
+          "title": "",
+          "examples": [
+            {
+              "description": "Pass the ID token when opening a WebSocket connection to your backend. This is a common use case for calling `shopify.idToken()` directly, since the fetch interceptor only handles standard fetch requests.",
+              "codeblock": {
+                "title": "Authenticate a WebSocket connection",
+                "tabs": [
+                  {
+                    "code": "const token = await shopify.idToken();\n\nconst socket = new WebSocket(\n  `wss://your-app.example.com/ws?token=${token}`\n);\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   },
   {
     "name": "Intents",
     "overviewPreviewDescription": "Orchestrate workflows and operations across Shopify resources",
-    "description": "The Intents API provides a way to invoke existing admin workflows for creating, editing, and managing Shopify resources.",
+    "description": "The Intents API launches Shopify's native admin interfaces for creating and editing resources. When your extension calls an intent, merchants complete their changes using the standard Shopify admin UI, and your app receives the result. This means you don't need to build custom forms.\n\nUse this API to build workflows like adding products to collections, creating multiple related resources in a sequence (like a product, collection, and discount for a promotion), opening specific resources for editing, or launching discount creation with pre-selected types.",
     "isVisualComponent": true,
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/intents.png",
     "defaultExample": {
+      "description": "Launch the collection creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
       "image": "/assets/templated-apis-screenshots/admin/apis/intents.png",
       "codeblock": {
-        "title": "Creating a collection",
+        "title": "Create a new collection",
         "tabs": [
           {
-            "code": "const activity = await shopify.intents.invoke('create:shopify/Collection');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Collection created:', response.data);\n}\n",
+            "code": "const activity = await shopify.intents.invoke('create:shopify/Collection');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Collection created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
             "language": "js"
           }
         ]
@@ -1960,7 +2101,7 @@
                 "description": ""
               }
             ],
-            "value": "export interface ProductVariant extends Resource {\n  availableForSale: boolean;\n  barcode?: string | null;\n  compareAtPrice?: Money | null;\n  createdAt: string;\n  displayName: string;\n  fulfillmentService?: {\n    id: string;\n    inventoryManagement: boolean;\n    productBased: boolean;\n    serviceName: string;\n    type: FulfillmentServiceType;\n  };\n  image?: Image | null;\n  inventoryItem: {id: string};\n  inventoryManagement: ProductVariantInventoryManagement;\n  inventoryPolicy: ProductVariantInventoryPolicy;\n  inventoryQuantity?: number | null;\n  position: number;\n  price: Money;\n  product: Partial<Product>;\n  requiresShipping: boolean;\n  selectedOptions: {value?: string | null}[];\n  sku?: string | null;\n  taxable: boolean;\n  title: string;\n  weight?: number | null;\n  weightUnit: WeightUnit;\n  updatedAt: string;\n}"
+            "value": "export interface ProductVariant extends Resource {\n  availableForSale: boolean;\n  barcode?: string | null;\n  compareAtPrice?: Money | null;\n  createdAt: string;\n  displayName: string;\n  fulfillmentService?: {\n    id: string;\n    inventoryManagement: boolean;\n    productBased: boolean;\n    serviceName: string;\n    type: FulfillmentServiceType;\n  };\n  image?: Image | null;\n  inventoryItem: { id: string };\n  inventoryManagement: ProductVariantInventoryManagement;\n  inventoryPolicy: ProductVariantInventoryPolicy;\n  inventoryQuantity?: number | null;\n  position: number;\n  price: Money;\n  product: Partial<Product>;\n  requiresShipping: boolean;\n  selectedOptions: { value?: string | null }[];\n  sku?: string | null;\n  taxable: boolean;\n  title: string;\n  weight?: number | null;\n  weightUnit: WeightUnit;\n  updatedAt: string;\n}"
           },
           "Money": {
             "filePath": "src/features/resource-picker.ts",
@@ -2903,7 +3044,7 @@
                 "description": ""
               }
             ],
-            "value": "export interface ProductVariant extends Resource {\n  availableForSale: boolean;\n  barcode?: string | null;\n  compareAtPrice?: Money | null;\n  createdAt: string;\n  displayName: string;\n  fulfillmentService?: {\n    id: string;\n    inventoryManagement: boolean;\n    productBased: boolean;\n    serviceName: string;\n    type: FulfillmentServiceType;\n  };\n  image?: Image | null;\n  inventoryItem: {id: string};\n  inventoryManagement: ProductVariantInventoryManagement;\n  inventoryPolicy: ProductVariantInventoryPolicy;\n  inventoryQuantity?: number | null;\n  position: number;\n  price: Money;\n  product: Partial<Product>;\n  requiresShipping: boolean;\n  selectedOptions: {value?: string | null}[];\n  sku?: string | null;\n  taxable: boolean;\n  title: string;\n  weight?: number | null;\n  weightUnit: WeightUnit;\n  updatedAt: string;\n}"
+            "value": "export interface ProductVariant extends Resource {\n  availableForSale: boolean;\n  barcode?: string | null;\n  compareAtPrice?: Money | null;\n  createdAt: string;\n  displayName: string;\n  fulfillmentService?: {\n    id: string;\n    inventoryManagement: boolean;\n    productBased: boolean;\n    serviceName: string;\n    type: FulfillmentServiceType;\n  };\n  image?: Image | null;\n  inventoryItem: { id: string };\n  inventoryManagement: ProductVariantInventoryManagement;\n  inventoryPolicy: ProductVariantInventoryPolicy;\n  inventoryQuantity?: number | null;\n  position: number;\n  price: Money;\n  product: Partial<Product>;\n  requiresShipping: boolean;\n  selectedOptions: { value?: string | null }[];\n  sku?: string | null;\n  taxable: boolean;\n  title: string;\n  weight?: number | null;\n  weightUnit: WeightUnit;\n  updatedAt: string;\n}"
           },
           "Money": {
             "filePath": "src/features/resource-picker.ts",
@@ -3125,378 +3266,318 @@
       }
     ],
     "examples": {
-      "description": "Intents for each Shopify resource type",
+      "description": "",
       "exampleGroups": [
         {
-          "title": "Article",
+          "title": "",
           "examples": [
             {
-              "description": "Create a new article. Opens the article creation workflow.",
+              "description": "Launch the article creation workflow in the Shopify admin. The merchant writes and publishes the article using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
               "codeblock": {
-                "title": "Create article",
+                "title": "Create a new article",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Article');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Article created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Article');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Article created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing article. Requires an article GID.",
+              "description": "Open an existing article for editing in the Shopify admin. Pass the article's GID (for example, `gid://shopify/Article/123456789`) as the value. Your app receives the updated data when the merchant saves their changes.",
               "codeblock": {
-                "title": "Edit article",
+                "title": "Edit an existing article",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Article', {\n  value: 'gid://shopify/Article/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Article updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Catalog",
-          "examples": [
-            {
-              "description": "Create a new catalog. Opens the catalog creation workflow.",
-              "codeblock": {
-                "title": "Create catalog",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Catalog');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Catalog created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Article', {\n  value: 'gid://shopify/Article/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Article updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing catalog. Requires a catalog GID.",
+              "description": "Launch the catalog creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
               "codeblock": {
-                "title": "Edit catalog",
+                "title": "Create a new catalog",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Catalog', {\n  value: 'gid://shopify/Catalog/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Catalog updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Collection",
-          "examples": [
-            {
-              "description": "Create a new collection. Opens the collection creation workflow.",
-              "codeblock": {
-                "title": "Create collection",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Collection');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Collection created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Catalog');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Catalog created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing collection. Requires a collection GID.",
+              "description": "Open an existing catalog for editing in the Shopify admin. Pass the catalog's GID as the value. Your app receives the updated data when the merchant saves their changes.",
               "codeblock": {
-                "title": "Edit collection",
+                "title": "Edit an existing catalog",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Collection', {\n  value: 'gid://shopify/Collection/987654321',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Collection updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Customer",
-          "examples": [
-            {
-              "description": "Create a new customer. Opens the customer creation workflow.",
-              "codeblock": {
-                "title": "Create customer",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Customer');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Customer created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Catalog', {\n  value: 'gid://shopify/Catalog/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Catalog updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing customer. Requires a customer GID.",
+              "description": "Launch the collection creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
               "codeblock": {
-                "title": "Edit customer",
+                "title": "Create a new collection",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Customer', {\n  value: 'gid://shopify/Customer/456789123',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Customer updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Discount",
-          "examples": [
-            {
-              "description": "Create a new discount. Opens the discount creation workflow. Requires a discount type.",
-              "codeblock": {
-                "title": "Create discount",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Discount', {\n  data: {type: 'amount-off-product'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Discount created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Collection');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Collection created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing discount. Requires a discount GID.",
+              "description": "Open an existing collection for editing in the Shopify admin. Pass the collection's GID as the value. Your app receives the updated data when the merchant saves their changes.",
               "codeblock": {
-                "title": "Edit discount",
+                "title": "Edit an existing collection",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Discount', {\n  value: 'gid://shopify/Discount/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Discount updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Market",
-          "examples": [
-            {
-              "description": "Create a new market. Opens the market creation workflow.",
-              "codeblock": {
-                "title": "Create market",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Market');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Market created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Collection', {\n  value: 'gid://shopify/Collection/987654321',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Collection updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing market. Requires a market GID.",
+              "description": "Launch the customer creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
               "codeblock": {
-                "title": "Edit market",
+                "title": "Create a new customer",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Market', {\n  value: 'gid://shopify/Market/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Market updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Menu",
-          "examples": [
-            {
-              "description": "Create a new menu. Opens the menu creation workflow.",
-              "codeblock": {
-                "title": "Create menu",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Menu');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Menu created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Customer');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Customer created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing menu. Requires a menu GID.",
+              "description": "Open an existing customer for editing in the Shopify admin. Pass the customer's GID as the value. Your app receives the updated data when the merchant saves their changes.",
               "codeblock": {
-                "title": "Edit menu",
+                "title": "Edit an existing customer",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Menu', {\n  value: 'gid://shopify/Menu/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Menu updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Metafield Definition",
-          "examples": [
-            {
-              "description": "Create a new metafield definition. Opens the metafield definition creation workflow.",
-              "codeblock": {
-                "title": "Create metafield definition",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke(\n  'create:shopify/MetafieldDefinition',\n  {data: {ownerType: 'product'}},\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metafield definition created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Customer', {\n  value: 'gid://shopify/Customer/456789123',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Customer updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing metafield definition. Requires a metafield definition GID.",
+              "description": "Launch the discount creation workflow in the Shopify admin. You must specify the discount type in the `data` parameter. Valid types are `'amount-off-product'`, `'amount-off-order'`, `'buy-x-get-y'`, and `'free-shipping'`. Your app receives the result when the merchant completes the workflow.",
               "codeblock": {
-                "title": "Edit metafield definition",
+                "title": "Create a new discount",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke(\n  'edit:shopify/MetafieldDefinition',\n  {\n    value: 'gid://shopify/MetafieldDefinition/123456789',\n    data: {ownerType: 'product'},\n  },\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metafield definition updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Metaobject",
-          "examples": [
-            {
-              "description": "Create a new metaobject. Opens the metaobject creation workflow. Requires a type.",
-              "codeblock": {
-                "title": "Create metaobject",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Metaobject', {\n  data: {type: 'shopify--color-pattern'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Discount', {\n  data: {type: 'amount-off-product'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Discount created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing metaobject. Requires a metaobject GID.",
+              "description": "Open an existing discount for editing in the Shopify admin. Pass the discount's GID as the value. Your app receives the updated data when the merchant saves their changes.",
               "codeblock": {
-                "title": "Edit metaobject",
+                "title": "Edit an existing discount",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Metaobject', {\n  value: 'gid://shopify/Metaobject/123456789',\n  data: {type: 'shopify--color-pattern'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Metaobject Definition",
-          "examples": [
-            {
-              "description": "Create a new metaobject definition. Opens the metaobject definition creation workflow.",
-              "codeblock": {
-                "title": "Create metaobject definition",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke(\n  'create:shopify/MetaobjectDefinition',\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject definition created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Discount', {\n  value: 'gid://shopify/Discount/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Discount updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing metaobject definition. Requires a metaobject definition GID.",
+              "description": "Launch the market creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
               "codeblock": {
-                "title": "Edit metaobject definition",
+                "title": "Create a new market",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke(\n  'edit:shopify/MetaobjectDefinition',\n  data: {type: 'my_metaobject_definition_type'},\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject definition updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Page",
-          "examples": [
-            {
-              "description": "Create a new page. Opens the page creation workflow.",
-              "codeblock": {
-                "title": "Create page",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Page');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Page created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Market');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Market created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing page. Requires a page GID.",
+              "description": "Open an existing market for editing in the Shopify admin. Pass the market's GID as the value. Your app receives the updated data when the merchant saves their changes.",
               "codeblock": {
-                "title": "Edit page",
+                "title": "Edit an existing market",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Page', {\n  value: 'gid://shopify/Page/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Page updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Product",
-          "examples": [
-            {
-              "description": "Create a new product. Opens the product creation workflow.",
-              "codeblock": {
-                "title": "Create product",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/Product');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Market', {\n  value: 'gid://shopify/Market/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Market updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing product. Requires a product GID.",
+              "description": "Launch the menu creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
               "codeblock": {
-                "title": "Edit product",
+                "title": "Create a new menu",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Product', {\n  value: 'gid://shopify/Product/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product updated:', response.data);\n}\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Product Variant",
-          "examples": [
-            {
-              "description": "Create a new product variant. Opens the variant creation workflow. Requires a product ID.",
-              "codeblock": {
-                "title": "Create variant",
-                "tabs": [
-                  {
-                    "code": "const activity = await shopify.intents.invoke('create:shopify/ProductVariant', {\n  data: {productId: 'gid://shopify/Product/123456789'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product variant created:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Menu');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Menu created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
               }
             },
             {
-              "description": "Edit an existing product variant. Requires a variant GID.",
+              "description": "Open an existing menu for editing in the Shopify admin. Pass the menu's GID as the value. Your app receives the updated data when the merchant saves their changes.",
               "codeblock": {
-                "title": "Edit variant",
+                "title": "Edit an existing menu",
                 "tabs": [
                   {
-                    "code": "const activity = await shopify.intents.invoke('edit:shopify/ProductVariant', {\n  value: 'gid://shopify/ProductVariant/123456789',\n  data: {productId: 'gid://shopify/Product/123456789'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product variant updated:', response.data);\n}\n",
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Menu', {\n  value: 'gid://shopify/Menu/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Menu updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Launch the metafield definition creation workflow in the Shopify admin. You must specify the owner type in the `data` parameter (for example, `'product'`). Your app receives the result when the merchant completes the workflow.",
+              "codeblock": {
+                "title": "Create a new metafield definition",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke(\n  'create:shopify/MetafieldDefinition',\n  {data: {ownerType: 'product'}},\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metafield definition created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Open an existing metafield definition for editing in the Shopify admin. Pass the metafield definition's GID as the value and the owner type in the `data` parameter. Your app receives the updated data when the merchant saves their changes.",
+              "codeblock": {
+                "title": "Edit an existing metafield definition",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke(\n  'edit:shopify/MetafieldDefinition',\n  {\n    value: 'gid://shopify/MetafieldDefinition/123456789',\n    data: {ownerType: 'product'},\n  },\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metafield definition updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Launch the metaobject creation workflow in the Shopify admin. You must specify the metaobject type in the `data` parameter (for example, `'shopify--color-pattern'`). Your app receives the result when the merchant completes the workflow.",
+              "codeblock": {
+                "title": "Create a new metaobject",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Metaobject', {\n  data: {type: 'shopify--color-pattern'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Open an existing metaobject for editing in the Shopify admin. Pass the metaobject's GID as the value and the metaobject type in the `data` parameter. Your app receives the updated data when the merchant saves their changes.",
+              "codeblock": {
+                "title": "Edit an existing metaobject",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Metaobject', {\n  value: 'gid://shopify/Metaobject/123456789',\n  data: {type: 'shopify--color-pattern'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Launch the metaobject definition creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
+              "codeblock": {
+                "title": "Create a new metaobject definition",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke(\n  'create:shopify/MetaobjectDefinition',\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject definition created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Open an existing metaobject definition for editing in the Shopify admin. Pass the metaobject definition type in the `data` parameter. Your app receives the updated data when the merchant saves their changes.",
+              "codeblock": {
+                "title": "Edit an existing metaobject definition",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke(\n  'edit:shopify/MetaobjectDefinition',\n  {data: {type: 'my_metaobject_definition_type'}},\n);\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Metaobject definition updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Launch the page creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
+              "codeblock": {
+                "title": "Create a new page",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Page');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Page created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Open an existing page for editing in the Shopify admin. Pass the page's GID as the value. Your app receives the updated data when the merchant saves their changes.",
+              "codeblock": {
+                "title": "Edit an existing page",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Page', {\n  value: 'gid://shopify/Page/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Page updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Launch the product creation workflow in the Shopify admin. The merchant completes the form using the standard Shopify admin UI, and your app receives the result when the workflow completes.",
+              "codeblock": {
+                "title": "Create a new product",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/Product');\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Open an existing product for editing in the Shopify admin. Pass the product's GID as the value. Your app receives the updated data when the merchant saves their changes.",
+              "codeblock": {
+                "title": "Edit an existing product",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/Product', {\n  value: 'gid://shopify/Product/123456789',\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Launch the product variant creation workflow in the Shopify admin. You must specify the parent product's GID in the `data` parameter. Your app receives the result when the merchant completes the workflow.",
+              "codeblock": {
+                "title": "Create a new product variant",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('create:shopify/ProductVariant', {\n  data: {productId: 'gid://shopify/Product/123456789'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product variant created:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Creation cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Open an existing product variant for editing in the Shopify admin. Pass the variant's GID as the value and the parent product's GID in the `data` parameter. Your app receives the updated data when the merchant saves their changes.",
+              "codeblock": {
+                "title": "Edit an existing product variant",
+                "tabs": [
+                  {
+                    "code": "const activity = await shopify.intents.invoke('edit:shopify/ProductVariant', {\n  value: 'gid://shopify/ProductVariant/123456789',\n  data: {productId: 'gid://shopify/Product/123456789'},\n});\n\nconst response = await activity.complete;\n\nif (response.code === 'ok') {\n  console.log('Product variant updated:', response.data);\n} else if (response.code === 'closed') {\n  console.log('Edit cancelled by user');\n} else if (response.code === 'error') {\n  console.log('Error:', response.message);\n}\n",
                     "language": "js"
                   }
                 ]
@@ -3510,46 +3591,18 @@
   },
   {
     "name": "Loading",
-    "overviewPreviewDescription": "Displays a loading indicator",
-    "description": "The Loading API indicates to users that a page is loading or an upload is processing.",
+    "overviewPreviewDescription": "Show a loading indicator during async operations",
+    "description": "The Loading API lets you display a loading indicator in the Shopify admin header. Use this to signal that a page is loading, data is being fetched, or an upload is processing. The indicator appears at the top of the admin and persists until you explicitly stop it.",
     "isVisualComponent": true,
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/loading.png",
-    "definitions": [
-      {
-        "title": "Loading API",
-        "description": "The `Loading` API is available on the `shopify` global. It displays a loading indicator in the Shopify admin.",
-        "type": "LoadingApi",
-        "typeDefinitions": {
-          "LoadingApi": {
-            "filePath": "src/features/loading.ts",
-            "name": "LoadingApi",
-            "description": "The `Loading` API provides a method to toggle the loading indicator in the Shopify admin.",
-            "params": [
-              {
-                "name": "isLoading",
-                "description": "",
-                "value": "boolean",
-                "isOptional": true,
-                "filePath": "src/features/loading.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "src/features/loading.ts",
-              "description": "",
-              "name": "void",
-              "value": "void"
-            },
-            "value": "(isLoading?: boolean) => void"
-          }
-        }
-      }
-    ],
     "related": [],
     "defaultExample": {
+      "description": "Toggle loading state. This example starts the loading indicator before an async operation and stops it when complete.",
       "image": "/assets/templated-apis-screenshots/admin/apis/loading.png",
       "codeblock": {
-        "title": "Loading",
+        "title": "Toggle loading state",
         "tabs": [
           {
             "code": "shopify.loading(true);\n// ...\nshopify.loading(false);\n",
@@ -3557,19 +3610,88 @@
           }
         ]
       }
-    }
+    },
+    "definitions": [
+      {
+        "title": "Inputs",
+        "description": "The `loading` function controls the loading indicator in the Shopify admin header. The indicator persists until it's explicitly stopped.",
+        "type": "LoadingOptions",
+        "typeDefinitions": {
+          "LoadingOptions": {
+            "filePath": "src/features/loading.ts",
+            "name": "LoadingOptions",
+            "description": "The input parameter for the Loading API.",
+            "members": [
+              {
+                "filePath": "src/features/loading.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isLoading",
+                "value": "boolean",
+                "description": "Pass `true` to show the loading indicator, `false` to hide it.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface LoadingOptions {\n  /**\n   * Pass `true` to show the loading indicator, `false` to hide it.\n   */\n  isLoading?: boolean;\n}"
+          }
+        }
+      }
+    ]
   },
   {
     "name": "Modal API",
-    "overviewPreviewDescription": "Displays an overlay with important information.",
-    "description": "The Modal API allows you to display an overlay that prevents interaction with the rest of the app until dismissed.",
+    "overviewPreviewDescription": "Display an overlay that requires merchant attention",
+    "description": "The Modal API lets you display an overlay that prevents interaction with the rest of the app until dismissed. Use modals for confirmations, forms, or important information that requires merchant acknowledgement before proceeding.",
     "isVisualComponent": true,
     "category": "APIs",
+    "related": [],
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/modal.png",
+    "defaultExample": {
+      "description": "Show a modal. This example opens a modal using the `show` method with a unique modal ID. The modal remains visible until the merchant dismisses it or you call the `hide` method.",
+      "image": "/assets/templated-apis-screenshots/admin/apis/modal.png",
+      "codeblock": {
+        "title": "Show a modal",
+        "tabs": [
+          {
+            "code": "&lt;s-modal id=\"my-modal\"&gt;\n  &lt;s-text&gt;Hello, World!&lt;/s-text&gt;\n&lt;/s-modal&gt;\n\n&lt;s-button onclick=\"shopify.modal.show('my-modal')\"&gt;\n  Open Modal\n&lt;/s-button&gt;\n",
+            "language": "html"
+          }
+        ]
+      }
+    },
+    "examples": {
+      "description": "Examples that demonstrate how to use the Modal API.",
+      "examples": [
+        {
+          "description": "Hide a modal. This example closes an open modal using the `hide` method with the modal ID. Use this when you need to programmatically dismiss a modal after an action completes or when a condition is met.",
+          "codeblock": {
+            "title": "Hide a modal",
+            "tabs": [
+              {
+                "code": "&lt;s-modal id=\"my-modal\"&gt;\n  &lt;s-text&gt;Hello, World!&lt;/s-text&gt;\n  &lt;s-button onclick=\"shopify.modal.hide('my-modal')\"&gt;\n    Close\n  &lt;/s-button&gt;\n&lt;/s-modal&gt;\n\n&lt;s-button onclick=\"shopify.modal.show('my-modal')\"&gt;\n  Open Modal\n&lt;/s-button&gt;\n",
+                "language": "html"
+              }
+            ]
+          }
+        },
+        {
+          "description": "Toggle a modal. This example switches the modal visibility using the `toggle` method. If the modal is hidden it becomes visible, and if visible it becomes hidden. Use this for UI elements that open and close the same modal.",
+          "codeblock": {
+            "title": "Toggle a modal",
+            "tabs": [
+              {
+                "code": "&lt;s-modal id=\"my-modal\"&gt;\n  &lt;s-text&gt;Hello, World!&lt;/s-text&gt;\n&lt;/s-modal&gt;\n\n&lt;s-button onclick=\"shopify.modal.toggle('my-modal')\"&gt;\n  Toggle Modal\n&lt;/s-button&gt;\n",
+                "language": "html"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "definitions": [
       {
-        "title": "Modal",
-        "description": "The `modal` API provides a `show` method to display a Modal, a `hide` method to hide a Modal, and a `toggle` method to toggle the visibility of a Modal. These are used in conjunction with the [`ui-modal` element](/docs/api/app-bridge-library/web-components/ui-modal). They are alternatives to the `show`, `hide`, and `toggle` instance methods.",
+        "title": "Methods",
+        "description": "The `modal` function provides methods to control modal visibility by a component's ID. These methods work with the [`s-modal` component](/docs/api/app-home/polaris-web-components/overlays/modal) and are alternatives to calling instance methods directly on the element.",
         "type": "_ModalApi",
         "typeDefinitions": {
           "_ModalApi": {
@@ -3582,7 +3704,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "hide",
                 "value": "(id: string) => Promise<void>",
-                "description": "Hides the modal element. An alternative to the `hide` instance method on the `ui-modal` element.",
+                "description": "Hides the modal element. An alternative to the `hideOverlay` instance method on the `s-modal` component.",
                 "isOptional": true
               },
               {
@@ -3590,7 +3712,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "show",
                 "value": "(id: string) => Promise<void>",
-                "description": "Shows the modal element. An alternative to the `show` instance method on the `ui-modal` element.",
+                "description": "Shows the modal element. An alternative to the `showOverlay` instance method on the `s-modal` component.",
                 "isOptional": true
               },
               {
@@ -3598,261 +3720,147 @@
                 "syntaxKind": "MethodSignature",
                 "name": "toggle",
                 "value": "(id: string) => Promise<void>",
-                "description": "Toggles the modal element visibility. An alternative to the `toggle` instance method on the `ui-modal` element.",
+                "description": "Toggles the modal element visibility. An alternative to the `toggleOverlay` instance method on the `s-modal` component.",
                 "isOptional": true
               }
             ],
-            "value": "interface _ModalApi {\n  /**\n   * Shows the modal element. An alternative to the `show` instance method on the `ui-modal` element.\n   * @param id A unique identifier for the Modal\n   */\n  show?(id: string): Promise<void>;\n  /**\n   * Hides the modal element. An alternative to the `hide` instance method on the `ui-modal` element.\n   * @param id A unique identifier for the Modal\n   */\n  hide?(id: string): Promise<void>;\n  /**\n   * Toggles the modal element visibility. An alternative to the `toggle` instance method on the `ui-modal` element.\n   * @param id A unique identifier for the Modal\n   */\n  toggle?(id: string): Promise<void>;\n}"
+            "value": "interface _ModalApi {\n  /**\n   * Shows the modal element. An alternative to the `showOverlay` instance method on the `s-modal` component.\n   * @param id A unique identifier for the Modal\n   */\n  show?(id: string): Promise<void>;\n  /**\n   * Hides the modal element. An alternative to the `hideOverlay` instance method on the `s-modal` component.\n   * @param id A unique identifier for the Modal\n   */\n  hide?(id: string): Promise<void>;\n  /**\n   * Toggles the modal element visibility. An alternative to the `toggleOverlay` instance method on the `s-modal` component.\n   * @param id A unique identifier for the Modal\n   */\n  toggle?(id: string): Promise<void>;\n}"
           }
         }
-      }
-    ],
-    "defaultExample": {
-      "image": "/assets/templated-apis-screenshots/admin/apis/modal.png",
-      "codeblock": {
-        "title": "Modal",
-        "tabs": [
-          {
-            "title": "Modal",
-            "code": "&lt;ui-modal id=\"my-modal\"&gt;\n  &lt;p&gt;Hello, World!&lt;/p&gt;\n&lt;/ui-modal&gt;\n\n&lt;button onclick=\"shopify.modal.show('my-modal')\"&gt;Open Modal&lt;/button&gt;\n",
-            "language": "html"
-          }
-        ]
-      }
-    },
-    "related": [
-      {
-        "name": "ui-modal",
-        "subtitle": "Component",
-        "url": "/docs/api/app-bridge-library/web-components/ui-modal",
-        "type": "component"
-      },
-      {
-        "name": "Modal",
-        "subtitle": "Component",
-        "url": "/docs/api/app-bridge-library/react-components/modal-component",
-        "type": "component"
       }
     ]
   },
   {
     "name": "Navigation",
-    "overviewPreviewDescription": "Allows you to navigate within and outside of your app",
-    "description": "The Navigation API allows you navigate within and outside of your app using the [HTML anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a). It also allows you to modify the top-level browser URL with or without navigating. It does this through the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) and the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API).",
+    "overviewPreviewDescription": "Navigate within your app, to external URLs, or to Shopify admin pages",
+    "description": "The Navigation API lets you navigate within and outside of your app using the [HTML anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a). You can also modify the top-level browser URL with or without navigating using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) or the browser's native [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API).",
     "isVisualComponent": false,
     "defaultExample": {
+      "description": "Navigate to Shopify admin pages. This example uses the `shopify:` protocol to navigate to admin index pages (products, orders, customers) or directly to specific resources by appending the resource ID.",
       "codeblock": {
-        "title": "anchor",
+        "title": "Navigate to Shopify admin pages",
         "tabs": [
           {
-            "code": "&lt;a href=\"shopify://admin/products\" target=\"_top\"&gt;Products page&lt;/a&gt;\n",
+            "code": "&lt;!-- Index pages --&gt;\n&lt;a href=\"shopify://admin/products\" target=\"_top\"&gt;Products&lt;/a&gt;\n&lt;a href=\"shopify://admin/orders\" target=\"_top\"&gt;Orders&lt;/a&gt;\n&lt;a href=\"shopify://admin/customers\" target=\"_top\"&gt;Customers&lt;/a&gt;\n\n&lt;!-- Specific resources --&gt;\n&lt;a href=\"shopify://admin/products/123\" target=\"_top\"&gt;Product #123&lt;/a&gt;\n&lt;a href=\"shopify://admin/orders/456\" target=\"_top\"&gt;Order #456&lt;/a&gt;\n&lt;a href=\"shopify://admin/customers/789\" target=\"_top\"&gt;Customer #789&lt;/a&gt;\n",
             "language": "html"
           }
         ]
       }
     },
     "examples": {
-      "description": "Navigating and updating the browser URL",
-      "exampleGroups": [
+      "description": "Examples that demonstrate how to use the Navigation API.",
+      "examples": [
         {
-          "title": "Navigating to routes within your app",
-          "examples": [
-            {
-              "description": "Navigating to relative path within your app",
-              "codeblock": {
-                "title": "App navigation with relative path",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;a href=\"/settings\"&gt;Settings&lt;/a&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "JavaScript",
-                    "code": "open('/settings', '_self');\n",
-                    "language": "js"
-                  }
-                ]
+          "description": "Navigate to a relative path in your app. This example navigates to a route within your app using a relative path. Use anchor elements or `window.open()` with paths relative to your app root.",
+          "codeblock": {
+            "title": "Navigate to a relative path in your app",
+            "tabs": [
+              {
+                "title": "HTML",
+                "code": "&lt;a href=\"/settings\"&gt;Settings&lt;/a&gt;\n",
+                "language": "html"
+              },
+              {
+                "title": "JavaScript",
+                "code": "open('/settings', '_self');\n",
+                "language": "js"
               }
-            }
-          ]
+            ]
+          }
         },
         {
-          "title": "Navigating to external URL's",
-          "examples": [
-            {
-              "description": "Navigating to external URL in same window",
-              "codeblock": {
-                "title": "External URL in same window",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;a href=\"https://example.com\"&gt;Settings&lt;/a&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "JavaScript",
-                    "code": "open('https://example.com', '_top');\n",
-                    "language": "js"
-                  }
-                ]
+          "description": "Update the browser URL with the History API. This example uses `history.pushState()` and `history.replaceState()` to update the browser URL without triggering a page reload. Use `pushState` to add a new history entry, or `replaceState` to modify the current entry.",
+          "codeblock": {
+            "title": "Update the browser URL with the History API",
+            "tabs": [
+              {
+                "title": "pushState",
+                "code": "history.pushState(null, '', '/settings');\n",
+                "language": "js"
+              },
+              {
+                "title": "replaceState",
+                "code": "history.replaceState(null, '', '/settings');\n",
+                "language": "js"
               }
-            },
-            {
-              "description": "Navigating to external URL in new window",
-              "codeblock": {
-                "title": "External URL in new window",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;a href=\"https://example.com\" target=\"_blank\"&gt;Settings&lt;/a&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "JavaScript",
-                    "code": "open('https://example.com', '_blank');\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
+            ]
+          }
         },
         {
-          "title": "Navigating to pages in the Shopify admin",
-          "examples": [
-            {
-              "description": "Navigating to /products page",
-              "codeblock": {
-                "title": "/products page",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;a href=\"shopify://admin/products\" target=\"_top\"&gt;Products page&lt;/a&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "JavaScript",
-                    "code": "open('shopify://admin/products', '_top');\n",
-                    "language": "js"
-                  }
-                ]
+          "description": "Update the browser URL with the Navigation API. This example uses `navigation.navigate()` with history options to update the browser URL. The Navigation API provides a more modern alternative to the History API with better support for SPA routing.",
+          "codeblock": {
+            "title": "Update the browser URL with the Navigation API",
+            "tabs": [
+              {
+                "title": "pushState",
+                "code": "navigation.navigate('/settings', {\n  history: 'push',\n});\n",
+                "language": "js"
+              },
+              {
+                "title": "replaceState",
+                "code": "navigation.navigate('/settings', {\n  history: 'replace',\n});\n",
+                "language": "js"
               }
-            },
-            {
-              "description": "Navigating to /products page with specific resource",
-              "codeblock": {
-                "title": "/products page with resource",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;a href=\"shopify://admin/products/123\" target=\"_top\"&gt;Products page&lt;/a&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "JavaScript",
-                    "code": "open('shopify://admin/products/123', '_top');\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Navigating to /customers page",
-              "codeblock": {
-                "title": "/customers page",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;a href=\"shopify://admin/customers\" target=\"_top\"&gt;Customers page&lt;/a&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "JavaScript",
-                    "code": "open('shopify://admin/customers', '_top');\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Navigating to /orders page",
-              "codeblock": {
-                "title": "/orders page",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;a href=\"shopify://admin/orders\" target=\"_top\"&gt;Orders page&lt;/a&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "JavaScript",
-                    "code": "open('shopify://admin/orders', '_top');\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
+            ]
+          }
         },
         {
-          "title": "Updating the browser URL without navigating",
-          "examples": [
-            {
-              "description": "Using the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API)",
-              "codeblock": {
-                "title": "History API",
-                "tabs": [
-                  {
-                    "title": "pushState",
-                    "code": "history.pushState(null, '', '/settings');\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "replaceState",
-                    "code": "history.replaceState(null, '', '/settings');\n",
-                    "language": "js"
-                  }
-                ]
+          "description": "Open an external URL in a new window. This example opens an external URL in a new browser tab or window using `target=\"_blank\"`. The Shopify admin remains open in the original tab.",
+          "codeblock": {
+            "title": "Open an external URL in a new window",
+            "tabs": [
+              {
+                "title": "HTML",
+                "code": "&lt;a href=\"https://example.com\" target=\"_blank\"&gt;Settings&lt;/a&gt;\n",
+                "language": "html"
+              },
+              {
+                "title": "JavaScript",
+                "code": "open('https://example.com', '_blank');\n",
+                "language": "js"
               }
-            },
-            {
-              "description": "Using the [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API)",
-              "codeblock": {
-                "title": "Navigation API",
-                "tabs": [
-                  {
-                    "title": "pushState",
-                    "code": "navigation.navigate('/settings', {\n  history: 'push',\n});\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "replaceState",
-                    "code": "navigation.navigate('/settings', {\n  history: 'replace',\n});\n",
-                    "language": "js"
-                  }
-                ]
+            ]
+          }
+        },
+        {
+          "description": "Open an external URL in the current window. This example navigates to an external URL in the current window using `target=\"_top\"`. The browser leaves the Shopify admin and loads the external page.",
+          "codeblock": {
+            "title": "Open an external URL in the current window",
+            "tabs": [
+              {
+                "title": "HTML",
+                "code": "&lt;a href=\"https://example.com\"&gt;Settings&lt;/a&gt;\n",
+                "language": "html"
+              },
+              {
+                "title": "JavaScript",
+                "code": "open('https://example.com', '_top');\n",
+                "language": "js"
               }
-            }
-          ]
+            ]
+          }
         }
       ]
     },
     "definitions": [],
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "related": []
   },
   {
     "name": "Picker",
-    "overviewPreviewDescription": "Opens a Picker in your app",
-    "description": "The Picker API provides a search-based interface to help users find and select one or more resources that you provide, such as product reviews, email templates, or subscription options, and then returns the selected resource `id`s to your app.\n\n> Tip:\n> If you are picking products, product variants, or collections, you should use the [Resource Picker](resource-picker) API instead.\n",
+    "overviewPreviewDescription": "Let merchants search and select app-specific resources",
+    "description": "The Picker API lets merchants search for and select items from your app-specific data, such as product reviews, email templates, or subscription options. Use this API to build custom selection dialogs with your own data structure, badges, and thumbnails. The picker returns the IDs of selected items.\n\n> Tip:\n> If you need to pick Shopify products, variants, or collections, use the [Resource Picker](/docs/api/app-bridge-library/apis/resource-picker) API instead.",
     "isVisualComponent": true,
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/picker.png",
+    "related": [],
     "defaultExample": {
+      "description": "Select email templates. This example builds a custom picker for email templates with multiple columns and status badges. It defines column headers, populates items with searchable data fields, adds visual status indicators, and handles the selection promise. Use this pattern for app-specific resources like templates, product reviews, or subscription options.",
       "image": "/assets/templated-apis-screenshots/admin/apis/picker.png",
       "codeblock": {
-        "title": "Picker",
+        "title": "Select email templates",
         "tabs": [
           {
             "code": "const picker = await shopify.picker({\n  heading: 'Select a template',\n  multiple: false,\n  headers: [\n    {content: 'Templates'},\n    {content: 'Created by'},\n    {content: 'Times used', type: 'number'},\n  ],\n  items: [\n    {\n      id: '1',\n      heading: 'Full width, 1 column',\n      data: ['Karine Ruby', '0'],\n      badges: [{content: 'Draft', tone: 'info'}, {content: 'Marketing'}],\n    },\n    {\n      id: '2',\n      heading: 'Large graphic, 3 column',\n      data: ['Charlie Mitchell', '5'],\n      badges: [\n        {content: 'Published', tone: 'success'},\n        {content: 'New feature'},\n      ],\n      selected: true,\n    },\n    {\n      id: '3',\n      heading: 'Promo header, 2 column',\n      data: ['Russell Winfield', '10'],\n      badges: [{content: 'Published', tone: 'success'}],\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
@@ -3861,288 +3869,64 @@
         ]
       }
     },
-    "definitions": [
-      {
-        "title": "picker",
-        "description": "The `picker` API is a function that accepts an options argument for configuration and returns a Promise that resolves to the picker instance once the picker modal is opened.",
-        "type": "PublicPickerApi",
-        "typeDefinitions": {
-          "PublicPickerApi": {
-            "filePath": "src/types.ts",
-            "name": "PublicPickerApi",
-            "description": "",
-            "params": [
-              {
-                "name": "options",
-                "description": "",
-                "value": "PickerOptions",
-                "filePath": "src/types.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "src/types.ts",
-              "description": "",
-              "name": "Promise<PickerInstance>",
-              "value": "Promise<PickerInstance>"
-            },
-            "value": "(\n  options: PickerOptions,\n) => Promise<PickerInstance>"
-          },
-          "PickerOptions": {
-            "filePath": "src/types.ts",
-            "name": "PickerOptions",
-            "description": "",
-            "members": [
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "headers",
-                "value": "Header[]",
-                "description": "The data headers for the picker. These are used to display the table headers in the picker modal.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "heading",
-                "value": "string",
-                "description": "The heading of the picker. This is displayed in the title of the picker modal."
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "items",
-                "value": "PickerItem[]",
-                "description": "The items to display in the picker. These are used to display the rows in the picker modal."
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "multiple",
-                "value": "boolean | number",
-                "description": "Whether to allow selecting multiple items of a specific type or not. If a number is provided, then limit the selections to a maximum of that number of items.",
-                "isOptional": true,
-                "defaultValue": "false"
-              }
-            ],
-            "value": "export interface PickerOptions {\n  /**\n   * The heading of the picker. This is displayed in the title of the picker modal.\n   */\n  heading: string;\n  /**\n   * Whether to allow selecting multiple items of a specific type or not. If a number is provided, then limit the selections to a maximum of that number of items.\n   * @defaultValue false\n   */\n  multiple?: boolean | number;\n  /**\n   * The data headers for the picker. These are used to display the table headers in the picker modal.\n   */\n  headers?: Header[];\n  /**\n   * The items to display in the picker. These are used to display the rows in the picker modal.\n   */\n  items: PickerItem[];\n}"
-          },
-          "Header": {
-            "filePath": "src/types.ts",
-            "name": "Header",
-            "description": "",
-            "members": [
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "content",
-                "value": "string",
-                "description": "The content to display in the table column header.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "type",
-                "value": "'string' | 'number'",
-                "description": "The type of data to display in the column. The type is used to format the data in the column. If the type is 'number', the data in the column will be right-aligned, this should be used when referencing currency or numeric values. If the type is 'string', the data in the column will be left-aligned.",
-                "isOptional": true,
-                "defaultValue": "'string'"
-              }
-            ],
-            "value": "interface Header {\n  /**\n   * The content to display in the table column header.\n   */\n  content?: string;\n  /**\n   * The type of data to display in the column. The type is used to format the data in the column.\n   * If the type is 'number', the data in the column will be right-aligned, this should be used when referencing currency or numeric values.\n   * If the type is 'string', the data in the column will be left-aligned.\n   * @defaultValue 'string'\n   */\n  type?: 'string' | 'number';\n}"
-          },
-          "PickerItem": {
-            "filePath": "src/types.ts",
-            "name": "PickerItem",
-            "description": "",
-            "members": [
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "badges",
-                "value": "Badge[]",
-                "description": "The badges to display in the first column of the row. These are used to display additional information about the item, such as progress of an action or tone indicating the status of that item.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "data",
-                "value": "DataPoint[]",
-                "description": "The additional content to display in the second and third columns of the row, if provided.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "disabled",
-                "value": "boolean",
-                "description": "Whether the item is disabled or not. If the item is disabled, it cannot be selected.",
-                "isOptional": true,
-                "defaultValue": "false"
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "heading",
-                "value": "string",
-                "description": "The primary content to display in the first column of the row."
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "selected",
-                "value": "boolean",
-                "description": "Whether the item is selected or not when the picker is opened. The user may deselect the item if it is preselected.",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "thumbnail",
-                "value": "{ url: string; }",
-                "description": "The thumbnail to display at the start of the row. This is used to display an image or icon for the item.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface PickerItem {\n  /*\n   * The unique identifier of the item. This will be returned by the picker if selected.\n   */\n  id: string;\n  /**\n   * The primary content to display in the first column of the row.\n   */\n  heading: string;\n  /**\n   * The additional content to display in the second and third columns of the row, if provided.\n   */\n  data?: DataPoint[];\n  /**\n   * Whether the item is disabled or not. If the item is disabled, it cannot be selected.\n   * @defaultValue false\n   */\n  disabled?: boolean;\n  /**\n   * Whether the item is selected or not when the picker is opened. The user may deselect the item if it is preselected.\n   */\n  selected?: boolean;\n  /**\n   * The badges to display in the first column of the row. These are used to display additional information about the item, such as progress of an action or tone indicating the status of that item.\n   */\n  badges?: Badge[];\n  /**\n   * The thumbnail to display at the start of the row. This is used to display an image or icon for the item.\n   */\n  thumbnail?: { url: string };\n}"
-          },
-          "Badge": {
-            "filePath": "src/types.ts",
-            "name": "Badge",
-            "description": "",
-            "members": [
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "content",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "progress",
-                "value": "Progress",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "tone",
-                "value": "Tone",
-                "description": "",
-                "isOptional": true
-              }
-            ],
-            "value": "interface Badge {\n  content: string;\n  tone?: Tone;\n  progress?: Progress;\n}"
-          },
-          "Progress": {
-            "filePath": "src/types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "Progress",
-            "value": "'incomplete' | 'partiallyComplete' | 'complete'",
-            "description": ""
-          },
-          "Tone": {
-            "filePath": "src/types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "Tone",
-            "value": "'info' | 'success' | 'warning' | 'critical'",
-            "description": ""
-          },
-          "DataPoint": {
-            "filePath": "src/types.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "DataPoint",
-            "value": "string | number | undefined",
-            "description": ""
-          },
-          "PickerInstance": {
-            "filePath": "src/types.ts",
-            "name": "PickerInstance",
-            "description": "",
-            "members": [
-              {
-                "filePath": "src/types.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "selected",
-                "value": "Promise<string[]>",
-                "description": "A Promise that resolves with the selected item IDs when the user presses the \"Select\" button in the picker.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface PickerInstance {\n  /**\n   * A Promise that resolves with the selected item IDs when the user presses the \"Select\" button in the picker.\n   */\n  selected?: Promise<string[]>;\n}"
-          }
-        }
-      }
-    ],
     "examples": {
-      "description": "Pickers with different options",
+      "description": "Examples that demonstrate how to use the Picker API.",
       "examples": [
         {
-          "description": "Minimal required fields picker configuration.\n\nIf you don't provide the required options (`heading` and `items`), the picker will not open and an error will be logged.",
+          "description": "Limit selection count. This example limits selection to a maximum number of items by setting `multiple: 2` in the picker options. Use this when your feature has hard constraints, such as A/B test variants needing exactly two options, comparison views with fixed slots, or integration mappings that support a specific connection count.",
           "codeblock": {
-            "title": "Simple picker",
+            "title": "Limit selection count",
             "tabs": [
               {
-                "code": "const picker = await shopify.picker({\n  heading: 'Simple picker configuration',\n  items: [\n    {\n      id: '1',\n      heading: 'Item 1',\n    },\n    {\n      id: '2',\n      heading: 'Item 2',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
+                "code": "const picker = await shopify.picker({\n  heading: 'Select up to 2 templates',\n  multiple: 2,\n  headers: [{content: 'Template'}],\n  items: [\n    {\n      id: '1',\n      heading: 'Welcome email',\n    },\n    {\n      id: '2',\n      heading: 'Order confirmation',\n    },\n    {\n      id: '3',\n      heading: 'Shipping notification',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
                 "language": "js"
               }
             ]
           }
         },
         {
-          "description": "Setting a specific number of selectable items. In this example, the user can select up to 2 items.",
+          "description": "Select unlimited items. This example allows unlimited selection by setting `multiple: true` without a numeric limit. Use this for bulk operations, mass notification sending, export tools, or tag management where selection quantity depends on merchant needs without artificial constraints.",
           "codeblock": {
-            "title": "Limited selectable items",
+            "title": "Select unlimited items",
             "tabs": [
               {
-                "code": "const picker = await shopify.picker({\n  heading: 'Limited selectable items (up to 2)',\n  multiple: 2,\n  headers: [{content: 'Main heading'}],\n  items: [\n    {\n      id: '1',\n      heading: 'Item 1',\n    },\n    {\n      id: '2',\n      heading: 'Item 2',\n    },\n    {\n      id: '3',\n      heading: 'Item 3',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
+                "code": "const picker = await shopify.picker({\n  heading: 'Select templates',\n  multiple: true,\n  headers: [{content: 'Template'}],\n  items: [\n    {\n      id: '1',\n      heading: 'Welcome email',\n    },\n    {\n      id: '2',\n      heading: 'Order confirmation',\n    },\n    {\n      id: '3',\n      heading: 'Shipping notification',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
                 "language": "js"
               }
             ]
           }
         },
         {
-          "description": "Setting an unlimited number of selectable items.",
+          "description": "Preselect items. This example opens the picker with items already selected by setting `selected: true` on individual items. Use this for edit workflows where you need to show what resources are already associated with a configuration. Merchants can modify the selection before confirming.",
           "codeblock": {
-            "title": "Unlimited selectable items",
+            "title": "Preselect items",
             "tabs": [
               {
-                "code": "const picker = await shopify.picker({\n  heading: 'Unlimited selectable items',\n  multiple: true,\n  headers: [{content: 'Main heading'}],\n  items: [\n    {\n      id: '1',\n      heading: 'Item 1',\n    },\n    {\n      id: '2',\n      heading: 'Item 2',\n    },\n    {\n      id: '3',\n      heading: 'Item 3',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
+                "code": "const picker = await shopify.picker({\n  heading: 'Select templates',\n  items: [\n    {\n      id: '1',\n      heading: 'Welcome email',\n      selected: true,\n    },\n    {\n      id: '2',\n      heading: 'Order confirmation',\n    },\n    {\n      id: '3',\n      heading: 'Shipping notification',\n      selected: true,\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
                 "language": "js"
               }
             ]
           }
         },
         {
-          "description": "Providing preselected items in the picker. These will be selected when the picker opens but can be deselected by the user.",
+          "description": "Disable specific items. This example disables specific picker items to prevent selection while keeping them visible for context. Set `disabled: true` on individual items to mark them as non-selectable. Use this for showing all available options while preventing selection of incompatible resources or deprecated features.",
           "codeblock": {
-            "title": "Preselected items",
+            "title": "Disable specific items",
             "tabs": [
               {
-                "code": "const picker = await shopify.picker({\n  heading: 'Preselected items',\n  items: [\n    {\n      id: '1',\n      heading: 'Item 1',\n      selected: true,\n    },\n    {\n      id: '2',\n      heading: 'Item 2',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
+                "code": "const picker = await shopify.picker({\n  heading: 'Select a template',\n  items: [\n    {\n      id: '1',\n      heading: 'Welcome email',\n      disabled: true,\n    },\n    {\n      id: '2',\n      heading: 'Order confirmation',\n    },\n    {\n      id: '3',\n      heading: 'Shipping notification',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
                 "language": "js"
               }
             ]
           }
         },
         {
-          "description": "Providing disabled items in the picker. These will be disabled and cannot be selected by the user.",
+          "description": "Use GraphQL data. This example populates the picker with data from the GraphQL Admin API. It fetches order data, maps results to picker items with badges showing fulfillment and payment status, and opens the picker with the returned data. Use this pattern for Shopify data not available through the Resource Picker API, such as orders, draft orders, or fulfillments.",
           "codeblock": {
-            "title": "Disabled items",
+            "title": "Use GraphQL data",
             "tabs": [
               {
-                "code": "const picker = await shopify.picker({\n  heading: 'Disabled items',\n  items: [\n    {\n      id: '1',\n      heading: 'Item 1',\n      disabled: true,\n    },\n    {\n      id: '2',\n      heading: 'Item 2',\n    },\n  ],\n});\n\nconst selected = await picker.selected;\n",
+                "code": "const response = await fetch('shopify:admin/api/graphql.json', {\n  method: 'POST',\n  body: JSON.stringify({\n    query: `\n      query GetOrders($first: Int!) {\n        orders(first: $first) {\n          edges {\n            node {\n              id\n              name\n              customer {\n                displayName\n              }\n              originalTotalPriceSet {\n                shopMoney {\n                  amount\n                }\n              }\n              displayFulfillmentStatus\n              displayFinancialStatus\n            }\n          }\n        }\n      }\n    `,\n    variables: {first: 10},\n  }),\n});\n\nconst {data} = await response.json();\nconst orders = data.orders.edges;\n\nconst picker = await shopify.picker({\n  heading: 'Select orders',\n  multiple: true,\n  headers: [\n    {content: 'Order'},\n    {content: 'Customer'},\n    {content: 'Total', type: 'number'},\n  ],\n  items: orders.map(({node: order}) =&gt; ({\n    id: order.id,\n    heading: order.name,\n    data: [order.customer.displayName, `$${order.originalTotalPriceSet.shopMoney.amount}`],\n    badges: [\n      {\n        content: order.displayFulfillmentStatus,\n        tone: order.displayFulfillmentStatus === 'FULFILLED' ? 'success' : 'warning',\n        progress: order.displayFulfillmentStatus === 'FULFILLED' ? 'complete' : 'incomplete',\n      },\n      {\n        content: order.displayFinancialStatus,\n        tone: order.displayFinancialStatus === 'PAID' ? 'success' : 'warning',\n        progress: order.displayFinancialStatus === 'PAID' ? 'complete' : 'incomplete',\n      },\n    ],\n  })),\n});\n\nconst selected = await picker.selected;\n",
                 "language": "js"
               }
             ]
@@ -4150,21 +3934,225 @@
         }
       ]
     },
-    "related": [
+    "definitions": [
       {
-        "name": "Picker",
-        "subtitle": "APIs",
-        "url": "/docs/api/admin-extensions/unstable/api/target-apis/picker",
-        "type": "component"
+        "title": "Inputs",
+        "description": "The `picker` function opens a custom selection dialog with your app-specific data. It accepts configuration options to define the picker's heading, items, headers, and selection behavior. It returns a Promise that resolves to a `Picker` object with a `selected` property for accessing the merchant's selection.",
+        "type": "PickerOptions",
+        "typeDefinitions": {
+          "PickerOptions": {
+            "filePath": "src/types.ts",
+            "name": "PickerOptions",
+            "description": "The configuration options for the custom picker dialog. Define the picker's appearance, selection behavior, and data structure.",
+            "members": [
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "Header[]",
+                "description": "The column headers for the picker table. Define headers to label and organize the data columns displayed for each item. The header order determines the column layout.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "heading",
+                "value": "string",
+                "description": "The heading displayed at the top of the picker modal. Use a clear, descriptive title that tells merchants what they're selecting."
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "items",
+                "value": "PickerItem[]",
+                "description": "The list of items that merchants can select from. Each item appears as a row in the picker table."
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "multiple",
+                "value": "boolean | number",
+                "description": "The selection mode for the picker. Pass `true` to allow unlimited selections, `false` for single-item selection only, or a number to set a maximum selection limit (for example, `3` allows up to three items).",
+                "isOptional": true,
+                "defaultValue": "false"
+              }
+            ],
+            "value": "export interface PickerOptions {\n  /**\n   * The heading displayed at the top of the picker modal. Use a clear, descriptive title that tells merchants what they're selecting.\n   */\n  heading: string;\n  /**\n   * The selection mode for the picker. Pass `true` to allow unlimited selections, `false` for single-item selection only, or a number to set a maximum selection limit (for example, `3` allows up to three items).\n   * @defaultValue false\n   */\n  multiple?: boolean | number;\n  /**\n   * The column headers for the picker table. Define headers to label and organize the data columns displayed for each item. The header order determines the column layout.\n   */\n  headers?: Header[];\n  /**\n   * The list of items that merchants can select from. Each item appears as a row in the picker table.\n   */\n  items: PickerItem[];\n}"
+          },
+          "Header": {
+            "filePath": "src/types.ts",
+            "name": "Header",
+            "description": "The configuration for a table column header in the picker. Each header creates a labeled column that displays corresponding data from items.",
+            "members": [
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "content",
+                "value": "string",
+                "description": "The label text displayed at the top of the table column. Use clear, concise labels that describe the data in that column (for example, \"Price\", \"Status\", \"Last Updated\").",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "type",
+                "value": "'string' | 'number'",
+                "description": "The data type that controls column formatting and text alignment. Use `'number'` for currency, prices, or numeric values (displays right-aligned), or `'string'` for text content (displays left-aligned).",
+                "isOptional": true,
+                "defaultValue": "'string'"
+              }
+            ],
+            "value": "interface Header {\n  /**\n   * The label text displayed at the top of the table column. Use clear, concise labels that describe the data in that column (for example, \"Price\", \"Status\", \"Last Updated\").\n   */\n  content?: string;\n  /**\n   * The data type that controls column formatting and text alignment. Use `'number'` for currency, prices, or numeric values (displays right-aligned), or `'string'` for text content (displays left-aligned).\n   * @defaultValue 'string'\n   */\n  type?: 'string' | 'number';\n}"
+          },
+          "PickerItem": {
+            "filePath": "src/types.ts",
+            "name": "PickerItem",
+            "description": "An individual item that merchants can select in the picker. Each item appears as a row in the picker table.",
+            "members": [
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "badges",
+                "value": "Badge[]",
+                "description": "Status or context badges displayed next to the heading in the first column. Use badges to highlight item state, completion status, or other important attributes (for example, \"Draft\", \"Published\", \"Incomplete\").",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "data",
+                "value": "DataPoint[]",
+                "description": "Additional data displayed in subsequent columns after the heading. Each value appears in its own column, and the order must match the `headers` array. For example, if headers are `[\"Price\", \"Status\"]`, then data would be `[19.99, \"Active\"]`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "disabled",
+                "value": "boolean",
+                "description": "Whether the item can be selected. When `true`, the item is disabled and can't be selected. Disabled items appear grayed out. Use this for items that are unavailable or don't meet selection criteria.",
+                "isOptional": true,
+                "defaultValue": "false"
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "heading",
+                "value": "string",
+                "description": "The primary text displayed in the first column. This is typically the item's name or title and is the most prominent text in the row."
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "The unique identifier for this item. This ID is returned in the selection array when the merchant selects this item. Use an ID that helps you identify the item in your system (for example, template IDs, review IDs, or custom option keys)."
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "selected",
+                "value": "boolean",
+                "description": "Whether the item is preselected when the picker opens. When `true`, the item appears selected by default. Merchants can still deselect preselected items. Use this to show current selections or suggest default choices.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "thumbnail",
+                "value": "{ url: string; }",
+                "description": "A small preview image or icon displayed at the start of the row. Thumbnails help merchants visually identify items at a glance. Provide a URL to the image file.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface PickerItem {\n  /**\n   * The unique identifier for this item. This ID is returned in the selection array when the merchant selects this item. Use an ID that helps you identify the item in your system (for example, template IDs, review IDs, or custom option keys).\n   */\n  id: string;\n  /**\n   * The primary text displayed in the first column. This is typically the item's name or title and is the most prominent text in the row.\n   */\n  heading: string;\n  /**\n   * Additional data displayed in subsequent columns after the heading. Each value appears in its own column, and the order must match the `headers` array. For example, if headers are `[\"Price\", \"Status\"]`, then data would be `[19.99, \"Active\"]`.\n   */\n  data?: DataPoint[];\n  /**\n   * Whether the item can be selected. When `true`, the item is disabled and can't be selected. Disabled items appear grayed out. Use this for items that are unavailable or don't meet selection criteria.\n   * @defaultValue false\n   */\n  disabled?: boolean;\n  /**\n   * Whether the item is preselected when the picker opens. When `true`, the item appears selected by default. Merchants can still deselect preselected items. Use this to show current selections or suggest default choices.\n   */\n  selected?: boolean;\n  /**\n   * Status or context badges displayed next to the heading in the first column. Use badges to highlight item state, completion status, or other important attributes (for example, \"Draft\", \"Published\", \"Incomplete\").\n   */\n  badges?: Badge[];\n  /**\n   * A small preview image or icon displayed at the start of the row. Thumbnails help merchants visually identify items at a glance. Provide a URL to the image file.\n   */\n  thumbnail?: {url: string};\n}"
+          },
+          "Badge": {
+            "filePath": "src/types.ts",
+            "name": "Badge",
+            "description": "A badge displayed next to an item in the picker to show status or progress. Use badges to highlight important item attributes or states that affect selection decisions.",
+            "members": [
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "content",
+                "value": "string",
+                "description": "The text content of the badge. Keep this short and descriptive (for example, \"Draft\", \"Active\", \"Incomplete\")."
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "progress",
+                "value": "Progress",
+                "description": "The progress indicator for the badge. Use this to show completion status for items that have progress states.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "tone",
+                "value": "Tone",
+                "description": "The visual tone indicating status or importance. Choose a tone that matches the badge's meaning.",
+                "isOptional": true
+              }
+            ],
+            "value": "interface Badge {\n  /** The text content of the badge. Keep this short and descriptive (for example, \"Draft\", \"Active\", \"Incomplete\"). */\n  content: string;\n  /** The visual tone indicating status or importance. Choose a tone that matches the badge's meaning. */\n  tone?: Tone;\n  /** The progress indicator for the badge. Use this to show completion status for items that have progress states. */\n  progress?: Progress;\n}"
+          },
+          "Progress": {
+            "filePath": "src/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Progress",
+            "value": "'incomplete' | 'partiallyComplete' | 'complete'",
+            "description": "The progress state for picker badges showing completion status. Use this to indicate how complete an item is: `'incomplete'` for not started, `'partiallyComplete'` for in progress, or `'complete'` for finished."
+          },
+          "Tone": {
+            "filePath": "src/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Tone",
+            "value": "'info' | 'success' | 'warning' | 'critical'",
+            "description": "The visual tone for picker badges indicating status or importance. Use different tones to communicate urgency or state: `'info'` for neutral information, `'success'` for positive states, `'warning'` for caution, or `'critical'` for urgent issues."
+          },
+          "DataPoint": {
+            "filePath": "src/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "DataPoint",
+            "value": "string | number | undefined",
+            "description": "A single data point that can appear in a picker table cell. Can be text, a number, or undefined if the cell should be empty."
+          }
+        }
+      },
+      {
+        "title": "Return payload",
+        "description": "The picker returns a Promise that resolves to an object containing the `selected` property. Use this handle to await the merchant's selection result.",
+        "type": "PickerInstance",
+        "typeDefinitions": {
+          "PickerInstance": {
+            "filePath": "src/types.ts",
+            "name": "PickerInstance",
+            "description": "A handle returned when opening a picker dialog. Use this to access the merchant's selection after they confirm or cancel the picker.",
+            "members": [
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "selected",
+                "value": "Promise<string[]>",
+                "description": "A Promise that resolves with an array of selected item IDs when the merchant presses the **Select** button, or `undefined` if they cancel. Await this Promise to handle the selection result.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface PickerInstance {\n  /**\n   * A Promise that resolves with an array of selected item IDs when the merchant presses the **Select** button, or `undefined` if they cancel. Await this Promise to handle the selection result.\n   */\n  selected?: Promise<string[]>;\n}"
+          }
+        }
       }
     ]
   },
   {
     "name": "POS",
     "overviewPreviewDescription": "Interact and retrieve data for the POS",
-    "description": "\n  The POS API provides the ability to retrieve POS user, device, and location data, while also interacting with the cart and closing the app.\n\n  > Tip:\n  > It is recommended to use POS UI extensions for your development needs as they provide a faster, more robust, and easier to use solution for merchants using apps on POS. To learn more about the benefits and implementation details, refer to [POS UI Extensions](/docs/apps/pos/ui-extensions).\n  ",
+    "description": "The POS API provides comprehensive access to Point of Sale data and cart operations, enabling apps to retrieve device and location information, manage the cart during a sale, apply discounts, and handle customer data. This API supports individual and bulk cart operations for efficient transaction management.\n\n> Tip:\n> We recommend using [POS UI extensions](/docs/api/pos-ui-extensions/) for your development needs as they provide a faster, more robust, and easier to use solution for merchants using apps on POS.\n  ",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Device and platform integration",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/pos.png",
     "related": [],
     "definitions": [
@@ -4783,7 +4771,7 @@
       },
       {
         "title": "Close",
-        "description": "Close the app",
+        "description": "Close the app.",
         "type": "PosClose",
         "typeDefinitions": {
           "PosClose": {
@@ -4803,7 +4791,7 @@
       },
       {
         "title": "Device",
-        "description": "Retrieve device data ",
+        "description": "Retrieve device data.",
         "type": "PosDevice",
         "typeDefinitions": {
           "PosDevice": {
@@ -4845,7 +4833,7 @@
       },
       {
         "title": "Location",
-        "description": "Retrieve location data",
+        "description": "Retrieve location data.",
         "type": "PosLocation",
         "typeDefinitions": {
           "PosLocation": {
@@ -4992,7 +4980,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accountAccess",
                 "value": "string",
-                "description": "The account access level of the logged-in user",
+                "description": "The account access level of the logged-in user.",
                 "isOptional": true
               },
               {
@@ -5024,7 +5012,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "number",
-                "description": "The ID of the user's staff.",
+                "description": "The staff member's numeric ID.",
                 "isOptional": true
               },
               {
@@ -5036,15 +5024,16 @@
                 "isOptional": true
               }
             ],
-            "value": "export interface POSUser {\n  /**\n   * The ID of the user's staff.\n   */\n  id?: number;\n  /**\n   * The user's first name.\n   */\n  firstName?: string;\n  /**\n   * The user's last name.\n   */\n  lastName?: string;\n  /**\n   * The user's email address.\n   */\n  email?: string;\n  /**\n   *   The account access level of the logged-in user\n   */\n  accountAccess?: string;\n  /**\n   * The user's account type.\n   */\n  accountType?: string;\n}"
+            "value": "export interface POSUser {\n  /**\n   * The staff member's numeric ID.\n   */\n  id?: number;\n  /**\n   * The user's first name.\n   */\n  firstName?: string;\n  /**\n   * The user's last name.\n   */\n  lastName?: string;\n  /**\n   * The user's email address.\n   */\n  email?: string;\n  /**\n   * The account access level of the logged-in user.\n   */\n  accountAccess?: string;\n  /**\n   * The user's account type.\n   */\n  accountType?: string;\n}"
           }
         }
       }
     ],
     "defaultExample": {
+      "description": "Retrieve current cart data. This example fetches the cart object containing line items, customer, and totals.",
       "image": "/assets/templated-apis-screenshots/admin/apis/pos.png",
       "codeblock": {
-        "title": "Fetch the POS cart",
+        "title": "Get cart data",
         "tabs": [
           {
             "code": "await shopify.pos.cart.fetch();\n",
@@ -5054,23 +5043,13 @@
       }
     },
     "examples": {
-      "description": "Examples for retrieving and interacting with data on the POS",
+      "description": "Examples for retrieving and interacting with data on the POS.",
       "exampleGroups": [
         {
-          "title": "Cart",
+          "title": "",
           "examples": [
             {
-              "codeblock": {
-                "title": "Fetch the cart",
-                "tabs": [
-                  {
-                    "code": "await shopify.pos.cart.fetch();\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            },
-            {
+              "description": "Listen for cart changes. This example subscribes to a callback that fires whenever the cart is updated.",
               "codeblock": {
                 "title": "Subscribe to cart updates",
                 "tabs": [
@@ -5082,6 +5061,7 @@
               }
             },
             {
+              "description": "Reset the cart to an empty state. This example clears all items, customer, and discounts from the cart.",
               "codeblock": {
                 "title": "Clear the cart",
                 "tabs": [
@@ -5093,8 +5073,9 @@
               }
             },
             {
+              "description": "Manage products in the cart. This example adds a variant by ID, updates quantity using the line item UUID, and removes items.",
               "codeblock": {
-                "title": "Line Items",
+                "title": "Add, update, or remove line items",
                 "tabs": [
                   {
                     "title": "Add line item",
@@ -5115,8 +5096,9 @@
               }
             },
             {
+              "description": "Add items without a product variant. This example creates a custom sale with a price, quantity, title, and tax setting.",
               "codeblock": {
-                "title": "Custom Sale",
+                "title": "Add a custom sale",
                 "tabs": [
                   {
                     "title": "Add custom sale",
@@ -5127,84 +5109,9 @@
               }
             },
             {
+              "description": "Apply discounts to specific items. This example sets a percentage or fixed discount on a line item using its UUID.",
               "codeblock": {
-                "title": "Customers",
-                "tabs": [
-                  {
-                    "title": "Add a customer by email",
-                    "code": "await shopify.pos.cart.setCustomer({\n  email: 'foo@shopify.com',\n  firstName: 'Jane',\n  lastName: 'Doe',\n  note: 'Customer note',\n});\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Add a customer by id",
-                    "code": "await shopify.pos.cart.setCustomer({\n  id: 5945486803009,\n  note: 'Customer note',\n});\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Remove customer",
-                    "code": "await shopify.pos.cart.removeCustomer();\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Add a customer address",
-                    "code": "await shopify.pos.cart.addAddress({\n  address1: '123 Cherry St.',\n  address2: 'Apt. 5',\n  city: 'Toronto',\n  company: 'Shopify',\n  firstName: 'Foo',\n  lastName: 'Bar',\n  phone: '(613) 555-5555',\n  province: 'Ontario',\n  country: 'Canada',\n  zip: 'M5V0G4',\n  name: 'Shopify',\n  provinceCode: 'M5V0G4',\n  countryCode: '1',\n});\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Update customer address",
-                    "code": "await shopify.pos.cart.updateAddress(0, {\n  address1: '555 Apple St.',\n  address2: 'Unit. 10',\n  city: 'Vancouver',\n  company: 'Shopify',\n  firstName: 'Jane',\n  lastName: 'Doe',\n  phone: '(403) 555-5555',\n  province: 'British Columbia',\n  country: 'Canada',\n  zip: 'M5V0G4',\n  name: 'Shopify',\n  provinceCode: 'M5V0G4',\n  countryCode: '2',\n});\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            },
-            {
-              "codeblock": {
-                "title": "Addresses",
-                "tabs": [
-                  {
-                    "title": "Add a customer address",
-                    "code": "await shopify.pos.cart.addAddress({\n  address1: '123 Cherry St.',\n  address2: 'Apt. 5',\n  city: 'Toronto',\n  company: 'Shopify',\n  firstName: 'Foo',\n  lastName: 'Bar',\n  phone: '(613) 555-5555',\n  province: 'Ontario',\n  country: 'Canada',\n  zip: 'M5V0G4',\n  name: 'Shopify',\n  provinceCode: 'M5V0G4',\n  countryCode: '1',\n});\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Update customer address",
-                    "code": "await shopify.pos.cart.updateAddress(0, {\n  address1: '555 Apple St.',\n  address2: 'Unit. 10',\n  city: 'Vancouver',\n  company: 'Shopify',\n  firstName: 'Jane',\n  lastName: 'Doe',\n  phone: '(403) 555-5555',\n  province: 'British Columbia',\n  country: 'Canada',\n  zip: 'M5V0G4',\n  name: 'Shopify',\n  provinceCode: 'M5V0G4',\n  countryCode: '2',\n});\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            },
-            {
-              "codeblock": {
-                "title": "Cart Discounts",
-                "tabs": [
-                  {
-                    "title": "Add cart discount",
-                    "code": "await shopify.pos.cart.applyCartDiscount('FixedAmount', 'Holiday sale', '10');\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Add dicount code",
-                    "code": "await shopify.pos.cart.applyCartCodeDiscount('HOLIDAY SALE');\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Remove cart discount",
-                    "code": "await shopify.pos.cart.removeCartDiscount();\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Remove all discounts with automatic discounts disabled",
-                    "code": "await shopify.pos.cart.removeAllDiscounts(true);\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            },
-            {
-              "codeblock": {
-                "title": "Line Item Discounts",
+                "title": "Apply line item discounts",
                 "tabs": [
                   {
                     "title": "Add line item discount",
@@ -5220,19 +5127,10 @@
               }
             },
             {
+              "description": "Attach custom metadata to items. This example adds and removes key-value properties on a line item.",
               "codeblock": {
-                "title": "Cart Properties",
+                "title": "Set line item properties",
                 "tabs": [
-                  {
-                    "title": "Add cart properties",
-                    "code": "await shopify.pos.cart.addCartProperties({\n  referral: 'Shopify',\n  employee: '472',\n});\n",
-                    "language": "js"
-                  },
-                  {
-                    "title": "Remove cart properties",
-                    "code": "await shopify.pos.cart.removeCartProperties(['referral', 'employee']);\n",
-                    "language": "js"
-                  },
                   {
                     "title": "Add line item properties",
                     "code": "const cart = await shopify.pos.cart.fetch();\nconst lineItemUuid = cart.lineItems[0].uuid;\nawait shopify.pos.cart.addLineItemProperties(lineItemUuid, {\n  referral: 'Shopify',\n  employee: '472',\n});\n",
@@ -5247,46 +5145,96 @@
               }
             },
             {
+              "description": "Associate a customer with the cart. This example sets a customer by email or ID, or removes an existing customer.",
               "codeblock": {
-                "title": "Line Item Properties",
+                "title": "Assign a customer",
                 "tabs": [
                   {
-                    "title": "Add line item properties",
-                    "code": "const cart = await shopify.pos.cart.fetch();\nconst lineItemUuid = cart.lineItems[0].uuid;\nawait shopify.pos.cart.addLineItemProperties(lineItemUuid, {\n  referral: 'Shopify',\n  employee: '472',\n});\n",
+                    "title": "Add a customer by email",
+                    "code": "await shopify.pos.cart.setCustomer({\n  email: 'foo@shopify.com',\n  firstName: 'Jane',\n  lastName: 'Doe',\n  note: 'Customer note',\n});\n",
                     "language": "js"
                   },
                   {
-                    "title": "Remove line item properties",
-                    "code": "const cart = await shopify.pos.cart.fetch();\nconst lineItemUuid = cart.lineItems[0].uuid;\nawait shopify.pos.cart.removeLineItemProperties(lineItemUuid, [\n  'referral',\n  'employee',\n]);\n",
+                    "title": "Add a customer by ID",
+                    "code": "await shopify.pos.cart.setCustomer({\n  id: 5945486803009,\n  note: 'Customer note',\n});\n",
+                    "language": "js"
+                  },
+                  {
+                    "title": "Remove customer",
+                    "code": "await shopify.pos.cart.removeCustomer();\n",
                     "language": "js"
                   }
                 ]
               }
-            }
-          ]
-        },
-        {
-          "title": "Close",
-          "examples": [
+            },
             {
+              "description": "Manage customer addresses. This example adds a new address and updates an existing address by index.",
               "codeblock": {
-                "title": "Dismiss the screen",
+                "title": "Add or update customer addresses",
                 "tabs": [
                   {
-                    "code": "await shopify.pos.close();\n",
+                    "title": "Add a customer address",
+                    "code": "await shopify.pos.cart.addAddress({\n  address1: '123 Cherry St.',\n  address2: 'Apt. 5',\n  city: 'Toronto',\n  company: 'Shopify',\n  firstName: 'Foo',\n  lastName: 'Bar',\n  phone: '(613) 555-5555',\n  province: 'Ontario',\n  country: 'Canada',\n  zip: 'M5V0G4',\n  name: 'Shopify',\n  provinceCode: 'M5V0G4',\n  countryCode: '1',\n});\n",
+                    "language": "js"
+                  },
+                  {
+                    "title": "Update customer address",
+                    "code": "await shopify.pos.cart.updateAddress(0, {\n  address1: '555 Apple St.',\n  address2: 'Unit. 10',\n  city: 'Vancouver',\n  company: 'Shopify',\n  firstName: 'Jane',\n  lastName: 'Doe',\n  phone: '(403) 555-5555',\n  province: 'British Columbia',\n  country: 'Canada',\n  zip: 'M5V0G4',\n  name: 'Shopify',\n  provinceCode: 'M5V0G4',\n  countryCode: '2',\n});\n",
                     "language": "js"
                   }
                 ]
               }
-            }
-          ]
-        },
-        {
-          "title": "Device",
-          "examples": [
+            },
             {
+              "description": "Apply discounts to the entire cart. This example adds fixed or percentage discounts, applies discount codes, and removes discounts.",
               "codeblock": {
-                "title": "Retrieve POS device data",
+                "title": "Apply cart discounts",
+                "tabs": [
+                  {
+                    "title": "Add cart discount",
+                    "code": "await shopify.pos.cart.applyCartDiscount('FixedAmount', 'Holiday sale', '10');\n",
+                    "language": "js"
+                  },
+                  {
+                    "title": "Add discount code",
+                    "code": "await shopify.pos.cart.applyCartCodeDiscount('HOLIDAY SALE');\n",
+                    "language": "js"
+                  },
+                  {
+                    "title": "Remove cart discount",
+                    "code": "await shopify.pos.cart.removeCartDiscount();\n",
+                    "language": "js"
+                  },
+                  {
+                    "title": "Remove all discounts",
+                    "code": "await shopify.pos.cart.removeAllDiscounts(true);\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Attach custom metadata to the cart. This example adds and removes key-value properties on the cart object.",
+              "codeblock": {
+                "title": "Set cart properties",
+                "tabs": [
+                  {
+                    "title": "Add cart properties",
+                    "code": "await shopify.pos.cart.addCartProperties({\n  referral: 'Shopify',\n  employee: '472',\n});\n",
+                    "language": "js"
+                  },
+                  {
+                    "title": "Remove cart properties",
+                    "code": "await shopify.pos.cart.removeCartProperties(['referral', 'employee']);\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Retrieve POS device information. This example gets the device name and serial number.",
+              "codeblock": {
+                "title": "Get device info",
                 "tabs": [
                   {
                     "code": "await shopify.pos.device();\n",
@@ -5294,18 +5242,26 @@
                   }
                 ]
               }
-            }
-          ]
-        },
-        {
-          "title": "Location",
-          "examples": [
+            },
             {
+              "description": "Retrieve POS location information. This example gets the location ID, name, and status.",
               "codeblock": {
-                "title": "Retrieve POS location data",
+                "title": "Get location info",
                 "tabs": [
                   {
                     "code": "await shopify.pos.location();\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Dismiss the app screen. This example programmatically closes the app and returns to POS.",
+              "codeblock": {
+                "title": "Close the app",
+                "tabs": [
+                  {
+                    "code": "await shopify.pos.close();\n",
                     "language": "js"
                   }
                 ]
@@ -5322,6 +5278,7 @@
     "description": "The Print API allows you to print the content from your App Home on Shopify Mobile and Shopify POS devices.\n\n For more information, see the [Window `print()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/print) documentation.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Device and platform integration",
     "related": [],
     "defaultExample": {
       "codeblock": {
@@ -5382,16 +5339,18 @@
   },
   {
     "name": "Resource Picker",
-    "overviewPreviewDescription": "Opens a Resource Picker in your app",
-    "description": "The Resource Picker API provides a search-based interface to help users find and select one or more products, collections, or product variants, and then returns the selected resources to your app. Both the app and the user must have the necessary permissions to access the resources selected.\n\n> Tip:\n> If you are picking app resources such as product reviews, email templates, or subscription options, you should use the [Picker](picker) API instead.",
+    "overviewPreviewDescription": "Let merchants search and select products, collections, or variants",
+    "description": "The Resource Picker API lets merchants search for and select products, collections, or product variants. Use this API when your app needs merchants to choose Shopify resources to work with. The resource picker returns detailed resource information including IDs, titles, images, and metadata.\n\n> Tip:\n> If you need to pick app-specific resources like product reviews, email templates, or subscription options, use the [Picker](/docs/api/app-bridge-library/apis/picker) API instead.",
     "isVisualComponent": true,
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/resource-picker.png",
     "related": [],
     "defaultExample": {
+      "description": "Select products from the store catalog. This example opens a product resource picker and handles the selection response. The resource picker returns an array of product objects with GIDs, titles, and handles.",
       "image": "/assets/templated-apis-screenshots/admin/apis/resource-picker.png",
       "codeblock": {
-        "title": "Product picker",
+        "title": "Select products",
         "tabs": [
           {
             "code": "const selected = await shopify.resourcePicker({type: 'product'});\n",
@@ -5401,20 +5360,20 @@
       }
     },
     "examples": {
-      "description": "Resource Pickers with different options",
+      "description": "Examples that demonstrate how to use the Resource Picker API.",
       "examples": [
         {
-          "description": "Alternate resources",
+          "description": "Select collections or variants. This example selects collections instead of individual products by setting `type: \"collection\"`, or selects specific product variants by setting `type: \"variant\"`. Use collection mode for choosing product groupings, such as homepage featured collection carousels, navigation menu builders, or promotional campaigns. Use variant mode for choosing individual SKUs, useful for inventory tools, variant-specific promotions, or shipment builders.",
           "codeblock": {
-            "title": "Alternate resources",
+            "title": "Select collections or variants",
             "tabs": [
               {
-                "title": "Collection picker",
+                "title": "Collections",
                 "code": "const selected = await shopify.resourcePicker({type: 'collection'});\n",
                 "language": "js"
               },
               {
-                "title": "Product variant picker",
+                "title": "Product variants",
                 "code": "const selected = await shopify.resourcePicker({type: 'variant'});\n",
                 "language": "js"
               }
@@ -5422,9 +5381,9 @@
           }
         },
         {
-          "description": "Preselected resources",
+          "description": "Preselect products. This example opens the resource picker with products already selected by passing GIDs to the `selectionIds` option. Use this to pre-populate the picker with current selections for edit workflows, showing what products are already in a bundle, collection, or promotional set. Merchants can see current selections and modify them before confirming.",
           "codeblock": {
-            "title": "Product picker with preselected resources",
+            "title": "Preselect products",
             "tabs": [
               {
                 "code": "const selected = await shopify.resourcePicker({\n  type: 'product',\n  selectionIds: [\n    {\n      id: 'gid://shopify/Product/12345',\n      variants: [\n        {\n          id: 'gid://shopify/ProductVariant/1',\n        },\n      ],\n    },\n    {\n      id: 'gid://shopify/Product/67890',\n    },\n  ],\n});\n",
@@ -5434,9 +5393,9 @@
           }
         },
         {
-          "description": "Action verb",
+          "description": "Set action verb. This example customizes the resource picker button text by setting the `action` option to \"add\" or \"select\". \"Add\" suggests appending to an existing list, while \"select\" implies choosing for a specific purpose or replacing selections. This subtle language difference improves clarity for different workflow contexts.",
           "codeblock": {
-            "title": "Product picker with action verb",
+            "title": "Set action verb",
             "tabs": [
               {
                 "code": "const selected = await shopify.resourcePicker({\n  type: 'product',\n  action: 'select',\n});\n",
@@ -5446,9 +5405,9 @@
           }
         },
         {
-          "description": "Multiple selection",
+          "description": "Limit selection count. This example controls how many products merchants can select. Set `multiple: true` for unlimited selection useful for mass product taggers, bulk inventory tools, or export utilities. Set `multiple` to a number like `5` to limit selection count for bundle builders with item limits, featured product sections, or promotional campaigns with maximum product counts.",
           "codeblock": {
-            "title": "Product picker with multiple selection",
+            "title": "Limit selection count",
             "tabs": [
               {
                 "title": "Unlimited selectable items",
@@ -5464,9 +5423,9 @@
           }
         },
         {
-          "description": "Filters",
+          "description": "Filter resources. This example filters the resource picker to show only specific products using the `filter` option. Use `variants: false` to hide variant information, `hidden: false` to exclude hidden products, `draft: false` to exclude draft products, or `archived: false` to exclude archived products. Combine filters to restrict the picker to live, customer-visible products.",
           "codeblock": {
-            "title": "Product picker with filters",
+            "title": "Filter resources",
             "tabs": [
               {
                 "code": "const selected = await shopify.resourcePicker({\n  type: 'product',\n  filter: {\n    hidden: true,\n    variants: false,\n    draft: false,\n    archived: false,\n  },\n});\n",
@@ -5476,9 +5435,9 @@
           }
         },
         {
-          "description": "Filter query",
+          "description": "Apply a filter query. This example applies a custom GraphQL search query using the `query` property in filters. The query runs server-side and is not visible to merchants. Use it to programmatically restrict results (for example, `vendor:Acme` or `tag:sale`) without exposing the filter logic.",
           "codeblock": {
-            "title": "Product picker with a custom filter query",
+            "title": "Apply a filter query",
             "tabs": [
               {
                 "code": "const selected = await shopify.resourcePicker({\n  type: 'product',\n  filter: {\n    query: 'Sweater',\n  },\n});\n",
@@ -5488,9 +5447,9 @@
           }
         },
         {
-          "description": "Selection",
+          "description": "Handle selection payload. This example handles the selection payload returned by the resource picker. When merchants confirm their selection, the picker returns an array of resource objects. When merchants cancel, it returns `undefined` rather than an empty array. Check for `undefined` explicitly to distinguish between cancellation and an empty selection.",
           "codeblock": {
-            "title": "Product picker using returned selection payload",
+            "title": "Handle selection payload",
             "tabs": [
               {
                 "code": "const selected = await shopify.resourcePicker({type: 'product'});\n\nif (selected) {\n  console.log(selected);\n} else {\n  console.log('Picker was cancelled by the user');\n}\n",
@@ -5500,9 +5459,9 @@
           }
         },
         {
-          "description": "Initial query",
+          "description": "Start with search query. This example starts the resource picker with a pre-filled search query by passing the `query` option. This initializes the picker with a search term already entered, helpful when you know what merchants are likely looking for. Merchants can modify the query, but starting with relevant results saves time in large catalogs.",
           "codeblock": {
-            "title": "Product picker with initial query provided",
+            "title": "Start with search query",
             "tabs": [
               {
                 "code": "const selected = await shopify.resourcePicker({\n  type: 'product',\n  query: 'Sweater',\n});\n",
@@ -5515,8 +5474,8 @@
     },
     "definitions": [
       {
-        "title": "Resource Picker Options",
-        "description": "The `Resource Picker` accepts a variety of options to customize the picker's behavior.",
+        "title": "Inputs",
+        "description": "The `ResourcePickerOptions` object defines how the resource picker behaves, including which resource type to display, selection limits, filters, and preselected items.",
         "type": "ResourcePickerOptions",
         "typeDefinitions": {
           "ResourcePickerOptions": {
@@ -5529,7 +5488,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "action",
                 "value": "'add' | 'select'",
-                "description": "The action verb appears in the title and as the primary action of the Resource Picker.",
+                "description": "The action verb that appears in the title as the primary action of the resource picker. \"Add\" prompts merchants that they are appending to an existing list, while \"select\" they'll choose a resource for a specific purpose or replacing selections.",
                 "isOptional": true,
                 "defaultValue": "'add'"
               },
@@ -5538,7 +5497,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "filter",
                 "value": "Filters",
-                "description": "Filters for what resource to show.",
+                "description": "Filtering options that control which resources appear in the resourcepicker. Use filters to restrict resources by publication status, include or exclude variants, or apply custom search criteria. This helps merchants find relevant items faster.",
                 "isOptional": true
               },
               {
@@ -5546,7 +5505,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "multiple",
                 "value": "boolean | number",
-                "description": "Whether to allow selecting multiple items of a specific type or not. If a number is provided, then limit the selections to a maximum of that number of items. When type is Product, the user may still select multiple variants of a single product, even if multiple is false.",
+                "description": "Whether to allow selecting multiple items of a specific type. If a number is provided, limit selections to that maximum. When `type` is `'product'`, merchants can still select multiple variants from a single product even when `multiple` is `false`.",
                 "isOptional": true,
                 "defaultValue": "false"
               },
@@ -5555,7 +5514,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "string",
-                "description": "GraphQL initial search query for filtering resources available in the picker. See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information. This is displayed in the search bar when the picker is opened and can be edited by users. For most use cases, you should use the `filter.query` option instead which doesn't show the query in the UI.",
+                "description": "Initial GraphQL search query for filtering resources available in the resource picker. See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information. This is displayed in the search bar when the picker is opened and can be edited by users. For most use cases, you should use the `filter.query` option instead which doesn't show the query in the UI.",
                 "isOptional": true,
                 "defaultValue": "''"
               },
@@ -5564,7 +5523,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "selectionIds",
                 "value": "BaseResource[]",
-                "description": "Resources that should be preselected when the picker is opened.",
+                "description": "Resources that should be preselected when the picker is opened. Use this for edit workflows to show what products are already in a bundle, collection, or promotional set. Merchants can see current selections and modify them before confirming.",
                 "isOptional": true,
                 "defaultValue": "[]"
               },
@@ -5573,10 +5532,10 @@
                 "syntaxKind": "PropertySignature",
                 "name": "type",
                 "value": "ResourceType",
-                "description": "The type of resource you want to pick."
+                "description": "The type of Shopify resource to select: `'product'` for products, `'variant'` for specific product variants, or `'collection'` for collections. This determines what appears in the picker and what data structure is returned."
               }
             ],
-            "value": "export interface ResourcePickerOptions<\n  ResourceType extends keyof ResourceTypes = keyof ResourceTypes,\n> {\n  /**\n   * The type of resource you want to pick.\n   */\n  type: ResourceType;\n  /**\n   *  The action verb appears in the title and as the primary action of the Resource Picker.\n   * @defaultValue 'add'\n   */\n  action?: 'add' | 'select';\n  /**\n   * Filters for what resource to show.\n   */\n  filter?: Filters;\n  /**\n   * Whether to allow selecting multiple items of a specific type or not. If a number is provided, then limit the selections to a maximum of that number of items. When type is Product, the user may still select multiple variants of a single product, even if multiple is false.\n   * @defaultValue false\n   */\n  multiple?: boolean | number;\n  /**\n   * GraphQL initial search query for filtering resources available in the picker. See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information.\n   * This is displayed in the search bar when the picker is opened and can be edited by users.\n   * For most use cases, you should use the `filter.query` option instead which doesn't show the query in the UI.\n   * @defaultValue ''\n   */\n  query?: string;\n  /**\n   * Resources that should be preselected when the picker is opened.\n   * @defaultValue []\n   */\n  selectionIds?: BaseResource[];\n}"
+            "value": "export interface ResourcePickerOptions<\n  ResourceType extends keyof ResourceTypes = keyof ResourceTypes,\n> {\n  /**\n   * The type of Shopify resource to select: `'product'` for products, `'variant'` for specific product variants, or `'collection'` for collections. This determines what appears in the picker and what data structure is returned.\n   */\n  type: ResourceType;\n  /**\n   * The action verb that appears in the title as the primary action of the resource picker. \"Add\" prompts merchants that they are appending to an existing list, while \"select\" they'll choose a resource for a specific purpose or replacing selections.\n   * @defaultValue 'add'\n   */\n  action?: 'add' | 'select';\n  /**\n   * Filtering options that control which resources appear in the resourcepicker. Use filters to restrict resources by publication status, include or exclude variants, or apply custom search criteria. This helps merchants find relevant items faster.\n   */\n  filter?: Filters;\n  /**\n   * Whether to allow selecting multiple items of a specific type. If a number is provided, limit selections to that maximum. When `type` is `'product'`, merchants can still select multiple variants from a single product even when `multiple` is `false`.\n   * @defaultValue false\n   */\n  multiple?: boolean | number;\n  /**\n   * Initial GraphQL search query for filtering resources available in the resource picker. See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information.\n   * This is displayed in the search bar when the picker is opened and can be edited by users.\n   * For most use cases, you should use the `filter.query` option instead which doesn't show the query in the UI.\n   * @defaultValue ''\n   */\n  query?: string;\n  /**\n   * Resources that should be preselected when the picker is opened. Use this for edit workflows to show what products are already in a bundle, collection, or promotional set. Merchants can see current selections and modify them before confirming.\n   * @defaultValue []\n   */\n  selectionIds?: BaseResource[];\n}"
           },
           "Filters": {
             "filePath": "src/features/resource-picker.ts",
@@ -5615,7 +5574,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "string",
-                "description": "GraphQL initial search query for filtering resources available in the picker. See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information. This is not displayed in the search bar when the picker is opened.",
+                "description": "GraphQL initial search query for filtering resources available in the picker. See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information. This query is not visible to merchants and runs server-side. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.",
                 "isOptional": true
               },
               {
@@ -5628,7 +5587,7 @@
                 "defaultValue": "true"
               }
             ],
-            "value": "interface Filters {\n  /**\n   * Whether to show hidden resources, referring to products that are not published on any sales channels.\n   * @defaultValue true\n   */\n  hidden?: boolean;\n  /**\n   * Whether to show product variants. Only applies to the Product resource type picker.\n   * @defaultValue true\n   */\n  variants?: boolean;\n  /**\n   * Whether to show [draft products](https://help.shopify.com/en/manual/products/details?shpxid=70af7d87-E0F2-4973-8B09-B972AAF0ADFD#product-availability).\n   * Only applies to the Product resource type picker.\n   * Setting this to undefined will show a badge on draft products.\n   * @defaultValue true\n   */\n  draft?: boolean | undefined;\n  /**\n   * Whether to show [archived products](https://help.shopify.com/en/manual/products/details?shpxid=70af7d87-E0F2-4973-8B09-B972AAF0ADFD#product-availability).\n   * Only applies to the Product resource type picker.\n   * Setting this to undefined will show a badge on draft products.\n   * @defaultValue true\n   */\n  archived?: boolean | undefined;\n  /**\n   * GraphQL initial search query for filtering resources available in the picker.\n   * See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information.\n   * This is not displayed in the search bar when the picker is opened.\n   */\n  query?: string;\n}"
+            "value": "interface Filters {\n  /**\n   * Whether to show hidden resources, referring to products that are not published on any sales channels.\n   * @defaultValue true\n   */\n  hidden?: boolean;\n  /**\n   * Whether to show product variants. Only applies to the Product resource type picker.\n   * @defaultValue true\n   */\n  variants?: boolean;\n  /**\n   * Whether to show [draft products](https://help.shopify.com/en/manual/products/details?shpxid=70af7d87-E0F2-4973-8B09-B972AAF0ADFD#product-availability).\n   * Only applies to the Product resource type picker.\n   * Setting this to undefined will show a badge on draft products.\n   * @defaultValue true\n   */\n  draft?: boolean | undefined;\n  /**\n   * Whether to show [archived products](https://help.shopify.com/en/manual/products/details?shpxid=70af7d87-E0F2-4973-8B09-B972AAF0ADFD#product-availability).\n   * Only applies to the Product resource type picker.\n   * Setting this to undefined will show a badge on draft products.\n   * @defaultValue true\n   */\n  archived?: boolean | undefined;\n  /**\n   * GraphQL initial search query for filtering resources available in the picker.\n   * See [search syntax](https://shopify.dev/docs/api/usage/search-syntax) for more information.\n   * This query is not visible to merchants and runs server-side. Use it to programmatically restrict results (for example, `vendor:Acme`) without exposing the filter logic.\n   */\n  query?: string;\n}"
           },
           "BaseResource": {
             "filePath": "src/features/resource-picker.ts",
@@ -5671,14 +5630,14 @@
         }
       },
       {
-        "title": "Resource Picker Return Payload",
-        "description": "The `Resource Picker` returns a Promise with an array of the selected resources. The object type in the array varies based on the provided `type` option.\n\nIf the picker is cancelled, the Promise resolves to `undefined`",
+        "title": "Return payload",
+        "description": "The resource picker returns an array of selected resources when the merchant confirms their selection, or `undefined` if they cancel. The resource structure in the array varies based on the `type` option: products include variants and images, collections include rule sets, and variants include pricing and inventory data.",
         "type": "ReturnPayload",
         "typeDefinitions": {
           "ReturnPayload": {
             "filePath": "src/features/resource-picker.ts",
             "name": "ReturnPayload",
-            "description": "",
+            "description": "The resource picker returns an array of selected resources when the merchant confirms their selection, or `undefined` if they cancel. The resource structure in the array varies based on the `type` option: products include variants and images, collections include rule sets, and variants include pricing and inventory data.",
             "members": [
               {
                 "filePath": "src/features/resource-picker.ts",
@@ -6318,7 +6277,7 @@
                 "description": ""
               }
             ],
-            "value": "export interface ProductVariant extends Resource {\n  availableForSale: boolean;\n  barcode?: string | null;\n  compareAtPrice?: Money | null;\n  createdAt: string;\n  displayName: string;\n  fulfillmentService?: {\n    id: string;\n    inventoryManagement: boolean;\n    productBased: boolean;\n    serviceName: string;\n    type: FulfillmentServiceType;\n  };\n  image?: Image | null;\n  inventoryItem: {id: string};\n  inventoryManagement: ProductVariantInventoryManagement;\n  inventoryPolicy: ProductVariantInventoryPolicy;\n  inventoryQuantity?: number | null;\n  position: number;\n  price: Money;\n  product: Partial<Product>;\n  requiresShipping: boolean;\n  selectedOptions: {value?: string | null}[];\n  sku?: string | null;\n  taxable: boolean;\n  title: string;\n  weight?: number | null;\n  weightUnit: WeightUnit;\n  updatedAt: string;\n}"
+            "value": "export interface ProductVariant extends Resource {\n  availableForSale: boolean;\n  barcode?: string | null;\n  compareAtPrice?: Money | null;\n  createdAt: string;\n  displayName: string;\n  fulfillmentService?: {\n    id: string;\n    inventoryManagement: boolean;\n    productBased: boolean;\n    serviceName: string;\n    type: FulfillmentServiceType;\n  };\n  image?: Image | null;\n  inventoryItem: { id: string };\n  inventoryManagement: ProductVariantInventoryManagement;\n  inventoryPolicy: ProductVariantInventoryPolicy;\n  inventoryQuantity?: number | null;\n  position: number;\n  price: Money;\n  product: Partial<Product>;\n  requiresShipping: boolean;\n  selectedOptions: { value?: string | null }[];\n  sku?: string | null;\n  taxable: boolean;\n  title: string;\n  weight?: number | null;\n  weightUnit: WeightUnit;\n  updatedAt: string;\n}"
           },
           "Money": {
             "filePath": "src/features/resource-picker.ts",
@@ -6426,31 +6385,32 @@
   {
     "name": "Reviews",
     "overviewPreviewDescription": "Request an app review modal in the Shopify admin",
-    "description": "\n  The Reviews API allows you to request an app review modal overlaid on your embedded app in the Shopify admin. You control when to request a modal, but it will only be displayed to the merchant if [certain conditions](#rate-limits-restrictions) are met.\n  ",
+    "description": "The Reviews API lets you request an app review modal overlaid on your app in the Shopify admin. You control when to request the modal, but it only displays if [certain conditions](#rate-limits-restrictions) are met. Use this API to prompt merchants for feedback at the right moment in your app workflow.\n\nIt's better to request a review at the end of a successful workflow than when a merchant first opens your app, or at any point that interrupts their task. Don't trigger a request with a merchant action, as rate-limiting might prevent the modal from displaying, making your app appear to be broken.\n\nYou can use your development store to test the Reviews API, which bypasses the rate limits and restrictions. Reviews submitted from development stores are not published on the Shopify App Store.",
     "isVisualComponent": true,
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/reviews.png",
     "related": [],
     "definitions": [
       {
-        "title": "Reviews",
-        "description": "The Reviews API provides a `request()` method that allows you to request an app review modal.",
+        "title": "Methods",
+        "description": "The `reviews` object provides methods for requesting app review modals from merchants.",
         "type": "ReviewsApi",
         "typeDefinitions": {
           "ReviewsApi": {
             "filePath": "src/features/reviews.ts",
             "name": "ReviewsApi",
-            "description": "",
+            "description": "The Reviews API for requesting app review modals.",
             "members": [
               {
                 "filePath": "src/features/reviews.ts",
                 "syntaxKind": "MethodSignature",
                 "name": "request",
                 "value": "() => Promise<ReviewRequestResponse>",
-                "description": ""
+                "description": "Requests an app review modal. The modal only displays if [rate limits and eligibility conditions](#rate-limits-restrictions) are met. Returns a Promise that resolves to a response object with `success`, `code`, and `message` properties indicating whether the modal was shown and, if not, the reason why."
               }
             ],
-            "value": "export interface ReviewsApi {\n  request(): Promise<ReviewRequestResponse>;\n}"
+            "value": "export interface ReviewsApi {\n  /**\n   * Requests an app review modal. The modal only displays if [rate limits and eligibility conditions](#rate-limits-restrictions) are met. Returns a Promise that resolves to a response object with `success`, `code`, and `message` properties indicating whether the modal was shown and, if not, the reason why.\n   */\n  request(): Promise<ReviewRequestResponse>;\n}"
           },
           "ReviewRequestResponse": {
             "filePath": "src/types.ts",
@@ -6532,34 +6492,23 @@
         "anchorLink": "responses",
         "title": "Response codes and messages",
         "type": "Generic",
-        "sectionContent": "\nA request to the Reviews API will return one of the following responses:\n\nsuccess | code | message\n--- | --- | ---\n`true` | `success` |\tReview modal displayed\n`false` | `mobile-app` |\tReview modal not supported on mobile devices\n`false` | `already-reviewed` |\tMerchant already reviewed this app\n`false` | `annual-limit-reached` |\tReview modal already displayed the maximum number of times within the last 365 days\n`false` | `cooldown-period` |\tReview modal already displayed within the last 60 days\n`false` | `merchant-ineligible` |\tMerchant isn't eligible to review this app\n`false` | `recently-installed` |\tMerchant installed this app for less than 24 hours\n`false` | `already-open` |\tReview modal is already open\n`false` | `open-in-progress` |\tReview modal opening is already in progress\n`false` | `cancelled` |\tReview modal opening was cancelled\n    "
+        "sectionContent": "\n\nA successful request to the Reviews API has a single response code:\n- `success`: `true`\n- `code`: `success`\n- `message`: Review modal displayed\n\nIf a request is unsuccessful (`success` is false), the response includes a `code` and `message` explaining why the modal was not displayed, such as rate limits or merchant eligibility.\n\n- `already-open`: Review modal is already open\n- `already-reviewed`: Merchant already reviewed this app\n- `annual-limit-reached`: Review modal already displayed the maximum number of times within the last 365 days\n- `cancelled`: Review modal opening was cancelled\n- `cooldown-period`: Review modal already displayed within the last 60 days\n- `merchant-ineligible`: Merchant isn't eligible to review this app\n- `mobile-app`: Review modal not supported on mobile devices\n- `open-in-progress`: Review modal opening is already in progress\n- `recently-installed`: Merchant installed this app for less than 24 hours\n    "
       },
       {
         "anchorLink": "rate-limits-restrictions",
         "title": "Rate limits and restrictions",
         "type": "Generic",
-        "sectionContent": "\nA review modal will only be displayed to the merchant if certain conditions are met. Be sure to follow the [recommended best practices](#best-practices) for requesting reviews.\n\n### Rate limits\nThe Reviews API applies rate limits to ensure a good merchant experience and to prevent abuse. A review modal will only be displayed to a merchant:\n- **Once** within any **60-day** period, and\n- **Three** times within any **365-day** period.\n\n### Restrictions\nA review modal will never be displayed in these cases:\n- The merchant already reviewed your app.\n- The merchant is on a mobile device.\n- The merchant is ineligible to leave a review.\n- The merchant has installed your app for less than 24 hours\n      "
-      },
-      {
-        "anchorLink": "best-practices",
-        "title": "Best practices for review requests",
-        "type": "Generic",
-        "sectionContent": "\nBecause you can make only a [limited number](#rate-limits-restrictions) of requests for review, make sure to choose the right time:\n\n- **Do** request a review at the end of a successful workflow.\n- **Don't** request a review at any point that interrupts a merchant task.\n- **Don't** request a review as soon as the merchant opens your app.\n- **Don't** trigger a request with a button, link, or other call to action. Because the request might be rate-limited and the modal isn't guaranteed to display, your app UI would appear to be broken.\n      "
-      },
-      {
-        "anchorLink": "testing-the-reviews-api",
-        "title": "Testing the Reviews API",
-        "type": "Generic",
-        "sectionContent": "\nYou can use your development store to test the Reviews API, which bypasses the rate limits and restrictions. Reviews submitted from development stores are not published on the Shopify App Store.\n      "
+        "sectionContent": "\nA review modal will only be displayed to the merchant if certain conditions are met. For each condition below, the [corresponding error `code`](#responses) is listed as a reference.\n\n### Rate limits\nThe Reviews API applies rate limits to ensure a good merchant experience and to prevent abuse. A review modal is only displayed to a merchant:\n- Once within any 60-day period (`cooldown-period`).\n- Three times within any 365-day period (`annual-limit-reached`).\n\n### Restrictions\nA review modal is never displayed in the following cases:\n- The merchant already reviewed your app (`already-reviewed`).\n- The merchant is on a mobile device (`mobile-app`).\n- The merchant is ineligible to leave a review (`merchant-ineligible`).\n- The merchant has installed your app for less than 24 hours (`recently-installed`).\n      "
       }
     ],
     "defaultExample": {
+      "description": "Request a review modal. This example calls the `request()` method and handles the response. If `success` is false, the response includes a `code` and `message` explaining why the modal was not displayed, such as rate limits or merchant eligibility.",
       "image": "/assets/templated-apis-screenshots/admin/apis/reviews.png",
       "codeblock": {
-        "title": "Request an app review modal",
+        "title": "Request a review modal",
         "tabs": [
           {
-            "code": "try {\n  const result = await shopify.reviews.request();\n  if (!result.success) {\n    console.log(`Review modal not displayed. Reason: ${result.code}: ${result.message}`);\n  }\n  // if result.success *is* true, then review modal is displayed\n} catch (error) {\n  console.error('Error requesting review:', error);\n}\n",
+            "code": "try {\n  const result = await shopify.reviews.request();\n  if (!result.success) {\n    console.log(`Review modal not displayed. Reason: ${result.code}: ${result.message}`);\n  }\n} catch (error) {\n  console.error('Error requesting review:', error);\n}\n",
             "language": "js"
           }
         ]
@@ -6567,32 +6516,22 @@
     }
   },
   {
-    "name": "Save Bar",
-    "overviewPreviewDescription": "Display a save bar when a form has unsaved changes.",
-    "description": "The Save Bar API is used to indicate that a form on the current page has unsaved information. It can be used in 2 ways:\n\n1. It is automatically configured when you provide the <code>data-save-bar</code> attribute to a [<code>form</code> element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) and will display the save bar when there are unsaved changes. The [<code>submit</code>](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event) event fires when the form is submitted or when the Save button is pressed. The [<code>reset</code>](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset_event) event fires when the form is reset or when the Discard button is pressed, which discards all unsaved changes in the form.\n\n2. It can be controlled declaratively through the `ui-save-bar` element. For more information, refer to the [`ui-save-bar` component](/docs/api/app-bridge-library/web-components/ui-save-bar).",
+    "name": "Save bar",
+    "overviewPreviewDescription": "Indicate unsaved changes and prompt merchants to save or discard",
+    "description": "The Save Bar API indicates that a form on the current page has unsaved information. You can implement save bar behavior in two ways:\n\n1. **Form attribute**: Add the `data-save-bar` attribute to a [`form` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form). The save bar displays automatically when there are unsaved changes. The [`submit`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event) event fires when the Save button is pressed, and the [`reset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset_event) event fires when the Discard button is pressed.\n\n2. **Programmatic control**: Use `shopify.saveBar` methods (`show()`, `hide()`, `toggle()`, `leaveConfirmation()`) to control the save bar based on your application state.",
     "isVisualComponent": true,
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/contextual-save-bar.png",
     "category": "APIs",
-    "related": [
-      {
-        "name": "ui-save-bar",
-        "subtitle": "Component",
-        "url": "/docs/api/app-home/app-bridge-web-components/forms",
-        "type": "component"
-      },
-      {
-        "name": "SaveBar",
-        "subtitle": "Component",
-        "url": "/docs/api/app-home/apis/save-bar",
-        "type": "component"
-      }
-    ],
+    "subCategory": "User interface and interactions",
+    "related": [],
     "defaultExample": {
+      "description": "Display a save bar. This example adds the `data-save-bar` attribute to a form element. When the form has unsaved changes, the save bar appears automatically.",
       "image": "/assets/templated-apis-screenshots/admin/apis/contextual-save-bar.png",
       "codeblock": {
-        "title": "Save Bar",
+        "title": "Display a save bar",
         "tabs": [
           {
+            "title": "html",
             "code": "&lt;form\n  data-save-bar\n  onsubmit=\"console.log('submit', new FormData(event.target)); event.preventDefault();\"\n&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n",
             "language": "html"
           }
@@ -6601,8 +6540,8 @@
     },
     "definitions": [
       {
-        "title": "saveBar",
-        "description": "The `saveBar` API provides a `show` method to display a save bar, a `hide` method to hide a save bar, and a `toggle` method to toggle the visibility of a save bar. These are used in conjunction with the `ui-save-bar` element. They are alternatives to the `show`, `hide`, and `toggle` instance methods.",
+        "title": "Methods",
+        "description": "The `saveBar` object provides methods to programmatically control save bar visibility.",
         "type": "_SaveBarApi",
         "typeDefinitions": {
           "_SaveBarApi": {
@@ -6615,7 +6554,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "hide",
                 "value": "(id: string) => Promise<void>",
-                "description": "Hides the save bar element. An alternative to the `hide` instance method on the `ui-save-bar` element.",
+                "description": "Hides the save bar. Call this after the merchant saves or discards their changes.",
                 "isOptional": true
               },
               {
@@ -6623,7 +6562,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "leaveConfirmation",
                 "value": "() => Promise<void>",
-                "description": "Checks if saveBar is shown. This promise resolves if the save bar is not shown. Uses this method before navigating away from the page only when you have a custom routing that is not anchor tag.",
+                "description": "Prompts the merchant to confirm before leaving the page when there are unsaved changes. The promise resolves when the merchant confirms or when no save bar is visible. Use this before programmatic navigation (for example, using `window.location` or custom routing) to prevent accidental data loss.",
                 "isOptional": true
               },
               {
@@ -6631,7 +6570,7 @@
                 "syntaxKind": "MethodSignature",
                 "name": "show",
                 "value": "(id: string) => Promise<void>",
-                "description": "Shows the save bar element. An alternative to the `show` instance method on the `ui-save-bar` element.",
+                "description": "Displays the save bar to indicate unsaved changes. Call this when you want to prompt the merchant to save.",
                 "isOptional": true
               },
               {
@@ -6639,83 +6578,101 @@
                 "syntaxKind": "MethodSignature",
                 "name": "toggle",
                 "value": "(id: string) => Promise<void>",
-                "description": "Toggles the save bar element visibility. An alternative to the `toggle` instance method on the `ui-save-bar` element.",
+                "description": "Toggles save bar visibility between shown and hidden states.",
                 "isOptional": true
               }
             ],
-            "value": "interface _SaveBarApi {\n  /**\n   * Shows the save bar element. An alternative to the `show` instance method on the `ui-save-bar` element.\n   * @param id A unique identifier for the save bar\n   */\n  show?(id: string): Promise<void>;\n  /**\n   * Hides the save bar element. An alternative to the `hide` instance method on the `ui-save-bar` element.\n   * @param id A unique identifier for the save bar\n   */\n  hide?(id: string): Promise<void>;\n  /**\n   * Toggles the save bar element visibility. An alternative to the `toggle` instance method on the `ui-save-bar` element.\n   * @param id A unique identifier for the save bar\n   */\n  toggle?(id: string): Promise<void>;\n  /**\n   * Checks if saveBar is shown. This promise resolves if the save bar is not shown. Uses this method before navigating away from the page only when you have a custom routing that is not anchor tag.\n   */\n  leaveConfirmation?(): Promise<void>;\n}"
+            "value": "interface _SaveBarApi {\n  /**\n   * Displays the save bar to indicate unsaved changes. Call this when you want to prompt the merchant to save.\n   * @param id A unique identifier for the save bar\n   */\n  show?(id: string): Promise<void>;\n  /**\n   * Hides the save bar. Call this after the merchant saves or discards their changes.\n   * @param id A unique identifier for the save bar\n   */\n  hide?(id: string): Promise<void>;\n  /**\n   * Toggles save bar visibility between shown and hidden states.\n   * @param id A unique identifier for the save bar\n   */\n  toggle?(id: string): Promise<void>;\n  /**\n   * Prompts the merchant to confirm before leaving the page when there are unsaved changes. The promise resolves when the merchant confirms or when no save bar is visible. Use this before programmatic navigation (for example, using `window.location` or custom routing) to prevent accidental data loss.\n   */\n  leaveConfirmation?(): Promise<void>;\n}"
           }
         }
       }
     ],
     "examples": {
-      "description": "Save bar options, variations, and events",
-      "exampleGroups": [
+      "description": "Examples that demonstrate how to use the Save Bar API.",
+      "examples": [
         {
-          "title": "Save bar configured through the data-save-bar attribute",
-          "examples": [
-            {
-              "description": "Subscribing to the [`HTMLFormElement: reset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset_event) event",
-              "codeblock": {
-                "title": "Subscribe to Discard",
-                "tabs": [
-                  {
-                    "title": "Event handler property",
-                    "code": "&lt;form\n  data-save-bar\n  onreset=\"console.log('discarding')\"\n&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "Event listener",
-                    "code": "&lt;form data-save-bar&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n\n&lt;script&gt;\n  const form = document.querySelector('form');\n  form.addEventListener('reset', (e) =&gt; {\n    console.log('discarding');\n  });\n&lt;/script&gt;\n",
-                    "language": "html"
-                  }
-                ]
+          "description": "Handle discard events. This example subscribes to the [`reset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset_event) event to run custom logic when the merchant clicks the Discard button.",
+          "codeblock": {
+            "title": "Handle discard events",
+            "tabs": [
+              {
+                "title": "Event handler property",
+                "code": "&lt;form\n  data-save-bar\n  onreset=\"console.log('discarding')\"\n&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n",
+                "language": "html"
+              },
+              {
+                "title": "Event listener",
+                "code": "&lt;form data-save-bar&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n\n&lt;script&gt;\n  const form = document.querySelector('form');\n  form.addEventListener('reset', (e) =&gt; {\n    console.log('discarding');\n  });\n&lt;/script&gt;\n",
+                "language": "html"
               }
-            },
-            {
-              "description": "Subscribing to the [`HTMLFormElement: submit`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/reset_event) event",
-              "codeblock": {
-                "title": "Subscribe to Save",
-                "tabs": [
-                  {
-                    "title": "Event handler property",
-                    "code": "&lt;form\n  data-save-bar\n  onsubmit=\"console.log('submitting');\"\n&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n",
-                    "language": "html"
-                  },
-                  {
-                    "title": "Event listener",
-                    "code": "&lt;form data-save-bar&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n\n&lt;script&gt;\n  const form = document.querySelector('form');\n  form.addEventListener('submit', (e) =&gt; {\n    console.log('submitting');\n  });\n&lt;/script&gt;\n",
-                    "language": "html"
-                  }
-                ]
+            ]
+          }
+        },
+        {
+          "description": "Handle save events. This example subscribes to the [`submit`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit_event) event to run custom logic when the merchant clicks the Save button.",
+          "codeblock": {
+            "title": "Handle save events",
+            "tabs": [
+              {
+                "title": "Event handler property",
+                "code": "&lt;form\n  data-save-bar\n  onsubmit=\"console.log('submitting');\"\n&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n",
+                "language": "html"
+              },
+              {
+                "title": "Event listener",
+                "code": "&lt;form data-save-bar&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n\n&lt;script&gt;\n  const form = document.querySelector('form');\n  form.addEventListener('submit', (e) =&gt; {\n    console.log('submitting');\n  });\n&lt;/script&gt;\n",
+                "language": "html"
               }
-            },
-            {
-              "description": "Provide the `data-discard-confirmation` attribute to a `form` with the `data-save-bar` attribute to show a confirmation modal after the user clicks the Discard button of the save bar",
-              "codeblock": {
-                "title": "Showing a discard confirmation modal",
-                "tabs": [
-                  {
-                    "title": "HTML",
-                    "code": "&lt;form\n  data-save-bar\n  data-discard-confirmation\n  onsubmit=\"console.log('submit', new FormData(event.target)); event.preventDefault();\"\n&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n",
-                    "language": "html"
-                  }
-                ]
+            ]
+          }
+        },
+        {
+          "description": "Show discard confirmation. This example adds the `data-discard-confirmation` attribute to show a confirmation modal when the merchant clicks the Discard button, preventing accidental data loss.",
+          "codeblock": {
+            "title": "Show discard confirmation",
+            "tabs": [
+              {
+                "code": "&lt;form\n  data-save-bar\n  data-discard-confirmation\n  onsubmit=\"console.log('submit', new FormData(event.target)); event.preventDefault();\"\n&gt;\n  &lt;label&gt;\n    Name:\n    &lt;input name=\"username\" /&gt;\n  &lt;/label&gt;\n&lt;/form&gt;\n",
+                "language": "html"
               }
-            },
-            {
-              "description": "Showing the save bar with the saveBar API",
-              "codeblock": {
-                "title": "Showing the save bar with the saveBar API",
-                "tabs": [
-                  {
-                    "code": "&lt;ui-save-bar id=\"my-save-bar\"&gt;&lt;/ui-save-bar&gt;\n\n&lt;button onclick=\"shopify.saveBar.show('my-save-bar')\"&gt;Show&lt;/button&gt;\n&lt;button onclick=\"shopify.saveBar.hide('my-save-bar')\"&gt;Hide&lt;/button&gt;\n",
-                    "language": "html"
-                  }
-                ]
+            ]
+          }
+        },
+        {
+          "description": "Control save bar programmatically. This example uses `saveBar.show()` and `saveBar.hide()` to manage the save bar based on form state changes.",
+          "codeblock": {
+            "title": "Control save bar programmatically",
+            "tabs": [
+              {
+                "code": "function SaveBarExample() {\n  const saveBar = shopify.saveBar;\n  const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false);\n\n  const handleFieldInput = () =&gt; {\n    if (!hasUnsavedChanges) {\n      setHasUnsavedChanges(true);\n      saveBar.show();\n    }\n  };\n\n  const handleDiscard = () =&gt; {\n    setHasUnsavedChanges(false);\n    saveBar.hide();\n  };\n\n  const handleSave = async () =&gt; {\n    // Save to your backend\n    setHasUnsavedChanges(false);\n    saveBar.hide();\n  };\n\n  return (\n    &lt;s-page heading=\"Settings\"&gt;\n      &lt;s-section heading=\"Configuration\"&gt;\n        &lt;s-text-field\n          label=\"Store name\"\n          onInput={handleFieldInput}\n        /&gt;\n      &lt;/s-section&gt;\n    &lt;/s-page&gt;\n  );\n}\n",
+                "language": "jsx"
               }
-            }
-          ]
+            ]
+          }
+        },
+        {
+          "description": "Toggle save bar. This example uses `saveBar.toggle()` to switch the save bar between shown and hidden states.",
+          "codeblock": {
+            "title": "Toggle save bar",
+            "tabs": [
+              {
+                "code": "function ToggleExample() {\n  const saveBar = shopify.saveBar;\n\n  const handleToggle = () =&gt; {\n    saveBar.toggle();\n  };\n\n  return (\n    &lt;s-page heading=\"Settings\"&gt;\n      &lt;s-section heading=\"Controls\"&gt;\n        &lt;s-button onClick={handleToggle}&gt;\n          Toggle save bar\n        &lt;/s-button&gt;\n      &lt;/s-section&gt;\n    &lt;/s-page&gt;\n  );\n}\n",
+                "language": "jsx"
+              }
+            ]
+          }
+        },
+        {
+          "description": "Leave confirmation. This example uses `saveBar.leaveConfirmation()` to prompt the merchant before programmatic navigation when there are unsaved changes.",
+          "codeblock": {
+            "title": "Leave confirmation",
+            "tabs": [
+              {
+                "code": "function LeaveConfirmationExample() {\n  const saveBar = shopify.saveBar;\n  const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false);\n\n  const handleFieldInput = () =&gt; {\n    if (!hasUnsavedChanges) {\n      setHasUnsavedChanges(true);\n      saveBar.show();\n    }\n  };\n\n  const handleCustomNavigation = async () =&gt; {\n    // Call leaveConfirmation before programmatic navigation\n    await saveBar.leaveConfirmation();\n    // Navigation proceeds after merchant confirms or if no unsaved changes\n    window.location.href = '/other-page';\n  };\n\n  return (\n    &lt;s-page heading=\"Settings\"&gt;\n      &lt;s-section heading=\"Configuration\"&gt;\n        &lt;s-text-field\n          label=\"Store name\"\n          onInput={handleFieldInput}\n        /&gt;\n        &lt;s-button onClick={handleCustomNavigation}&gt;\n          Go to other page\n        &lt;/s-button&gt;\n      &lt;/s-section&gt;\n    &lt;/s-page&gt;\n  );\n}\n",
+                "language": "jsx"
+              }
+            ]
+          }
         }
       ]
     }
@@ -6723,16 +6680,18 @@
   {
     "name": "Scanner",
     "overviewPreviewDescription": "Use the mobile device's camera to scan barcodes",
-    "description": "The Scanner API allows you to use the mobile device's camera to scan barcodes.",
+    "description": "The Scanner API allows you to use the mobile device's camera to scan barcodes. Use this API to capture barcode data and integrate it into your app's workflow on Shopify POS.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Device and platform integration",
     "related": [],
     "defaultExample": {
+      "description": "Look up products by scanning their barcode. This example captures a barcode and queries the Admin API to find the matching product variant.",
       "codeblock": {
-        "title": "Scanner",
+        "title": "Scan and look up a product",
         "tabs": [
           {
-            "code": "try {\n  const payload = await shopify.scanner.capture();\n  console.log('Scanner success', payload);\n} catch (error) {\n  console.log('Scanner error', error);\n}\n",
+            "code": "// Scan a product barcode and look it up\ntry {\n  const { data: barcode } = await shopify.scanner.capture();\n\n  // Look up the product variant by barcode\n  const response = await fetch('shopify:admin/api/graphql.json', {\n    method: 'POST',\n    body: JSON.stringify({\n      query: `\n        query getVariantByBarcode($barcode: String!) {\n          productVariants(first: 1, query: $barcode) {\n            nodes {\n              id\n              title\n              price\n              product {\n                title\n              }\n            }\n          }\n        }\n      `,\n      variables: { barcode: `barcode:${barcode}` }\n    })\n  });\n\n  const { data } = await response.json();\n  const variant = data.productVariants.nodes[0];\n\n  if (variant) {\n    shopify.toast.show(`Found: ${variant.product.title} - ${variant.title}`);\n  } else {\n    shopify.toast.show('Product not found', { isError: true });\n  }\n} catch (error) {\n  shopify.toast.show('Scan cancelled or failed', { isError: true });\n}\n",
             "language": "js"
           }
         ]
@@ -6780,44 +6739,45 @@
   },
   {
     "name": "Scopes",
-    "overviewPreviewDescription": "Manage optional access scopes",
-    "description": "The Scopes API provides the ability to dynamically manage your access scopes within an embedded context.\n\n  > Tip:\n  > To learn more about declaring and requesting access scopes, as well as required vs. optional scopes, refer to [manage access scopes](/docs/apps/build/authentication-authorization/app-installation/manage-access-scopes).  ",
+    "overviewPreviewDescription": "Query, request, and revoke access scopes for your app",
+    "description": "The Scopes API lets you manage your app's <a href='https://shopify.dev/docs/api/usage/access-scopes'>access scopes</a> at runtime. You can query which scopes are currently granted, request additional optional scopes from the merchant (which opens a permission grant modal), and revoke optional scopes you no longer need.\n\n> Tip:\n> To learn more about declaring and requesting access scopes, as well as required vs. optional scopes, refer to <a href='/docs/apps/build/authentication-authorization/app-installation/manage-access-scopes'>manage access scopes</a>.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Authentication and data",
     "definitions": [
       {
-        "title": "Scopes",
-        "description": "Provides utilities to query, request, and revoke access scopes for the app using the Admin API.",
+        "title": "Methods",
+        "description": "The `scopes` API is available on the `shopify` global. All methods are asynchronous and return a Promise.",
         "type": "Scopes",
         "typeDefinitions": {
           "Scopes": {
             "filePath": "src/types.ts",
             "name": "Scopes",
-            "description": "The Scopes API enables embedded apps and extensions to request merchant consent for access scopes.",
+            "description": "The Scopes API lets you query, request, and revoke access scopes for your app at runtime.",
             "members": [
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "() => Promise<ScopesDetail>",
-                "description": "Queries Shopify for the scopes for this app on this shop"
+                "description": "Returns the current access scopes for this app on this shop, including which are granted, required, and optional."
               },
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "request",
                 "value": "(scopes: string[]) => Promise<ScopesRequestResponse>",
-                "description": "Requests the merchant to grant the provided scopes for this app on this shop\n\nThis will open a [permission grant modal](/docs/apps/build/authentication-authorization/app-installation/manage-access-scopes#request-access-scopes-using-the-app-bridge-api-for-embedded-apps) for the merchant to accept or decline the scopes."
+                "description": "Opens a permission grant modal asking the merchant to grant the specified scopes.\n\nThe scopes must be [access scope](https://shopify.dev/docs/api/usage/access-scopes) handles (for example, `'read_products'` or `'write_orders'`) that are declared as optional in your app configuration.\n\nSee the [permission grant modal](/docs/apps/build/authentication-authorization/app-installation/manage-access-scopes#request-access-scopes-using-the-app-bridge-api-for-embedded-apps) documentation for more details."
               },
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "revoke",
                 "value": "(scopes: string[]) => Promise<ScopesRevokeResponse>",
-                "description": "Revokes the provided scopes from this app on this shop"
+                "description": "Revokes the specified optional scopes from this app on this shop.\n\nThe scopes must be [access scope](https://shopify.dev/docs/api/usage/access-scopes) handles (for example, `'read_products'` or `'write_orders'`) that are currently granted and declared as optional. Required scopes cannot be revoked."
               }
             ],
-            "value": "export interface Scopes {\n  /**\n   * Queries Shopify for the scopes for this app on this shop\n   */\n  query: () => Promise<ScopesDetail>;\n\n  /**\n   * Requests the merchant to grant the provided scopes for this app on this shop\n   *\n   * This will open a [permission grant modal](/docs/apps/build/authentication-authorization/app-installation/manage-access-scopes#request-access-scopes-using-the-app-bridge-api-for-embedded-apps) for the merchant to accept or decline the scopes.\n   */\n  request: (scopes: Scope[]) => Promise<ScopesRequestResponse>;\n\n  /**\n   * Revokes the provided scopes from this app on this shop\n   */\n  revoke: (scopes: Scope[]) => Promise<ScopesRevokeResponse>;\n}"
+            "value": "export interface Scopes {\n  /**\n   * Returns the current access scopes for this app on this shop, including which are granted, required, and optional.\n   */\n  query: () => Promise<ScopesDetail>;\n\n  /**\n   * Opens a permission grant modal asking the merchant to grant the specified scopes.\n   *\n   * The scopes must be [access scope](https://shopify.dev/docs/api/usage/access-scopes) handles (for example, `'read_products'` or `'write_orders'`) that are declared as optional in your app configuration.\n   *\n   * See the [permission grant modal](/docs/apps/build/authentication-authorization/app-installation/manage-access-scopes#request-access-scopes-using-the-app-bridge-api-for-embedded-apps) documentation for more details.\n   */\n  request: (scopes: Scope[]) => Promise<ScopesRequestResponse>;\n\n  /**\n   * Revokes the specified optional scopes from this app on this shop.\n   *\n   * The scopes must be [access scope](https://shopify.dev/docs/api/usage/access-scopes) handles (for example, `'read_products'` or `'write_orders'`) that are currently granted and declared as optional. Required scopes cannot be revoked.\n   */\n  revoke: (scopes: Scope[]) => Promise<ScopesRevokeResponse>;\n}"
           },
           "ScopesDetail": {
             "filePath": "src/types.ts",
@@ -6829,24 +6789,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "granted",
                 "value": "string[]",
-                "description": "The scopes that have been granted on the shop for this app"
+                "description": "The scopes currently granted to this app on this shop. This includes both required and optional scopes."
               },
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "optional",
                 "value": "string[]",
-                "description": "The optional scopes that the app has declared in its configuration"
+                "description": "The scopes declared as optional in your app configuration. These may or may not be currently granted — check `granted` to see which are active."
               },
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "required",
                 "value": "string[]",
-                "description": "The required scopes that the app has declared in its configuration"
+                "description": "The scopes declared as required in your app configuration. These are always granted at install time and cannot be revoked by the app."
               }
             ],
-            "value": "export interface ScopesDetail {\n  /**\n   * The scopes that have been granted on the shop for this app\n   */\n  granted: Scope[];\n  /**\n   * The required scopes that the app has declared in its configuration\n   */\n  required: Scope[];\n  /**\n   * The optional scopes that the app has declared in its configuration\n   */\n  optional: Scope[];\n}"
+            "value": "export interface ScopesDetail {\n  /**\n   * The scopes currently granted to this app on this shop. This includes both required and optional scopes.\n   */\n  granted: Scope[];\n  /**\n   * The scopes declared as required in your app configuration. These are always granted at install time and cannot be revoked by the app.\n   */\n  required: Scope[];\n  /**\n   * The scopes declared as optional in your app configuration. These may or may not be currently granted — check `granted` to see which are active.\n   */\n  optional: Scope[];\n}"
           },
           "ScopesRequestResponse": {
             "filePath": "src/types.ts",
@@ -6858,24 +6818,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "detail",
                 "value": "ScopesDetail",
-                "description": ""
+                "description": "The updated scopes for this app on this shop after the merchant's response."
               },
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "result",
                 "value": "UserResult",
-                "description": ""
+                "description": "The merchant's response: `'granted-all'` if they accepted all requested scopes, or `'declined-all'` if they declined."
               }
             ],
-            "value": "export interface ScopesRequestResponse {\n  result: UserResult;\n  detail: ScopesDetail;\n}"
+            "value": "export interface ScopesRequestResponse {\n  /**\n   * The merchant's response: `'granted-all'` if they accepted all requested scopes, or `'declined-all'` if they declined.\n   */\n  result: UserResult;\n  /**\n   * The updated scopes for this app on this shop after the merchant's response.\n   */\n  detail: ScopesDetail;\n}"
           },
           "UserResult": {
             "filePath": "src/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "UserResult",
             "value": "'granted-all' | 'declined-all'",
-            "description": "`UserResult` represents the results of a user responding to a scopes request, i.e. a merchant user’s action taken when presented with a grant modal."
+            "description": "The merchant's response to a scopes request: `'granted-all'` if they accepted all requested scopes, or `'declined-all'` if they declined."
           },
           "ScopesRevokeResponse": {
             "filePath": "src/types.ts",
@@ -6887,10 +6847,10 @@
                 "syntaxKind": "PropertySignature",
                 "name": "detail",
                 "value": "ScopesDetail",
-                "description": ""
+                "description": "The updated scopes for this app on this shop after the revocation."
               }
             ],
-            "value": "export interface ScopesRevokeResponse {\n  detail: ScopesDetail;\n}"
+            "value": "export interface ScopesRevokeResponse {\n  /**\n   * The updated scopes for this app on this shop after the revocation.\n   */\n  detail: ScopesDetail;\n}"
           }
         }
       }
@@ -6909,51 +6869,44 @@
         "type": "api"
       }
     ],
+    "defaultExample": {
+      "description": "Query the current scopes for your app on this shop. The response includes which scopes are granted, which are required, and which are declared as optional in your app configuration.",
+      "codeblock": {
+        "title": "Query your app's access scopes",
+        "tabs": [
+          {
+            "code": "const {granted, required, optional} = await shopify.scopes.query();\n\nconsole.log(granted); // =&gt; ['read_products', 'write_products', 'read_orders']\nconsole.log(required); // =&gt; ['read_products', 'write_products']\nconsole.log(optional); // =&gt; ['read_orders', 'write_orders']\n",
+            "language": "js"
+          }
+        ]
+      }
+    },
     "examples": {
-      "description": "Examples for using App Bridge's Scopes API methods",
+      "description": "",
       "exampleGroups": [
         {
-          "title": "Query",
+          "title": "",
           "examples": [
             {
-              "codeblock": {
-                "title": "Query access scopes granted to the app on this store",
-                "tabs": [
-                  {
-                    "code": "const { granted } = await shopify.scopes.query();\n",
-                    "language": "js"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "title": "Request",
-          "examples": [
-            {
+              "description": "Request the merchant to grant additional optional scopes. This opens a permission grant modal where the merchant can accept or decline. The scopes you request must be declared as optional in your app configuration, and each value must be a valid access scope handle such as 'read_products' or 'write_orders'.",
               "image": "requestmodal.png",
               "codeblock": {
-                "title": "Request the user to grant access to the `read_products` scope",
+                "title": "Request optional scopes from the merchant",
                 "tabs": [
                   {
-                    "code": "const response = await shopify.scopes.request(['read_products', 'write_discounts']);\n\nif (response.result === 'granted-all') {\n  // merchant has been granted access — continue\n  ...\n}\nelse if (response.result === 'declined-all') {\n  // merchant has declined access — handle accordingly\n  ...\n}\n",
+                    "code": "const response = await shopify.scopes.request([\n  'read_products',\n  'write_discounts',\n]);\n\nif (response.result === 'granted-all') {\n  console.log('Merchant granted access');\n} else if (response.result === 'declined-all') {\n  console.log('Merchant declined access');\n}\n\nconsole.log(response.detail.granted);\n",
                     "language": "js"
                   }
                 ]
               }
-            }
-          ]
-        },
-        {
-          "title": "Revoke",
-          "examples": [
+            },
             {
+              "description": "Revoke optional scopes that your app no longer needs. The response includes the updated list of granted scopes. Only optional scopes can be revoked — required scopes cannot be removed.",
               "codeblock": {
-                "title": "Revoke the granted access to the `read_products` scope",
+                "title": "Revoke optional scopes",
                 "tabs": [
                   {
-                    "code": "await shopify.scopes.revoke(['read_products']);\n",
+                    "code": "const response = await shopify.scopes.revoke(['read_products']);\n\nconsole.log(response.detail.granted);\n",
                     "language": "js"
                   }
                 ]
@@ -6970,6 +6923,7 @@
     "description": "The Share API allows you to invoke the \"share sheet\" to share content from your App Home on an iOS or Android device.\n\n For more information, see the [`navigator.share()`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) documentation. When using the `navigator.share()` method in an App Home, the `files` value within the `data` parameter is not supported.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Device and platform integration",
     "related": [],
     "defaultExample": {
       "codeblock": {
@@ -6986,38 +6940,39 @@
   },
   {
     "name": "Support",
-    "overviewPreviewDescription": "Register a custom handler for support requests.",
-    "description": "\n  The Support API allows you to optionally register a custom handler when support requests are made directly through App Bridge. This interaction is triggered when a merchant clicks the get support button at the top of the app.\n\n  > Tip:\n  > To register a custom support callback, you must define a [Support link extension](/docs/apps/launch/distribution/support-your-customers#custom-support-events) and the link extension must point to a page within your app. This is to ensure consistent behavior when a merchant clicks a support button outside of the app. Without a support link extension, the support callback will be ignored.\n  ",
+    "overviewPreviewDescription": "Register a custom handler for support requests",
+    "description": "The Support API lets you register a custom handler when merchants request support through App Bridge. This handler is triggered when a merchant clicks the support button at the top of the app, allowing you to provide in-app support such as opening a live chat widget.\n\n> Tip:\n> To register a custom support callback, you must define a [Support link extension](/docs/apps/launch/distribution/support-your-customers#custom-support-events) that points to a page within your app. Without this extension, the support callback is ignored.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/support.png",
     "related": [],
     "definitions": [
       {
-        "title": "Support",
-        "description": "The Support API provides a registerHandler method that registers a handler to call when support is requested. It allows you to provide bespoke, in-app support such as opening a live chat widget.",
+        "title": "Methods",
+        "description": "The `support` object provides a method that registers a callback function to run when support is requested.",
         "type": "SupportApi",
         "typeDefinitions": {
           "SupportApi": {
             "filePath": "src/features/support.ts",
             "name": "SupportApi",
-            "description": "",
+            "description": "The Support API for handling custom support requests.",
             "members": [
               {
                 "filePath": "src/features/support.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "registerHandler",
                 "value": "(callback: SupportCallback) => Promise<void>",
-                "description": "",
+                "description": "Registers a callback function to run when the merchant clicks the support button. Pass `null` to unregister a previously registered handler.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SupportApi {\n  registerHandler?: (callback: SupportCallback | null) => Promise<void>;\n}"
+            "value": "export interface SupportApi {\n  /**\n   * Registers a callback function to run when the merchant clicks the support button. Pass `null` to unregister a previously registered handler.\n   * @param callback - The function to call when support is requested, or `null` to unregister.\n   */\n  registerHandler?: (callback: SupportCallback | null) => Promise<void>;\n}"
           },
           "SupportCallback": {
             "filePath": "src/features/support.ts",
             "name": "SupportCallback",
-            "description": "",
+            "description": "A callback function that runs when support is requested.",
             "params": [],
             "returns": {
               "filePath": "src/features/support.ts",
@@ -7031,8 +6986,9 @@
       }
     ],
     "defaultExample": {
+      "description": "Register a support handler. This example registers a callback function that runs when the merchant clicks the support button. Use this to open a live chat widget, display a contact form, or trigger any custom support flow.",
       "codeblock": {
-        "title": "Register support handle",
+        "title": "Register a support handler",
         "tabs": [
           {
             "code": "// Define the callback function\nconst handler = () =&gt; {\n  // implement your custom functionality\n  openLiveChat();\n};\n\n// Register the callback\nshopify.support.registerHandler(handler);\n",
@@ -7048,6 +7004,7 @@
     "description": "The Toast API displays a non-disruptive message that appears at the bottom of the interface to provide quick and short feedback on the outcome of an action. This API is modeled after the [Web Notification API](https://developer.mozilla.org/en-US/docs/Web/API/Notification).",
     "isVisualComponent": true,
     "category": "APIs",
+    "subCategory": "User interface and interactions",
     "thumbnail": "/assets/templated-apis-screenshots/admin/apis/toast.png",
     "related": [],
     "defaultExample": {
@@ -7219,15 +7176,16 @@
   },
   {
     "name": "User",
-    "overviewPreviewDescription": "Retrieves information about the current user",
-    "description": "The User API lets you asynchronously retrieve information about the currently logged-in user.\n\nThe API returns a `Promise`, which contains user information, and the payload varies based on whether the user is logged into the Shopify admin or Shopify POS.",
+    "overviewPreviewDescription": "Get information about the currently logged-in user",
+    "description": "The User API retrieves information about the currently logged-in user, such as their name, email, and account access level. The response shape depends on the platform: admin users and POS users return different sets of properties.",
     "isVisualComponent": false,
     "defaultExample": {
+      "description": "Retrieve information about the current user. The properties available in the response depend on whether the user is logged into the Shopify admin or Shopify POS.",
       "codeblock": {
-        "title": "User",
+        "title": "Get the current user's information",
         "tabs": [
           {
-            "code": "await shopify.user();\n",
+            "code": "const user = await shopify.user();\n\nconsole.log(user.accountAccess); // =&gt; 'full'\n",
             "language": "js"
           }
         ]
@@ -7236,13 +7194,13 @@
     "definitions": [
       {
         "title": "Admin User",
-        "description": "The `user` API, which is available on the `shopify` global, asynchronously retrieves information about the user that's logged into the Shopify admin.",
+        "description": "When the user is logged into the Shopify admin, `shopify.user()` returns the user's account access level.",
         "type": "AdminUserAPI",
         "typeDefinitions": {
           "AdminUserAPI": {
             "filePath": "src/features/user.ts",
             "name": "AdminUserAPI",
-            "description": "Asynchronously returns information about the current user.",
+            "description": "Returns information about the currently logged-in user.\n\nThe shape of the response depends on whether the user is logged into the Shopify admin or Shopify POS. Admin users have `accountAccess` and optionally `id`, `name`, and `email`. POS users have `id`, `firstName`, `lastName`, `email`, `accountAccess`, and `accountType`.",
             "params": [],
             "returns": {
               "filePath": "src/features/user.ts",
@@ -7262,17 +7220,17 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accountAccess",
                 "value": "string",
-                "description": "The account access level of the logged-in user",
+                "description": "The account access level of the logged-in user.",
                 "isOptional": true
               }
             ],
-            "value": "export interface AdminUser {\n  /**\n   * The account access level of the logged-in user\n   */\n  accountAccess?: string;\n}"
+            "value": "export interface AdminUser {\n  /**\n   * The account access level of the logged-in user.\n   */\n  accountAccess?: string;\n}"
           }
         }
       },
       {
         "title": "POS User",
-        "description": "The `user` API, which is available on the `shopify` global, asynchronously retrieves information about the current user logged into Shopify POS.",
+        "description": "When the user is logged into Shopify POS, `shopify.user()` returns the user's ID, first and last name, email, account access level, and account type.",
         "type": "POSUserAPI",
         "typeDefinitions": {
           "POSUserAPI": {
@@ -7298,7 +7256,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accountAccess",
                 "value": "string",
-                "description": "The account access level of the logged-in user",
+                "description": "The account access level of the logged-in user.",
                 "isOptional": true
               },
               {
@@ -7330,7 +7288,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "number",
-                "description": "The ID of the user's staff.",
+                "description": "The staff member's numeric ID.",
                 "isOptional": true
               },
               {
@@ -7342,20 +7300,44 @@
                 "isOptional": true
               }
             ],
-            "value": "export interface POSUser {\n  /**\n   * The ID of the user's staff.\n   */\n  id?: number;\n  /**\n   * The user's first name.\n   */\n  firstName?: string;\n  /**\n   * The user's last name.\n   */\n  lastName?: string;\n  /**\n   * The user's email address.\n   */\n  email?: string;\n  /**\n   *   The account access level of the logged-in user\n   */\n  accountAccess?: string;\n  /**\n   * The user's account type.\n   */\n  accountType?: string;\n}"
+            "value": "export interface POSUser {\n  /**\n   * The staff member's numeric ID.\n   */\n  id?: number;\n  /**\n   * The user's first name.\n   */\n  firstName?: string;\n  /**\n   * The user's last name.\n   */\n  lastName?: string;\n  /**\n   * The user's email address.\n   */\n  email?: string;\n  /**\n   * The account access level of the logged-in user.\n   */\n  accountAccess?: string;\n  /**\n   * The user's account type.\n   */\n  accountType?: string;\n}"
           }
         }
       }
     ],
     "category": "APIs",
-    "related": []
+    "subCategory": "Authentication and data",
+    "related": [],
+    "examples": {
+      "description": "",
+      "exampleGroups": [
+        {
+          "title": "",
+          "examples": [
+            {
+              "description": "On Shopify POS, the user object includes additional properties such as `firstName`, `lastName`, and `accountType` that are not available on the admin.",
+              "codeblock": {
+                "title": "Get user information on Shopify POS",
+                "tabs": [
+                  {
+                    "code": "const user = await shopify.user();\n\nconsole.log(user.id); // =&gt; 12345\nconsole.log(user.firstName); // =&gt; 'Jane'\nconsole.log(user.lastName); // =&gt; 'Doe'\nconsole.log(user.email); // =&gt; 'jane@example.com'\nconsole.log(user.accountAccess); // =&gt; 'full'\nconsole.log(user.accountType); // =&gt; 'regular'\n",
+                    "language": "js"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
   },
   {
     "name": "Web Vitals",
     "overviewPreviewDescription": "Monitor Web Vitals for your app",
-    "description": "The Web Vitals API allows you to access performance metrics for your app directly through App Bridge.",
+    "description": "The Web Vitals API allows you to access performance metrics for your embedded app directly through App Bridge. Use this API to monitor [Core Web Vitals](https://web.dev/vitals/) and send metrics to your own monitoring service.",
     "isVisualComponent": false,
     "category": "APIs",
+    "subCategory": "Device and platform integration",
     "related": [
       {
         "name": "App Performance Guidelines",
@@ -7371,8 +7353,9 @@
       }
     ],
     "defaultExample": {
+      "description": "Track Core Web Vitals for your embedded app. This example registers a callback that sends performance metrics to your monitoring service.",
       "codeblock": {
-        "title": "Callback onReport",
+        "title": "Monitor app performance",
         "tabs": [
           {
             "code": "// Define the callback function\nconst callback = async (metrics) =&gt; {\n    const monitorUrl = 'https://yourserver.com/web-vitals-metrics';\n    const data = JSON.stringify(metrics);\n\n    navigator.sendBeacon(monitorUrl, data);\n};\n\n// Register the callback\nshopify.webVitals.onReport(callback);\n",
@@ -7446,6 +7429,14 @@
               {
                 "filePath": "src/types.ts",
                 "syntaxKind": "PropertySignature",
+                "name": "country",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/types.ts",
+                "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
                 "description": ""
@@ -7465,7 +7456,7 @@
                 "description": ""
               }
             ],
-            "value": "export interface WebVitalsMetric {\n  id: string;\n  name: string;\n  value: number;\n}"
+            "value": "export interface WebVitalsMetric {\n  id: string;\n  name: string;\n  value: number;\n  country?: string;\n}"
           }
         }
       }
@@ -7473,8 +7464,8 @@
   },
   {
     "name": "Avatar",
-    "description": "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available.\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image).",
-    "category": "Polaris web components",
+    "description": "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available.\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/avatar.png",
@@ -7663,7 +7654,7 @@
       },
       {
         "title": "Events",
-        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The avatar component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "AvatarEvents",
         "typeDefinitions": {
           "AvatarEvents": {
@@ -7835,7 +7826,7 @@
               }
             },
             {
-              "description": "Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text) components.",
+              "description": "Create a profile layout with multiple components. This example combines an avatar with [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section), [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading), and [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text) components.",
               "codeblock": {
                 "title": "Build a merchant profile card",
                 "tabs": [
@@ -7858,8 +7849,8 @@
   },
   {
     "name": "Badge",
-    "description": "The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.",
-    "category": "Polaris web components",
+    "description": "The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.\n\nBadges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) instead.",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/badge.png",
@@ -8050,7 +8041,7 @@
       },
       {
         "title": "Slots",
-        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The badge component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "BadgeSlots",
         "typeDefinitions": {
           "BadgeSlots": {
@@ -8115,7 +8106,7 @@
               }
             },
             {
-              "description": "Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.",
+              "description": "Place badges inside [table cells](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/table) to give merchants a scannable overview of status information. This example shows fulfillment and payment badges in an order table.",
               "codeblock": {
                 "title": "Display badges in a table",
                 "tabs": [
@@ -8155,8 +8146,8 @@
   },
   {
     "name": "Banner",
-    "description": "The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).",
-    "category": "Polaris web components",
+    "description": "The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.\n\nBanners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge).",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/banner.png",
@@ -8348,7 +8339,7 @@
       },
       {
         "title": "Events",
-        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The banner component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "BannerEvents",
         "typeDefinitions": {
           "BannerEvents": {
@@ -8393,7 +8384,7 @@
       },
       {
         "title": "Slots",
-        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The banner component supports slots for additional content placement within the banner. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "BannerSlots",
         "typeDefinitions": {
           "BannerSlots": {
@@ -8449,7 +8440,7 @@
           "title": "",
           "examples": [
             {
-              "description": "Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.",
+              "description": "Use a warning-toned banner with secondary action [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to highlight a problem and give merchants clear next steps. This example shows a shipping weight issue with links to review products and access a setup guide.",
               "codeblock": {
                 "title": "Create a warning banner with buttons for next steps",
                 "tabs": [
@@ -8466,7 +8457,7 @@
               }
             },
             {
-              "description": "Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) to review order details and adjust settings.",
+              "description": "Use a critical-toned banner to signal an urgent issue that requires immediate merchant action. This example shows a fraud review alert with [buttons](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) to review order details and adjust settings.",
               "codeblock": {
                 "title": "Alert merchants to critical issues requiring action",
                 "tabs": [
@@ -8506,8 +8497,8 @@
   },
   {
     "name": "Box",
-    "description": "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components.\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).",
-    "category": "Polaris web components",
+    "description": "The box component provides a generic, flexible container for custom designs and layouts. Use box to apply styling like backgrounds, padding, borders, or border radius when existing components don't meet your needs, or to nest and group other components.\n\nBox contents maintain their natural size, making it especially useful within layout components that would otherwise stretch their children. For structured layouts, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/box.png",
@@ -8517,7 +8508,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.\n- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.\n- **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.\n- **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.\n- **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components."
+        "sectionContent": "- **Use for layout and grouping:** The component provides spacing, borders, and backgrounds for organizing content. When you need specific layout patterns like rows or columns, use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) or [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid) instead. The component works best as a general-purpose container.\n- **Consider semantic alternatives first:** Before using the component, check whether a more specific component like [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) or [banner](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/banner) better describes your content's purpose. Semantic components provide better accessibility and clearer intent.\n- **Design for different screen sizes:** Layouts that work on desktop might not work on mobile. Use responsive properties to adjust spacing and layout based on available space rather than creating fixed layouts.\n- **Make interactive containers accessible:** When boxes contain interactive content or represent distinct regions, provide appropriate ARIA roles and labels so screen reader users can navigate and understand the interface structure.\n- **Avoid excessive nesting:** Deep nesting of boxes creates complex DOM structures and makes styling harder to manage. Look for opportunities to simplify your layout or use more appropriate layout components."
       }
     ],
     "definitions": [
@@ -8745,7 +8736,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -8754,7 +8745,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -8763,7 +8754,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -8772,7 +8763,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -8781,7 +8772,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -8790,7 +8781,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -8799,7 +8790,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -8996,7 +8987,7 @@
       },
       {
         "title": "Slots",
-        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The box component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "BoxSlots",
         "typeDefinitions": {
           "BoxSlots": {
@@ -9118,8 +9109,8 @@
   },
   {
     "name": "Button",
-    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use button to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).",
-    "category": "Polaris web components",
+    "description": "The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use buttons to let users perform specific tasks or initiate interactions throughout the interface.\n\nButtons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button-group).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/button.png",
@@ -9393,7 +9384,7 @@
       },
       {
         "title": "Events",
-        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ButtonEvents",
         "typeDefinitions": {
           "ButtonEvents": {
@@ -9446,7 +9437,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The button component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ButtonSlots",
         "typeDefinitions": {
           "ButtonSlots": {
@@ -9670,8 +9661,8 @@
   },
   {
     "name": "Button group",
-    "description": "The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button).",
-    "category": "Polaris web components",
+    "description": "The button group component displays multiple related buttons in a structured layout. Use button group to organize action buttons together, creating clear visual hierarchies and helping users understand available options.\n\nButton groups support various layouts including segmented appearances for tightly related options like view switching or filter controls. For individual actions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/buttongroup.png",
@@ -9838,7 +9829,7 @@
       },
       {
         "title": "Slots",
-        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The button group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ButtonGroupSlots",
         "typeDefinitions": {
           "ButtonGroupSlots": {
@@ -9877,24 +9868,19 @@
       }
     ],
     "defaultExample": {
-      "image": "button-default.png",
+      "image": "buttongroup-default.png",
+      "description": "Group related buttons together with a primary action and secondary options. This example shows a button group with a save button and a cancel button.",
       "codeblock": {
-        "title": "Code",
+        "title": "Group a primary and secondary action",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"primary-action\"&gt;Save&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-            "language": "html",
-            "layout": "inline",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: flex; justify-content: center; align-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"primary-action\">Save</s-button>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"primary-action\">Save</s-button>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n</s-button-group>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -9904,141 +9890,71 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Standard button group with cancel and primary action for form workflows.",
+              "description": "Present multiple secondary actions for operating on selected items. This example shows archive, export, and delete buttons grouped together for bulk operations.",
               "codeblock": {
-                "title": "Basic usage",
+                "title": "Add bulk action buttons",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;\n    Save\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;Save&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"primary-action\" variant=\"primary\">\n    Save\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Action buttons for selected items with destructive option.",
-              "codeblock": {
-                "title": "Bulk action buttons",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Archive&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Export&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;\n    Delete\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Archive&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Export&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;Delete&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Archive</s-button>\n  <s-button slot=\"secondary-actions\">Export</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">\n    Delete\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"secondary-actions\">Archive</s-button>\n  <s-button slot=\"secondary-actions\">Export</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">Delete</s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Typical form completion actions with clear visual hierarchy.",
+              "description": "Add icons to grouped buttons to help merchants identify each action. This example shows duplicate, archive, and delete buttons with icons.",
               "codeblock": {
-                "title": "Form action buttons",
+                "title": "Add icons to grouped buttons",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;\n    Save product\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"primary-action\" variant=\"primary\"&gt;Save product&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"primary-action\" variant=\"primary\">\n    Save product\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Icon-labeled buttons for common actions.",
-              "codeblock": {
-                "title": "Buttons with icons",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"duplicate\"&gt;\n    Duplicate\n  &lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"archive\"&gt;\n    Archive\n  &lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\"&gt;\n    Delete\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"duplicate\"&gt;Duplicate&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"archive\"&gt;Archive&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\"&gt;\n    Delete\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\" icon=\"duplicate\">\n    Duplicate\n  </s-button>\n  <s-button slot=\"secondary-actions\" icon=\"archive\">\n    Archive\n  </s-button>\n  <s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\">\n    Delete\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"secondary-actions\" icon=\"duplicate\">Duplicate</s-button>\n  <s-button slot=\"secondary-actions\" icon=\"archive\">Archive</s-button>\n  <s-button slot=\"secondary-actions\" icon=\"delete\" tone=\"critical\">\n    Delete\n  </s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Tightly grouped buttons for view switching and filter options.",
+              "description": "Remove the gap between buttons to create a segmented control for toggling between views or options. This example shows day, week, and month buttons joined together with no spacing.",
               "codeblock": {
-                "title": "Segmented appearance",
+                "title": "Create a segmented button group",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group gap=\"none\"&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Day&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Week&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Month&lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group gap=\"none\"&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Day&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Week&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Month&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group gap=\"none\">\n  <s-button slot=\"secondary-actions\">Day</s-button>\n  <s-button slot=\"secondary-actions\">Week</s-button>\n  <s-button slot=\"secondary-actions\">Month</s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group gap=\"none\">\n  <s-button slot=\"secondary-actions\">Day</s-button>\n  <s-button slot=\"secondary-actions\">Week</s-button>\n  <s-button slot=\"secondary-actions\">Month</s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Confirmation dialog style with cancel option and destructive action.",
+              "description": "Pair a cancel button with a critical action for destructive confirmation flows. This example shows a cancel and delete button grouped together for a confirmation dialog.",
               "codeblock": {
-                "title": "Destructive actions pattern",
+                "title": "Confirm a destructive action",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;\n    Delete product\n  &lt;/s-button&gt;\n&lt;/s-button-group&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button-group&gt;\n  &lt;s-button slot=\"secondary-actions\"&gt;Cancel&lt;/s-button&gt;\n  &lt;s-button slot=\"secondary-actions\" tone=\"critical\"&gt;Delete product&lt;/s-button&gt;\n&lt;/s-button-group&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">\n    Delete product\n  </s-button>\n</s-button-group>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button-group>\n  <s-button slot=\"secondary-actions\">Cancel</s-button>\n  <s-button slot=\"secondary-actions\" tone=\"critical\">Delete product</s-button>\n</s-button-group>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -10051,8 +9967,8 @@
   },
   {
     "name": "Checkbox",
-    "description": "The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.\n\nCheckboxes support labels, help text, error states, and an indeterminate state for \"select all\" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/switch) instead.",
-    "category": "Polaris web components",
+    "description": "The checkbox component provides a clear way for users to make selections, such as agreeing to terms, enabling settings, or choosing multiple items from a list. Use checkbox to create binary on/off controls or multi-select interfaces where users can select any combination of options.\n\nCheckboxes support labels, help text, error states, and an indeterminate state for \"select all\" functionality when working with grouped selections. For settings that take effect immediately, use [switch](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/switch) instead.",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/checkbox.png",
@@ -10079,7 +9995,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -10329,7 +10245,7 @@
       },
       {
         "title": "Events",
-        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "CheckboxEvents",
         "typeDefinitions": {
           "CheckboxEvents": {
@@ -10495,8 +10411,8 @@
   },
   {
     "name": "Chip",
-    "description": "The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip).",
-    "category": "Polaris web components",
+    "description": "The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.\n\nChips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/chip.png",
@@ -10506,7 +10422,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip) instead.\n- **Keep chip text concise and scannable:** Short labels like \"Featured\" or \"On sale\" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.\n- **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.\n- **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.\n- **Add icons to reinforce meaning:** Icons can make chip meanings clearer at a glance, especially for status indicators or commonly recognized categories."
+        "sectionContent": "- **Use chips to label and categorize content:** Chip works best for displaying tags, statuses, and categories that help merchants quickly understand content attributes. Don't use chips for actions—they're visual indicators, not buttons. For interactive or dismissible chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable-chip) instead.\n- **Keep chip text concise and scannable:** Short labels like \"Featured\" or \"On sale\" are instantly recognizable. Long chip text defeats the purpose of quick scanning and might truncate, hiding important information.\n- **Choose the right visual weight:** Use subdued chips for secondary metadata, standard chips for typical tags and categories, and strong chips for important or verified information that needs emphasis.\n- **Position chips near what they describe:** Place chips adjacent to the items they categorize for immediate context. In lists, position chips consistently to help merchants scan efficiently.\n- **Add icons to reinforce meaning:** Icons can make chip meanings clearer at a glance, especially for status indicators or commonly recognized categories."
       },
       {
         "title": "Limitations",
@@ -10676,7 +10592,7 @@
       },
       {
         "title": "Slots",
-        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ChipSlots",
         "typeDefinitions": {
           "ChipSlots": {
@@ -10789,8 +10705,8 @@
   },
   {
     "name": "Choice list",
-    "description": "The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select).",
-    "category": "Polaris web components",
+    "description": "The choice list component presents multiple options for single or multiple selections. Use it when merchants need to choose from a defined set of options, such as filtering results or collecting preferences.\n\nThe component supports both single selection (radio button behavior) and multiple selection (checkbox behavior) modes. It includes configurable labels, help text, and validation. For compact dropdown selection with four or more options, use [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/choicelist.png",
@@ -10806,7 +10722,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/select) dropdown instead.\n- Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.\n- The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.\n- Component types other than choice can't be used as options within the choice list."
+        "sectionContent": "- The component doesn't include search, filtering, or lazy loading. For large option sets (20+ choices), consider using a [select](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/select) dropdown instead.\n- Rendering 50+ checkboxes or radio buttons can cause noticeable performance issues, especially on mobile devices. Consider pagination, virtualization, or alternative UI patterns for large lists.\n- The component is either single-selection (radio buttons) or multiple-selection (checkboxes) for all choices. You can't mix both types in the same list.\n- Component types other than choice can't be used as options within the choice list."
       }
     ],
     "definitions": [
@@ -10823,7 +10739,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@6847",
+                "name": "__@internals$3@6845",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -11031,7 +10947,7 @@
       },
       {
         "title": "Events",
-        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ChoiceListEvents",
         "typeDefinitions": {
           "ChoiceListEvents": {
@@ -11253,7 +11169,7 @@
       },
       {
         "title": "Slots",
-        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The choice list component supports slots for additional content placement within each choice. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ChoiceSlots",
         "typeDefinitions": {
           "ChoiceSlots": {
@@ -11383,8 +11299,8 @@
   },
   {
     "name": "Clickable",
-    "description": "The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.",
-    "category": "Polaris web components",
+    "description": "The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.\n\nClickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/clickable.png",
@@ -11679,7 +11595,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -11688,7 +11604,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -11697,7 +11613,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -11706,7 +11622,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -11715,7 +11631,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -11724,7 +11640,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -11733,7 +11649,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -11955,7 +11871,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ClickableEvents",
         "typeDefinitions": {
           "ClickableEvents": {
@@ -12008,7 +11924,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The clickable component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ClickableSlots",
         "typeDefinitions": {
           "ClickableSlots": {
@@ -12032,22 +11948,18 @@
     ],
     "defaultExample": {
       "image": "clickable-default.png",
+      "description": "Build custom interactive elements with flexible styling that [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/link) don't support. This example shows two clickable elements with different background and border styles.",
       "codeblock": {
-        "title": "Code",
+        "title": "Create a custom interactive element",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;&gt;\n  &lt;s-clickable padding=\"base\"&gt;Create Store&lt;/s-clickable&gt;\n\n  &lt;s-clickable\n    border=\"base\"\n    padding=\"base\"\n    background=\"subdued\"\n    borderRadius=\"base\"\n  &gt;\n    View Shipping Settings\n  &lt;/s-clickable&gt;\n&lt;/&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-clickable padding=\"base\"&gt;Create Store&lt;/s-clickable&gt;\n\n&lt;s-clickable\n  border=\"base\"\n  padding=\"base\"\n  background=\"subdued\"\n  borderRadius=\"base\"\n&gt;\n  View Shipping Settings\n&lt;/s-clickable&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-clickable padding=\"base\"&gt;Create Store&lt;/s-clickable&gt;\n\n&lt;s-clickable\n  border=\"base\"\n  padding=\"base\"\n  background=\"subdued\"\n  borderRadius=\"base\"\n&gt;\n  View Shipping Settings\n&lt;/s-clickable&gt;\n",
-            "language": "html",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-clickable padding=\"base\">Create Store</s-clickable>\n\n  <s-clickable\n    border=\"base\"\n    padding=\"base\"\n    background=\"subdued\"\n    borderRadius=\"base\"\n  >\n    View Shipping Settings\n  </s-clickable>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-clickable padding=\"base\">Create Store</s-clickable>\n\n<s-clickable\n  border=\"base\"\n  padding=\"base\"\n  background=\"subdued\"\n  borderRadius=\"base\"\n>\n  View Shipping Settings\n</s-clickable>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -12057,141 +11969,88 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "A simple clickable button with a base border and padding, demonstrating the default button behavior of the clickable component.",
+              "description": "Set the `href` property to make a clickable element navigate like a link. This example shows a clickable component that opens a URL in a new browser tab.",
               "codeblock": {
-                "title": "Basic Button Usage",
+                "title": "Navigate to a URL",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable border=\"base\" padding=\"base\"&gt;\n  Click me\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-clickable border=\"base\" padding=\"base\"&gt;Click me&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable border=\"base\" padding=\"base\">\n  Click me\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates the clickable component's ability to function as a link, opening the specified URL in a new browser tab when clicked.",
-              "codeblock": {
-                "title": "Link Mode",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable href=\"javascript:void(0)\" target=\"_blank\"&gt;\n  Visit Shopify\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable href=\"javascript:void(0)\" target=\"_blank\"&gt;\n  Visit Shopify\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable href=\"javascript:void(0)\" target=\"_blank\">\n  Visit Shopify\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable href=\"javascript:void(0)\" target=\"_blank\">\n  Visit Shopify\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "A disabled submit button that can be used within a form, showing the component's form integration capabilities and disabled state.",
+              "description": "Use a clickable component as a form submit button with a disabled state to prevent premature submission. This example shows a disabled submit-type clickable component with a border and padding.",
               "codeblock": {
-                "title": "Form Submit Button",
+                "title": "Create a form submit button",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\"&gt;\n  Save changes\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\"&gt;\n  Save changes\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\">\n  Save changes\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable type=\"submit\" disabled border=\"base\" padding=\"base\">\n  Save changes\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates how the clickable component can be integrated into a section layout to provide an interactive action button.",
+              "description": "Add a clickable button alongside descriptive content in a section. This example shows a styled clickable button inside a box with a heading and description.",
               "codeblock": {
-                "title": "Section with Clickable Action",
+                "title": "Add a clickable action to a section",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\"&gt;\n  &lt;s-stack gap=\"large-300\"&gt;\n    &lt;s-heading&gt;Product settings&lt;/s-heading&gt;\n    &lt;s-text&gt;Configure your product inventory and pricing settings.&lt;/s-text&gt;\n    &lt;s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\"&gt;\n      &lt;s-text type=\"strong\"&gt;Configure settings&lt;/s-text&gt;\n    &lt;/s-clickable&gt;\n  &lt;/s-stack&gt;\n&lt;/s-box&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\"&gt;\n  &lt;s-stack gap=\"large-300\"&gt;\n    &lt;s-heading&gt;Product settings&lt;/s-heading&gt;\n    &lt;s-text&gt;Configure your product inventory and pricing settings.&lt;/s-text&gt;\n    &lt;s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\"&gt;\n      &lt;s-text type=\"strong\"&gt;Configure settings&lt;/s-text&gt;\n    &lt;/s-clickable&gt;\n  &lt;/s-stack&gt;\n&lt;/s-box&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\">\n  <s-stack gap=\"large-300\">\n    <s-heading>Product settings</s-heading>\n    <s-text>Configure your product inventory and pricing settings.</s-text>\n    <s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\">\n      <s-text type=\"strong\">Configure settings</s-text>\n    </s-clickable>\n  </s-stack>\n</s-box>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-box padding=\"large-400\" background=\"base\" borderRadius=\"small-200\">\n  <s-stack gap=\"large-300\">\n    <s-heading>Product settings</s-heading>\n    <s-text>Configure your product inventory and pricing settings.</s-text>\n    <s-clickable background=\"base\" padding=\"base\" borderRadius=\"small\">\n      <s-text type=\"strong\">Configure settings</s-text>\n    </s-clickable>\n  </s-stack>\n</s-box>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates the use of an accessibility label to provide context for screen readers, enhancing the component's usability for users with assistive technologies.",
+              "description": "Add an accessibility label to provide screen readers with more context than the visible text alone. This example shows a clickable delete button with a descriptive label for assistive technologies.",
               "codeblock": {
-                "title": "Accessibility with ARIA Attributes",
+                "title": "Add an accessibility label",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n&gt;\n  &lt;s-text&gt;Delete&lt;/s-text&gt;\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n&gt;\n  &lt;s-text&gt;Delete&lt;/s-text&gt;\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n>\n  <s-text>Delete</s-text>\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable\n  accessibilityLabel=\"Delete product winter collection jacket\"\n  background=\"base\"\n  padding=\"base\"\n  borderRadius=\"small\"\n>\n  <s-text>Delete</s-text>\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Shows a disabled link with an accessibility label, explaining the unavailability of a feature to users of assistive technologies.",
+              "description": "Disable a clickable link while providing an accessibility label that explains why the feature is unavailable. This example shows a disabled navigation element with a descriptive label for screen readers.",
               "codeblock": {
-                "title": "Disabled Link with ARIA",
+                "title": "Describe a disabled link with an accessibility label",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n&gt;\n  &lt;s-text&gt;Unavailable feature&lt;/s-text&gt;\n&lt;/s-clickable&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n&gt;\n  &lt;s-text&gt;Unavailable feature&lt;/s-text&gt;\n&lt;/s-clickable&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n>\n  <s-text>Unavailable feature</s-text>\n</s-clickable>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable\n  href=\"javascript:void(0)\"\n  disabled\n  accessibilityLabel=\"This link is currently unavailable\"\n>\n  <s-text>Unavailable feature</s-text>\n</s-clickable>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -12204,8 +12063,8 @@
   },
   {
     "name": "Clickable chip",
-    "description": "The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).",
-    "category": "Polaris web components",
+    "description": "The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.\n\nClickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip).",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/clickable-chip.png",
@@ -12215,7 +12074,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.\n- **Choose color variants by importance:** Use `subdued` for less important or secondary chips, `base` (default) for standard selections, and `strong` to emphasize primary or active selections.\n- **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.\n- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing."
+        "sectionContent": "- **Keep labels to 1-3 words:** Aim for labels like **Electronics**, **Summer sale**, or **Clearance items**.\n- **Choose color variants by importance:** Use `subdued` for less important or secondary chips, `base` (default) for standard selections, and `strong` to emphasize primary or active selections.\n- **Make remove action clear:** When chips are removable, ensure the remove button's visible and has clear hover/focus states.\n- **Group related chips together:** Use an inline [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack) to arrange multiple chips horizontally with consistent spacing."
       }
     ],
     "definitions": [
@@ -12439,7 +12298,7 @@
       },
       {
         "title": "Events",
-        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ClickableChipEvents",
         "typeDefinitions": {
           "ClickableChipEvents": {
@@ -12492,7 +12351,7 @@
       },
       {
         "title": "Slots",
-        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The clickable chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ClickableChipSlots",
         "typeDefinitions": {
           "ClickableChipSlots": {
@@ -12523,23 +12382,19 @@
       }
     ],
     "defaultExample": {
-      "image": "clickable-chip-default.png",
+      "image": "clickablechip-default.png",
+      "description": "Create an interactive chip that merchants can click to trigger an action. This example shows a clickable chip component with default styling.",
       "codeblock": {
-        "title": "Code",
+        "title": "Add a clickable chip with default styling",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;s-clickable-chip&gt;Clickable chip&lt;/s-clickable-chip&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-clickable-chip&gt;Clickable chip&lt;/s-clickable-chip&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-clickable-chip&gt;Clickable chip&lt;/s-clickable-chip&gt;\n",
-            "language": "html",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip>Clickable chip</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-clickable-chip>Clickable chip</s-clickable-chip>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -12549,118 +12404,71 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Demonstrates a simple clickable chip with a base color and interactive functionality.",
+              "description": "Use the `color` property to visually distinguish chips by importance or category. This example shows three chips with `base`, `subdued`, and `strong` color variants.",
               "codeblock": {
-                "title": "Basic Usage",
+                "title": "Apply color variants to chips",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  &gt;\n    Draft\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  &gt;\n    Archived\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  &gt;\n    Draft\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  &gt;\n    Archived\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-stack direction=\"inline\" gap=\"base\">\n  <s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\">\n    Active\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  >\n    Draft\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  >\n    Archived\n  </s-clickable-chip>\n</s-stack>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-stack direction=\"inline\" gap=\"base\">\n  <s-clickable-chip color=\"base\" accessibilityLabel=\"Filter by active products\">\n    Active\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"subdued\"\n    accessibilityLabel=\"Filter by draft products\"\n  >\n    Draft\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Filter by archived products\"\n  >\n    Archived\n  </s-clickable-chip>\n</s-stack>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Showcases a strong-colored clickable chip with a check circle icon and a removable state.",
+              "description": "Add an icon and a remove button so merchants can see the status and dismiss the chip. This example shows a removable chip with a check circle icon in the graphic slot.",
               "codeblock": {
-                "title": "With Icon and Remove Button",
+                "title": "Add an icon and a remove button to a chip",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"check-circle\" /&gt;\n  In progress\n&lt;/s-clickable-chip&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"check-circle\"&gt;&lt;/s-icon&gt;\n  In progress\n&lt;/s-clickable-chip&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n>\n  <s-icon slot=\"graphic\" type=\"check-circle\" />\n  In progress\n</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable-chip\n  color=\"strong\"\n  accessibilityLabel=\"Remove status filter\"\n  removable\n>\n  <s-icon slot=\"graphic\" type=\"check-circle\"></s-icon>\n  In progress\n</s-clickable-chip>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates a subdued clickable chip configured as a link with a product icon.",
+              "description": "Set the `href` property to make a chip link to another page when clicked. This example shows a subdued chip with a product icon that acts as a link.",
               "codeblock": {
-                "title": "As a Link",
+                "title": "Use a chip as a link",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"product\" /&gt;\n  T-shirt\n&lt;/s-clickable-chip&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n&gt;\n  &lt;s-icon slot=\"graphic\" type=\"product\"&gt;&lt;/s-icon&gt;\n  T-shirt\n&lt;/s-clickable-chip&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n>\n  <s-icon slot=\"graphic\" type=\"product\" />\n  T-shirt\n</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable-chip\n  color=\"subdued\"\n  href=\"javascript:void(0)\"\n  accessibilityLabel=\"View T-shirt product\"\n>\n  <s-icon slot=\"graphic\" type=\"product\"></s-icon>\n  T-shirt\n</s-clickable-chip>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates a clickable chip in a disabled state, preventing interaction while displaying an inactive status.",
+              "description": "Disable a chip to prevent interaction while keeping it visible. This example shows a disabled chip with an accessibility label explaining the inactive state.",
               "codeblock": {
-                "title": "Disabled State",
+                "title": "Disable a clickable chip",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n&gt;\n  Inactive\n&lt;/s-clickable-chip&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n&gt;\n  Inactive\n&lt;/s-clickable-chip&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n>\n  Inactive\n</s-clickable-chip>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates how multiple clickable chips with different colors, icons, and states can be arranged using an inline stack for consistent layout and spacing.",
-              "codeblock": {
-                "title": "Multiple Chips with Proper Spacing",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip accessibilityLabel=\"Filter by status\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Remove status filter\"\n    removable\n  &gt;\n    &lt;s-icon slot=\"graphic\" type=\"check-circle\" /&gt;\n    In progress\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip color=\"subdued\" accessibilityLabel=\"Filter by category\"&gt;\n    &lt;s-icon slot=\"graphic\" type=\"filter\" /&gt;\n    Category\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-stack direction=\"inline\" gap=\"base\"&gt;\n  &lt;s-clickable-chip accessibilityLabel=\"Filter by status\"&gt;\n    Active\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Remove status filter\"\n    removable\n  &gt;\n    &lt;s-icon slot=\"graphic\" type=\"check-circle\"&gt;&lt;/s-icon&gt;\n    In progress\n  &lt;/s-clickable-chip&gt;\n  &lt;s-clickable-chip color=\"subdued\" accessibilityLabel=\"Filter by category\"&gt;\n    &lt;s-icon slot=\"graphic\" type=\"filter\"&gt;&lt;/s-icon&gt;\n    Category\n  &lt;/s-clickable-chip&gt;\n&lt;/s-stack&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-stack direction=\"inline\" gap=\"base\">\n  <s-clickable-chip accessibilityLabel=\"Filter by status\">\n    Active\n  </s-clickable-chip>\n  <s-clickable-chip\n    color=\"strong\"\n    accessibilityLabel=\"Remove status filter\"\n    removable\n  >\n    <s-icon slot=\"graphic\" type=\"check-circle\" />\n    In progress\n  </s-clickable-chip>\n  <s-clickable-chip color=\"subdued\" accessibilityLabel=\"Filter by category\">\n    <s-icon slot=\"graphic\" type=\"filter\" />\n    Category\n  </s-clickable-chip>\n</s-stack>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-clickable-chip\n  color=\"base\"\n  disabled\n  accessibilityLabel=\"Status filter (disabled)\"\n>\n  Inactive\n</s-clickable-chip>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -12673,8 +12481,8 @@
   },
   {
     "name": "Color field",
-    "description": "The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-picker).",
-    "category": "Polaris web components",
+    "description": "The color field component allows users to select colors through an integrated color picker or direct text input. Use color field for theme colors, brand colors, or any color selection to provide both visual and text-based color input methods.\n\nColor fields support hex color codes, color preview swatches, and validation to ensure users select or enter valid color values. For a standalone visual color palette interface without text input, use [color picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-picker).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/color-field.png",
@@ -12707,7 +12515,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -13002,7 +12810,7 @@
       },
       {
         "title": "Events",
-        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The color field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ColorFieldEvents",
         "typeDefinitions": {
           "ColorFieldEvents": {
@@ -13235,8 +13043,8 @@
   },
   {
     "name": "Color picker",
-    "description": "The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field).",
-    "category": "Polaris web components",
+    "description": "The color picker component allows users to select colors from a visual color palette interface. Use color picker to provide an intuitive, visual way for users to choose colors for themes, branding, or design customization.\n\nColor pickers support multiple color formats, predefined color swatches, and interactive selection to make color choice easy and accurate. For combined visual and text-based color input with validation, use [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/color-picker.png",
@@ -13246,7 +13054,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.\n- **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.\n- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control."
+        "sectionContent": "- **Initialize with current values:** When editing existing colors, always set the picker's initial value to the current color. This shows merchants what they're changing from and maintains context.\n- **Show preview of final result:** If possible, show how the selected color will look in its actual context (like previewing a button color on a button) alongside the picker.\n- **Pair with color field for precision:** Use the component for visual selection combined with a [color field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/color-field) for precise hex input. This gives merchants both visual intuition and exact control."
       },
       {
         "title": "Limitations",
@@ -13269,7 +13077,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@6948",
+                "name": "__@internals$2@6946",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -13442,7 +13250,7 @@
       },
       {
         "title": "Events",
-        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The color picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ColorPickerEvents",
         "typeDefinitions": {
           "ColorPickerEvents": {
@@ -13535,8 +13343,8 @@
   },
   {
     "name": "Date field",
-    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-picker).",
-    "category": "Polaris web components",
+    "description": "The date field component captures date input with a consistent interface for date selection and proper validation. Use it to collect date information in forms, scheduling interfaces, or data entry workflows.\n\nThe component supports manual text entry. For visual calendar-based selection, consider using [date picker](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-picker).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/datefield.png",
@@ -13563,7 +13371,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -13901,7 +13709,7 @@
       },
       {
         "title": "Events",
-        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "DateFieldEvents",
         "typeDefinitions": {
           "DateFieldEvents": {
@@ -14162,8 +13970,8 @@
   },
   {
     "name": "Date picker",
-    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/date-field).",
-    "category": "Polaris web components",
+    "description": "The date picker component allows merchants to select dates using a calendar interface. Use it when merchants benefit from seeing dates in context of the full month, such as selecting dates relative to today or needing weekday context.\n\nThe component supports single dates, multiple dates, and date ranges. For text date entry, use [date field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/date-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/datepicker.png",
@@ -14178,7 +13986,7 @@
     ],
     "definitions": [
       {
-        "title": "DatePicker",
+        "title": "Properties",
         "description": "Configure the following properties on the date picker component.",
         "type": "DatePicker",
         "typeDefinitions": {
@@ -14190,7 +13998,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@6992",
+                "name": "__@dirtyStateSymbol@6990",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -14199,7 +14007,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@6991",
+                "name": "__@internals$1@6989",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -14427,7 +14235,7 @@
       },
       {
         "title": "Events",
-        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "DatePickerEvents",
         "typeDefinitions": {
           "DatePickerEvents": {
@@ -14595,8 +14403,8 @@
   },
   {
     "name": "Divider",
-    "description": "The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section).",
-    "category": "Polaris web components",
+    "description": "The divider component creates clear visual separation between elements in the interface. Use divider to separate distinct content groups in forms, settings panels, lists, or page sections, helping users scan and understand content organization.\n\nDividers support both horizontal and vertical orientations, along with different visual strengths for varying levels of emphasis. For more structured content grouping with headings, use [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "subSections": [
@@ -14847,7 +14655,7 @@
   {
     "name": "Drop zone",
     "description": "The drop zone component lets users upload files through drag-and-drop or by clicking to browse. Use for file uploads such as images, documents, or CSV imports.\n\nThe component provides visual feedback during drag operations and supports file type validation through the `accept` property. Rejected files trigger the `droprejected` event for custom error handling.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/dropzone.png",
@@ -14857,7 +14665,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- Set clear file type and size restrictions using the `accept` property.\n- Use the `droprejected` event to display meaningful error messages when uploads fail validation.\n- Consider using `disabled` to prevent uploads during processing."
+        "sectionContent": "- **Define file restrictions**: Set clear file type and size restrictions using the `accept` property.\n- **Provide meaningful error messages**: Use the `droprejected` event to display meaningful error messages when uploads fail validation.\n- **Prevent duplicate uploads**: Consider using `disabled` to prevent uploads during processing."
       },
       {
         "title": "Limitations",
@@ -14880,7 +14688,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@7029",
+                "name": "__@getFileInput@7027",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true,
@@ -14889,7 +14697,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@7028",
+                "name": "__@internals@7026",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -14898,7 +14706,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@7027",
+                "name": "__@setFiles@7025",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true,
@@ -15134,7 +14942,7 @@
       },
       {
         "title": "Events",
-        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "DropZoneEvents",
         "typeDefinitions": {
           "DropZoneEvents": {
@@ -15358,8 +15166,8 @@
   },
   {
     "name": "Email field",
-    "description": "The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The email field component captures email address input. Use it to collect email information in forms, customer profiles, or contact workflows.\n\nEmail field doesn't perform automatic email validation. Implement your own validation logic, and use the `error` property to display validation results. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/emailfield.png",
@@ -15392,7 +15200,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -15694,7 +15502,7 @@
       },
       {
         "title": "Events",
-        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "EmailFieldEvents",
         "typeDefinitions": {
           "EmailFieldEvents": {
@@ -15854,8 +15662,8 @@
   },
   {
     "name": "Grid",
-    "description": "The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/stack).",
-    "category": "Polaris web components",
+    "description": "The grid component organizes content in a matrix of rows and columns to create responsive page layouts. Use grid to build complex, multi-column layouts that adapt to different screen sizes and maintain consistent alignment.\n\nGrid follows the CSS grid layout pattern and supports flexible column configurations, gap spacing, and alignment properties for precise layout control. For simpler linear layouts (horizontal or vertical), use [stack](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/stack).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "subSections": [
@@ -16036,7 +15844,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16072,7 +15880,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -16081,7 +15889,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateColumns",
                 "value": "string",
-                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -16090,7 +15898,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gridTemplateRows",
                 "value": "string",
-                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
+                "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -16171,7 +15979,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -16180,7 +15988,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16189,7 +15997,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16198,7 +16006,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16207,7 +16015,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16216,7 +16024,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16225,7 +16033,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16261,7 +16069,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16512,7 +16320,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The grid component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "GridSlots",
         "typeDefinitions": {
           "GridSlots": {
@@ -16775,7 +16583,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -16784,7 +16592,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16793,7 +16601,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16802,7 +16610,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16811,7 +16619,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16820,7 +16628,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -16829,7 +16637,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -17026,7 +16834,7 @@
       },
       {
         "title": "Slots",
-        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The grid item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "GridItemSlots",
         "typeDefinitions": {
           "GridItemSlots": {
@@ -17131,8 +16939,8 @@
   },
   {
     "name": "Heading",
-    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.",
-    "category": "Polaris web components",
+    "description": "The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.\n\nHeading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/heading.png",
@@ -17315,7 +17123,7 @@
       },
       {
         "title": "Slots",
-        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The heading component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "HeadingSlots",
         "typeDefinitions": {
           "HeadingSlots": {
@@ -17420,8 +17228,8 @@
   },
   {
     "name": "Icon",
-    "description": "The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) to enhance visual communication.",
-    "category": "Polaris web components",
+    "description": "The icon component renders graphic symbols to visually communicate actions, status, and navigation throughout the interface. Use icon to reinforce button actions, indicate status states, or provide wayfinding cues that help users understand available functionality.\n\nIcons support multiple sizes, tones for semantic meaning, and can be integrated with other components like [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button), [badge](/docs/api/{API_NAME}/{API_VERSION}/web-components/feedback-and-status-indicators/badge), and [chip](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/chip) to enhance visual communication.",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/icon.png",
@@ -17443,7 +17251,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.\n- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image) component instead.\n- Icon color is determined by the `tone` and `color` properties. Custom colors or gradients aren't available."
+        "sectionContent": "- Icons are limited to the predefined set provided by the component. Custom SVG icons, icon fonts, or external icon libraries aren't supported.\n- Icons can't be animated or include interactive states beyond color changes. For complex graphics or illustrations, use the [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image) component instead.\n- Icon color is determined by the `tone` and `color` properties. Custom colors or gradients aren't available."
       }
     ],
     "definitions": [
@@ -17776,36 +17584,30 @@
   },
   {
     "name": "Image",
-    "description": "The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).",
-    "category": "Polaris web components",
+    "description": "The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.\n\nImages support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/image.png",
     "isVisualComponent": true,
     "subSections": [
       {
-        "title": "Useful for",
-        "type": "Generic",
-        "anchorLink": "useful-for",
-        "sectionContent": "- Adding illustrations and photos."
-      },
-      {
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- Use high-resolution, optimized images.\n- Use intentionally to add clarity and guide users."
+        "sectionContent": "- **Always provide descriptive alternative text:** Write alt text that describes what's in the image, not what the image is for. Use \"Blue cotton t-shirt with crew neck\" instead of \"Product image.\" For decorative images that don't add information, use an empty alt attribute.\n- **Use images for meaningful content, not decoration:** Display product photos, diagrams, charts, or instructional screenshots. For icons or decorative elements, use the [Icon](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/icon) component instead.\n- **Ensure images are accessible and performant:** Use appropriate image formats (WebP for photos, PNG for graphics with transparency, SVG for logos). Ensure images load from reliable sources with proper CORS configuration if cross-origin.\n- **Consider the image's purpose and context:** Use images to help merchants understand products, visualize data, or follow instructions. Every image should serve a clear purpose in your interface."
       },
       {
-        "title": "Content guidelines",
+        "title": "Limitations",
         "type": "Generic",
-        "anchorLink": "content-guidelines",
-        "sectionContent": "Alt text should be accurate, concise, and descriptive:\n- Indicate it's an image: \"Image of\", \"Photo of\".\n- Focus on description: \"Image of a woman with curly brown hair smiling\"."
+        "anchorLink": "limitations",
+        "sectionContent": "- Images can be loaded from remote URLs or local file resources. Cross-origin images require proper CORS headers from the image host.\n- The component displays images at their intrinsic aspect ratio. Use `aspectRatio` (for example, `'16/9'`) to set a fixed ratio, and `objectFit` (`'cover'` or `'contain'`) to control how the image resizes within its container.\n- The component provides a basic placeholder while images load but doesn't include built-in loading skeletons or progressive loading features."
       }
     ],
     "definitions": [
       {
         "title": "Properties",
-        "description": "",
+        "description": "Configure the following properties on the image component.",
         "type": "Image",
         "typeDefinitions": {
           "Image": {
@@ -18130,7 +17932,7 @@
       },
       {
         "title": "Events",
-        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The image component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ImageEvents",
         "typeDefinitions": {
           "ImageEvents": {
@@ -18268,7 +18070,7 @@
               }
             },
             {
-              "description": "Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.",
+              "description": "Build a product image gallery with consistent sizing using [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid). This example arranges three product photos in a row, each constrained to a square with rounded corners so they line up evenly.",
               "codeblock": {
                 "title": "Use in a grid layout",
                 "tabs": [
@@ -18291,8 +18093,8 @@
   },
   {
     "name": "Link",
-    "description": "The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.",
-    "category": "Polaris web components",
+    "description": "The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.\n\nLinks support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) instead.",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/link.png",
@@ -18530,7 +18332,7 @@
       },
       {
         "title": "Events",
-        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "LinkEvents",
         "typeDefinitions": {
           "LinkEvents": {
@@ -18567,7 +18369,7 @@
       },
       {
         "title": "Slots",
-        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The link component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "LinkSlots",
         "typeDefinitions": {
           "LinkSlots": {
@@ -18591,22 +18393,18 @@
     ],
     "defaultExample": {
       "image": "link-default.png",
+      "description": "Add an inline link to let merchants navigate to another page. This example shows a basic text link with an `href` property.",
       "codeblock": {
-        "title": "Code",
+        "title": "Add a basic link",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;s-link href=\"javascript:void(0)\"&gt;fufilling orders&lt;/s-link&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-link href=\"#beep\"&gt;fulfilling orders&lt;/s-link&gt;",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-link href=\"#beep\"&gt;fufilling orders&lt;/s-link&gt;\n",
-            "language": "html",
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-link href=\"javascript:void(0)\">fufilling orders</s-link>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-link href=\"#beep\">fulfilling orders</s-link></div></body></html>",
             "language": "preview"
           }
         ]
@@ -18616,256 +18414,122 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Links automatically inherit the tone from their surrounding paragraph context.",
+              "description": "Embed links within a [Paragraph](/docs/api/app-home/web-components/typography-and-content/paragraph) so merchants can navigate to related content inline. This example shows two links inside a paragraph that inherit the surrounding text tone.",
               "codeblock": {
-                "title": "Basic Links in Paragraph",
+                "title": "Embed links in paragraph text",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  Your product catalog is empty. Start by &lt;s-link href=\"javascript:void(0)\"&gt;adding your first product&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;importing existing inventory&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-paragraph&gt;\n  Your product catalog is empty. Start by &lt;s-link href=\"javascript:void(0)\"&gt;adding your first product&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;importing existing inventory&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  Your product catalog is empty. Start by <s-link href=\"javascript:void(0)\">adding your first product</s-link> or <s-link href=\"javascript:void(0)\">importing existing inventory</s-link>.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-paragraph>\n  Your product catalog is empty. Start by <s-link href=\"javascript:void(0)\">adding your first product</s-link> or <s-link href=\"javascript:void(0)\">importing existing inventory</s-link>.\n</s-paragraph>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates links within subdued paragraph, showing how links can be used in less prominent paragraph contexts for additional guidance or support.",
+              "description": "Place links inside banners to provide direct actions alongside important notifications. This example shows a link inside an info banner prompting merchants to create a campaign.",
               "codeblock": {
-                "title": "Links in Subdued Paragraph",
+                "title": "Add links inside a banner",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph color=\"subdued\"&gt;\n  Need help setting up shipping rates? &lt;s-link&gt;View shipping guide&lt;/s-link&gt; or &lt;s-link&gt;contact merchant support&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-paragraph color=\"subdued\"&gt;\n  Need help setting up shipping rates? &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;View shipping guide&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;contact merchant support&lt;/s-link&gt;.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph color=\"subdued\">\n  Need help setting up shipping rates? <s-link>View shipping guide</s-link> or <s-link>contact merchant support</s-link>.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Illustrates how links can be used in critical or urgent text contexts, drawing attention to important actions that require immediate user intervention.",
-              "codeblock": {
-                "title": "Critical Context Links",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph tone=\"critical\"&gt;\n  Your store will be suspended in 24 hours due to unpaid balance. &lt;s-link href=\"javascript:void(0)\"&gt;Update payment method&lt;/s-link&gt; to avoid service interruption.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-paragraph tone=\"critical\"&gt;\n  Your store will be suspended in 24 hours due to unpaid balance. &lt;s-link href=\"javascript:void(0)\"&gt;Update payment method&lt;/s-link&gt; to avoid service interruption.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph tone=\"critical\">\n  Your store will be suspended in 24 hours due to unpaid balance. <s-link href=\"javascript:void(0)\">Update payment method</s-link> to avoid service interruption.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Shows how links automatically adapt their tone to the surrounding text context, maintaining visual consistency while providing navigation.",
-              "codeblock": {
-                "title": "Links with Auto Tone",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  You have 15 pending orders to fulfill. &lt;s-link href=\"javascript:void(0)\"&gt;Review unfulfilled orders&lt;/s-link&gt; to keep customers happy.\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-paragraph&gt;\n  You have 15 pending orders to fulfill. &lt;s-link href=\"javascript:void(0)\"&gt;Review unfulfilled orders&lt;/s-link&gt; to keep customers happy.\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  You have 15 pending orders to fulfill. <s-link href=\"javascript:void(0)\">Review unfulfilled orders</s-link> to keep customers happy.\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates how links can be integrated within banner components to highlight important information and provide direct action paths.",
-              "codeblock": {
-                "title": "Links in Banner",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-banner tone=\"info\"&gt;\n  &lt;s-paragraph&gt;\n    Black Friday campaigns are now available!  &lt;s-link href=\"javascript:void(0)\"&gt;Create your campaign&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-banner tone=\"info\"&gt;\n  &lt;s-paragraph&gt;\n    Black Friday campaigns are now available!\n    &lt;s-link href=\"javascript:void(0)\"&gt;Create your campaign&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-banner tone=\"info\">\n  <s-paragraph>\n    Black Friday campaigns are now available!  <s-link href=\"javascript:void(0)\">Create your campaign</s-link>\n  </s-paragraph>\n</s-banner>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-banner tone=\"info\">\n  <s-paragraph>\n    Black Friday campaigns are now available!\n    <s-link href=\"javascript:void(0)\">Create your campaign</s-link>\n  </s-paragraph>\n</s-banner>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates using links within a box container to provide contextual navigation and additional information in a visually contained area.",
+              "description": "Place links inside a box container to provide navigation within a visually distinct content area. This example shows two links inside a bordered box with background and padding.",
               "codeblock": {
-                "title": "Links in Box Container",
+                "title": "Add links inside a box container",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Boost your store's conversion with professional themes. &lt;s-link href=\"javascript:void(0)\"&gt;Browse theme store&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;customize your current theme&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Boost your store's conversion with professional themes. &lt;s-link href=\"javascript:void(0)\"&gt;Browse theme store&lt;/s-link&gt; or &lt;s-link href=\"javascript:void(0)\"&gt;customize your current theme&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\">\n  <s-paragraph>\n    Boost your store's conversion with professional themes. <s-link href=\"javascript:void(0)\">Browse theme store</s-link> or <s-link href=\"javascript:void(0)\">customize your current theme</s-link>.\n  </s-paragraph>\n</s-box>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-box padding=\"base\" background=\"base\" borderWidth=\"base\" borderColor=\"base\">\n  <s-paragraph>\n    Boost your store's conversion with professional themes. <s-link href=\"javascript:void(0)\">Browse theme store</s-link> or <s-link href=\"javascript:void(0)\">customize your current theme</s-link>.\n  </s-paragraph>\n</s-box>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Shows how links can be used within warning banners to provide immediate actions related to critical notifications.",
+              "description": "Use the `download` property to trigger a file download when the link is clicked. This example shows a link that downloads a CSV file for customer data export.",
               "codeblock": {
-                "title": "Links in Banner Context",
+                "title": "Trigger a file download",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-banner tone=\"warning\"&gt;\n  &lt;s-paragraph&gt;\n    Your inventory for \"Vintage t-shirt\" is running low (3 remaining).  &lt;s-link&gt;Restock inventory&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-banner tone=\"warning\"&gt;\n  &lt;s-paragraph&gt;\n    Your inventory for \"Vintage t-shirt\" is running low (3 remaining). &lt;s-link&gt;Restock inventory&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-banner&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-banner tone=\"warning\">\n  <s-paragraph>\n    Your inventory for \"Vintage t-shirt\" is running low (3 remaining).  <s-link>Restock inventory</s-link>\n  </s-paragraph>\n</s-banner>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Demonstrates how to create links that trigger file downloads, useful for exporting data or providing downloadable resources.",
-              "codeblock": {
-                "title": "Download Links",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  Export your customer data for marketing analysis. &lt;s-link href=\"javascript:void(0)\" download=\"customer-export.csv\"&gt;Download customer list&lt;/s-link&gt;\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-paragraph&gt;\n  Export your customer data for marketing analysis. &lt;s-link href=\"javascript:void(0)\" download=\"customer-export.csv\"&gt;Download customer list&lt;/s-link&gt;\n&lt;/s-paragraph&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  Export your customer data for marketing analysis. <s-link href=\"javascript:void(0)\" download=\"customer-export.csv\">Download customer list</s-link>\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-paragraph>\n  Export your customer data for marketing analysis. <s-link href=\"javascript:void(0)\" download=\"customer-export.csv\">Download customer list</s-link>\n</s-paragraph>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates linking to external resources with different targets, showing how to open links in new tabs and provide navigation to external documentation.",
+              "description": "Open external URLs in a new tab so merchants stay on the current page. This example shows two links with `target=\"_blank\"` pointing to external documentation.",
               "codeblock": {
-                "title": "External Links",
+                "title": "Open external links in a new tab",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-box padding=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Need help with policies? Read our &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;billing docs&lt;/s-link&gt; or review the &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;terms of service&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-box padding=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Need help with policies? Read our &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;billing docs&lt;/s-link&gt; or review the &lt;s-link href=\"javascript:void(0)\" target=\"_blank\"&gt;terms of service&lt;/s-link&gt;.\n  &lt;/s-paragraph&gt;\n&lt;/s-box&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-box padding=\"base\">\n  <s-paragraph>\n    Need help with policies? Read our <s-link href=\"javascript:void(0)\" target=\"_blank\">billing docs</s-link> or review the <s-link href=\"javascript:void(0)\" target=\"_blank\">terms of service</s-link>.\n  </s-paragraph>\n</s-box>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-box padding=\"base\">\n  <s-paragraph>\n    Need help with policies? Read our <s-link href=\"javascript:void(0)\" target=\"_blank\">billing docs</s-link> or review the <s-link href=\"javascript:void(0)\" target=\"_blank\">terms of service</s-link>.\n  </s-paragraph>\n</s-box>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Shows how to use the `lang` attribute to specify the language of a link, supporting internationalization and proper screen reader pronunciation.",
+              "description": "Set the `lang` property so screen readers pronounce the link text correctly. This example shows a French-language link with the `lang` attribute set.",
               "codeblock": {
-                "title": "Links with Language Attribute",
+                "title": "Set the language for a link",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-paragraph&gt;\n  Voir en français: &lt;s-link lang=\"fr\"&gt;Gérer les produits&lt;/s-link&gt;\n&lt;/s-paragraph&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-paragraph&gt;\n  Voir en français: &lt;s-link lang=\"fr\"&gt;Gérer les produits&lt;/s-link&gt;\n&lt;/s-paragraph&gt;",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-paragraph>\n  Voir en français: <s-link lang=\"fr\">Gérer les produits</s-link>\n</s-paragraph>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-paragraph>\n  Voir en français: <s-link lang=\"fr\">Gérer les produits</s-link>\n</s-paragraph></s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates how links can have different visual tones, including default, neutral, and critical, allowing for varied contextual styling.",
+              "description": "Configure links that inherit the tone of their parent paragraph and match the surrounding context. This example shows links inside paragraphs with six different tones.",
               "codeblock": {
-                "title": "Links with Different Tones",
+                "title": "Match link tone to surrounding context",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;s-stack gap=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Default tone: &lt;s-link&gt;View orders&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"success\"&gt;\n    Success tone: &lt;s-link&gt;Inventory help&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"critical\"&gt;\n    Critical tone: &lt;s-link&gt;Close store&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"warning\"&gt;\n    Warning tone: &lt;s-link&gt;Update billing info&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"info\"&gt;\n    Info tone: &lt;s-link&gt;Learn more about reports&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"caution\"&gt;\n    Caution tone: &lt;s-link&gt;View archived products&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-stack&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-stack gap=\"base\"&gt;\n  &lt;s-paragraph&gt;\n    Default tone: &lt;s-link&gt;View orders&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"success\"&gt;\n    Neutral tone: &lt;s-link&gt;Inventory help&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"critical\"&gt;\n    Critical tone: &lt;s-link&gt;Close store&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"warning\"&gt;\n    Warning tone: &lt;s-link&gt;Update billing info&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"info\"&gt;\n    Info tone: &lt;s-link&gt;Learn more about reports&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n\n  &lt;s-paragraph tone=\"caution\"&gt;\n    Subdued tone: &lt;s-link&gt;View archived products&lt;/s-link&gt;\n  &lt;/s-paragraph&gt;\n&lt;/s-stack&gt;",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><s-box padding=\"base\" id=\"wrapper-element\"></s-box><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<s-stack gap=\"base\">\n  <s-paragraph>\n    Default tone: <s-link>View orders</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"success\">\n    Success tone: <s-link>Inventory help</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"critical\">\n    Critical tone: <s-link>Close store</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"warning\">\n    Warning tone: <s-link>Update billing info</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"info\">\n    Info tone: <s-link>Learn more about reports</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"caution\">\n    Caution tone: <s-link>View archived products</s-link>\n  </s-paragraph>\n</s-stack>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-stack gap=\"base\">\n  <s-paragraph>\n    Default tone: <s-link>View orders</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"success\">\n    Neutral tone: <s-link>Inventory help</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"critical\">\n    Critical tone: <s-link>Close store</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"warning\">\n    Warning tone: <s-link>Update billing info</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"info\">\n    Info tone: <s-link>Learn more about reports</s-link>\n  </s-paragraph>\n\n  <s-paragraph tone=\"caution\">\n    Subdued tone: <s-link>View archived products</s-link>\n  </s-paragraph>\n</s-stack></s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -18879,7 +18543,7 @@
   {
     "name": "Menu",
     "description": "The menu component displays a list of actions that can be performed on a resource or within a specific context. Use menu to present multiple related actions in a compact dropdown format, reducing visual clutter while maintaining discoverability.\n\nMenus support action grouping, icons for visual clarity, and keyboard navigation for efficient interaction.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Actions",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/menu.png",
@@ -18912,7 +18576,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -18921,7 +18585,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -18930,7 +18594,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true,
@@ -19070,7 +18734,7 @@
       },
       {
         "title": "Slots",
-        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The menu component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "MenuSlots",
         "typeDefinitions": {
           "MenuSlots": {
@@ -19093,26 +18757,19 @@
       }
     ],
     "defaultExample": {
+      "image": "menu-default.png",
+      "description": "Add a dropdown menu of actions triggered by a button. This example shows a menu with three icon buttons including a critical delete action.",
       "codeblock": {
-        "title": "Code",
+        "title": "Add a basic actions menu",
         "tabs": [
           {
-            "title": "jsx",
-            "code": "&lt;&gt;\n  &lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n  &lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n    &lt;s-button icon=\"merge\"&gt;Merge customer&lt;/s-button&gt;\n    &lt;s-button icon=\"incoming\"&gt;Request customer data&lt;/s-button&gt;\n    &lt;s-button icon=\"delete\" tone=\"critical\"&gt;\n      Delete customer\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-            "language": "jsx",
+            "title": "html",
+            "code": "&lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n&lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n  &lt;s-button icon=\"merge\"&gt;Merge customer&lt;/s-button&gt;\n  &lt;s-button icon=\"incoming\"&gt;Request customer data&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete customer&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
+            "language": "html",
             "editable": false
           },
           {
-            "code": "&lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n&lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n  &lt;s-button icon=\"merge\"&gt;Merge customer&lt;/s-button&gt;\n  &lt;s-button icon=\"incoming\"&gt;Request customer data&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete customer&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-            "language": "html",
-            "layout": "alignStart",
-            "customStyles": {
-              "minHeight": "300px"
-            },
-            "title": "html"
-          },
-          {
-            "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n  <s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n    <s-button icon=\"merge\">Merge customer</s-button>\n    <s-button icon=\"incoming\">Request customer data</s-button>\n    <s-button icon=\"delete\" tone=\"critical\">\n      Delete customer\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+            "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><div id=\"wrapper-element\"><s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n<s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n  <s-button icon=\"merge\">Merge customer</s-button>\n  <s-button icon=\"incoming\">Request customer data</s-button>\n  <s-button icon=\"delete\" tone=\"critical\">Delete customer</s-button>\n</s-menu>\n</div></body></html>",
             "language": "preview"
           }
         ]
@@ -19122,141 +18779,88 @@
       "description": "Component examples",
       "exampleGroups": [
         {
-          "title": "Basic usage",
+          "title": "",
           "examples": [
             {
-              "description": "Demonstrates a simple menu with basic action buttons and shows how to link it to a trigger button.",
+              "description": "Organize menu items into labeled groups so merchants can find related actions. This example shows two sections with headings separating product actions from export options.",
               "codeblock": {
-                "title": "Basic Menu",
+                "title": "Organize items into sections",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"product-menu\"&gt;Product actions&lt;/s-button&gt;\n\n  &lt;s-menu id=\"product-menu\" accessibilityLabel=\"Product actions\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button commandFor=\"product-menu\"&gt;Product actions&lt;/s-button&gt;\n\n&lt;s-menu id=\"product-menu\" accessibilityLabel=\"Product actions\"&gt;\n  &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n  &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n  &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"product-menu\">Product actions</s-button>\n\n  <s-menu id=\"product-menu\" accessibilityLabel=\"Product actions\">\n    <s-button icon=\"edit\">Edit product</s-button>\n    <s-button icon=\"duplicate\">Duplicate product</s-button>\n    <s-button icon=\"archive\">Archive product</s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Illustrates a menu with icons for each action, providing visual context for different menu items and showing how to use the caret-down icon on the trigger button.",
-              "codeblock": {
-                "title": "Menu with Icons",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button icon=\"caret-down\" commandFor=\"actions-menu\"&gt;\n    More actions\n  &lt;/s-button&gt;\n\n  &lt;s-menu id=\"actions-menu\" accessibilityLabel=\"Product actions menu\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n    &lt;s-button icon=\"delete\" tone=\"critical\"&gt;\n      Delete product\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
-                  {
-                    "title": "html",
-                    "code": "&lt;s-button icon=\"caret-down\" commandFor=\"actions-menu\"&gt;More actions&lt;/s-button&gt;\n\n&lt;s-menu id=\"actions-menu\" accessibilityLabel=\"Product actions menu\"&gt;\n  &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n  &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n  &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete product&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
-                  },
-                  {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button icon=\"caret-down\" commandFor=\"actions-menu\">\n    More actions\n  </s-button>\n\n  <s-menu id=\"actions-menu\" accessibilityLabel=\"Product actions menu\">\n    <s-button icon=\"edit\">Edit product</s-button>\n    <s-button icon=\"duplicate\">Duplicate product</s-button>\n    <s-button icon=\"archive\">Archive product</s-button>\n    <s-button icon=\"delete\" tone=\"critical\">\n      Delete product\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
-                    "language": "preview"
-                  }
-                ]
-              }
-            },
-            {
-              "description": "Shows how to organize menu items into logical sections with headings, helping to group related actions and improve menu readability.",
-              "codeblock": {
-                "title": "Menu with Sections",
-                "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"organized-menu\"&gt;Bulk actions&lt;/s-button&gt;\n\n  &lt;s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\"&gt;\n    &lt;s-section heading=\"Product actions\"&gt;\n      &lt;s-button icon=\"edit\"&gt;Edit selected&lt;/s-button&gt;\n      &lt;s-button icon=\"duplicate\"&gt;Duplicate selected&lt;/s-button&gt;\n      &lt;s-button icon=\"archive\"&gt;Archive selected&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-section heading=\"Export options\"&gt;\n      &lt;s-button icon=\"export\"&gt;Export as CSV&lt;/s-button&gt;\n      &lt;s-button icon=\"print\"&gt;Print barcodes&lt;/s-button&gt;\n    &lt;/s-section&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button commandFor=\"organized-menu\"&gt;Bulk actions&lt;/s-button&gt;\n\n&lt;s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\"&gt;\n  &lt;s-section heading=\"Product actions\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit selected&lt;/s-button&gt;\n    &lt;s-button icon=\"duplicate\"&gt;Duplicate selected&lt;/s-button&gt;\n    &lt;s-button icon=\"archive\"&gt;Archive selected&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-section heading=\"Export options\"&gt;\n    &lt;s-button icon=\"export\"&gt;Export as CSV&lt;/s-button&gt;\n    &lt;s-button icon=\"print\"&gt;Print barcodes&lt;/s-button&gt;\n  &lt;/s-section&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 400px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"organized-menu\">Bulk actions</s-button>\n\n  <s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\">\n    <s-section heading=\"Product actions\">\n      <s-button icon=\"edit\">Edit selected</s-button>\n      <s-button icon=\"duplicate\">Duplicate selected</s-button>\n      <s-button icon=\"archive\">Archive selected</s-button>\n    </s-section>\n    <s-section heading=\"Export options\">\n      <s-button icon=\"export\">Export as CSV</s-button>\n      <s-button icon=\"print\">Print barcodes</s-button>\n    </s-section>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button commandFor=\"organized-menu\">Bulk actions</s-button>\n\n<s-menu id=\"organized-menu\" accessibilityLabel=\"Organized menu\">\n  <s-section heading=\"Product actions\">\n    <s-button icon=\"edit\">Edit selected</s-button>\n    <s-button icon=\"duplicate\">Duplicate selected</s-button>\n    <s-button icon=\"archive\">Archive selected</s-button>\n  </s-section>\n  <s-section heading=\"Export options\">\n    <s-button icon=\"export\">Export as CSV</s-button>\n    <s-button icon=\"print\">Print barcodes</s-button>\n  </s-section>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Demonstrates a menu with a mix of link-based buttons, standard buttons, and a disabled button, showcasing the menu's flexibility in handling different interaction states.",
+              "description": "Mix link-based, standard, and disabled buttons in a single menu. This example shows a menu with a link that opens in a new tab, a disabled action, and a download link.",
               "codeblock": {
-                "title": "Menu with Links and Disabled Items",
+                "title": "Add links and disabled items to a menu",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"mixed-menu\"&gt;Options&lt;/s-button&gt;\n\n  &lt;s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\"&gt;\n    &lt;s-button href=\"javascript:void(0)\" target=\"_blank\"&gt;\n      View product page\n    &lt;/s-button&gt;\n    &lt;s-button disabled&gt;Unavailable action&lt;/s-button&gt;\n    &lt;s-button download=\"sales-report.csv\" href=\"/reports/sales-report.csv\"&gt;\n      Download report\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button commandFor=\"mixed-menu\"&gt;Options&lt;/s-button&gt;\n\n&lt;s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\"&gt;\n  &lt;s-button href=\"javascript:void(0)\" target=\"_blank\"&gt;\n    View product page\n  &lt;/s-button&gt;\n  &lt;s-button disabled&gt;Unavailable action&lt;/s-button&gt;\n  &lt;s-button download href=\"javascript:void(0)\"&gt;Download report&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"mixed-menu\">Options</s-button>\n\n  <s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\">\n    <s-button href=\"javascript:void(0)\" target=\"_blank\">\n      View product page\n    </s-button>\n    <s-button disabled>Unavailable action</s-button>\n    <s-button download=\"sales-report.csv\" href=\"/reports/sales-report.csv\">\n      Download report\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button commandFor=\"mixed-menu\">Options</s-button>\n\n<s-menu id=\"mixed-menu\" accessibilityLabel=\"Mixed menu options\">\n  <s-button href=\"javascript:void(0)\" target=\"_blank\">\n    View product page\n  </s-button>\n  <s-button disabled>Unavailable action</s-button>\n  <s-button download href=\"javascript:void(0)\">Download report</s-button>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Presents a comprehensive menu showing how to create sections with different action groups and include a critical action at the menu's root level.",
+              "description": "Combine sections with root-level items to separate grouped actions from standalone ones like a destructive action. This example shows two sections for customer management alongside a root-level delete button.",
               "codeblock": {
-                "title": "Actions menu with sections",
+                "title": "Mix sections with root-level actions",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n  &lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n    &lt;s-section heading=\"Customer management\"&gt;\n      &lt;s-button icon=\"edit\"&gt;Edit customer&lt;/s-button&gt;\n      &lt;s-button icon=\"email\"&gt;Send email&lt;/s-button&gt;\n      &lt;s-button icon=\"order\"&gt;View orders&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-section heading=\"Account actions\"&gt;\n      &lt;s-button icon=\"reset\"&gt;Reset password&lt;/s-button&gt;\n      &lt;s-button icon=\"lock\"&gt;Disable account&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-button tone=\"critical\" icon=\"delete\"&gt;\n      Delete customer\n    &lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button commandFor=\"customer-menu\"&gt;Edit customer&lt;/s-button&gt;\n\n&lt;s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\"&gt;\n  &lt;s-section heading=\"Customer management\"&gt;\n    &lt;s-button icon=\"edit\"&gt;Edit customer&lt;/s-button&gt;\n    &lt;s-button icon=\"email\"&gt;Send email&lt;/s-button&gt;\n    &lt;s-button icon=\"order\"&gt;View orders&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-section heading=\"Account actions\"&gt;\n    &lt;s-button icon=\"reset\"&gt;Reset password&lt;/s-button&gt;\n    &lt;s-button icon=\"lock\"&gt;Disable account&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-button tone=\"critical\" icon=\"delete\"&gt;Delete customer&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 300px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n  <s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n    <s-section heading=\"Customer management\">\n      <s-button icon=\"edit\">Edit customer</s-button>\n      <s-button icon=\"email\">Send email</s-button>\n      <s-button icon=\"order\">View orders</s-button>\n    </s-section>\n    <s-section heading=\"Account actions\">\n      <s-button icon=\"reset\">Reset password</s-button>\n      <s-button icon=\"lock\">Disable account</s-button>\n    </s-section>\n    <s-button tone=\"critical\" icon=\"delete\">\n      Delete customer\n    </s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button commandFor=\"customer-menu\">Edit customer</s-button>\n\n<s-menu id=\"customer-menu\" accessibilityLabel=\"Customer actions\">\n  <s-section heading=\"Customer management\">\n    <s-button icon=\"edit\">Edit customer</s-button>\n    <s-button icon=\"email\">Send email</s-button>\n    <s-button icon=\"order\">View orders</s-button>\n  </s-section>\n  <s-section heading=\"Account actions\">\n    <s-button icon=\"reset\">Reset password</s-button>\n    <s-button icon=\"lock\">Disable account</s-button>\n  </s-section>\n  <s-button tone=\"critical\" icon=\"delete\">Delete customer</s-button>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
               }
             },
             {
-              "description": "Illustrates a complex menu with nested sections, demonstrating how to organize multiple related actions with icons.",
+              "description": "Build a settings-style menu with multiple sections and a standalone action at the bottom. This example shows account and store settings sections with a root-level sign-out link.",
               "codeblock": {
-                "title": "Menu with nested sections",
+                "title": "Build a settings menu with sections",
                 "tabs": [
-                  {
-                    "title": "jsx",
-                    "code": "&lt;&gt;\n  &lt;s-button icon=\"settings\" commandFor=\"admin-settings\"&gt;\n    Settings\n  &lt;/s-button&gt;\n\n  &lt;s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\"&gt;\n    &lt;s-section heading=\"Account\"&gt;\n      &lt;s-button icon=\"profile\"&gt;Profile settings&lt;/s-button&gt;\n      &lt;s-button icon=\"lock\"&gt;Security&lt;/s-button&gt;\n      &lt;s-button&gt;Billing information&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-section heading=\"Store\"&gt;\n      &lt;s-button icon=\"store\"&gt;Store settings&lt;/s-button&gt;\n      &lt;s-button&gt;Payment providers&lt;/s-button&gt;\n      &lt;s-button icon=\"delivery\"&gt;Shipping rates&lt;/s-button&gt;\n    &lt;/s-section&gt;\n    &lt;s-button href=\"javascript:void(0)\" icon=\"person-exit\"&gt;Sign out&lt;/s-button&gt;\n  &lt;/s-menu&gt;\n&lt;/&gt;",
-                    "language": "jsx"
-                  },
                   {
                     "title": "html",
                     "code": "&lt;s-button icon=\"settings\" commandFor=\"admin-settings\"&gt;Settings&lt;/s-button&gt;\n\n&lt;s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\"&gt;\n  &lt;s-section heading=\"Account\"&gt;\n    &lt;s-button icon=\"profile\"&gt;Profile settings&lt;/s-button&gt;\n    &lt;s-button icon=\"lock\"&gt;Security&lt;/s-button&gt;\n    &lt;s-button&gt;Billing information&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-section heading=\"Store\"&gt;\n    &lt;s-button icon=\"store\"&gt;Store settings&lt;/s-button&gt;\n    &lt;s-button&gt;Payment providers&lt;/s-button&gt;\n    &lt;s-button icon=\"delivery\"&gt;Shipping rates&lt;/s-button&gt;\n  &lt;/s-section&gt;\n  &lt;s-button href=\"javascript:void(0)\" icon=\"person-exit\"&gt;Sign out&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
-                    "language": "html",
-                    "editable": false
+                    "language": "html"
                   },
                   {
-                    "code": "<!DOCTYPE html> <html> <head> <style> html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: start center; gap: 0.5rem; min-height: 350px} </style> <script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script> <script src=\"https://cdn.shopify.com/shopifycloud/jsx-builder/jsx-builder.min.js\"></script> </head>\n  <body><div id=\"wrapper-element\"></div><script> (function() { const {render, h, Fragment, Component, useState} = window.preact; const jsxCode = `const App = () => { return (<>\n  <s-button icon=\"settings\" commandFor=\"admin-settings\">\n    Settings\n  </s-button>\n\n  <s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\">\n    <s-section heading=\"Account\">\n      <s-button icon=\"profile\">Profile settings</s-button>\n      <s-button icon=\"lock\">Security</s-button>\n      <s-button>Billing information</s-button>\n    </s-section>\n    <s-section heading=\"Store\">\n      <s-button icon=\"store\">Store settings</s-button>\n      <s-button>Payment providers</s-button>\n      <s-button icon=\"delivery\">Shipping rates</s-button>\n    </s-section>\n    <s-button href=\"javascript:void(0)\" icon=\"person-exit\">Sign out</s-button>\n  </s-menu>\n</>) };`; try { const {code} = window.sucrase.transform(jsxCode, { transforms: ['jsx'], jsxPragma: 'h', jsxFragmentPragma: 'Fragment', production: true }); const fn = new Function('h', 'Fragment', 'Component', 'useState', code + '; return App;'); const App = fn(h, Fragment, Component, useState); const target = document.getElementById('wrapper-element') || document.body; if (target) render(h(App), target); } catch(e) { console.error('JSX Transform Error:', e); const body = document.body; if (body) body.innerHTML = '<div style=\"color:red;padding:1rem;\">Error rendering example: ' + e.message + '</div>'; } })();\n    </script>\n</body>\n</html>\n",
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button icon=\"settings\" commandFor=\"admin-settings\">Settings</s-button>\n\n<s-menu id=\"admin-settings\" accessibilityLabel=\"Settings menu\">\n  <s-section heading=\"Account\">\n    <s-button icon=\"profile\">Profile settings</s-button>\n    <s-button icon=\"lock\">Security</s-button>\n    <s-button>Billing information</s-button>\n  </s-section>\n  <s-section heading=\"Store\">\n    <s-button icon=\"store\">Store settings</s-button>\n    <s-button>Payment providers</s-button>\n    <s-button icon=\"delivery\">Shipping rates</s-button>\n  </s-section>\n  <s-button href=\"javascript:void(0)\" icon=\"person-exit\">Sign out</s-button>\n</s-menu>\n</s-box></body></html>",
+                    "language": "preview"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Use an icon-only button as the menu trigger for a compact \"more actions\" pattern. This example shows a three-dot icon button that opens a menu with common product actions.",
+              "codeblock": {
+                "title": "Trigger a menu from an icon-only button",
+                "tabs": [
+                  {
+                    "title": "html",
+                    "code": "&lt;s-button\n  icon=\"menu-horizontal\"\n  variant=\"tertiary\"\n  accessibilityLabel=\"More actions\"\n  commandFor=\"more-actions-menu\"\n&gt;&lt;/s-button&gt;\n\n&lt;s-menu id=\"more-actions-menu\" accessibilityLabel=\"More actions\"&gt;\n  &lt;s-button icon=\"edit\"&gt;Edit product&lt;/s-button&gt;\n  &lt;s-button icon=\"duplicate\"&gt;Duplicate product&lt;/s-button&gt;\n  &lt;s-button icon=\"archive\"&gt;Archive product&lt;/s-button&gt;\n  &lt;s-button icon=\"delete\" tone=\"critical\"&gt;Delete product&lt;/s-button&gt;\n&lt;/s-menu&gt;\n",
+                    "language": "html"
+                  },
+                  {
+                    "code": "<!DOCTYPE html><html><head><style>html, body {height:100%} body {box-sizing: border-box; margin: 0; padding: 0.5rem; display: grid; place-items: center; gap: 0.5rem;}</style><script src=\"https://cdn.shopify.com/shopifycloud/polaris.js\"></script></head><body><s-box padding=\"base\" id=\"wrapper-element\"><s-button\n  icon=\"menu-horizontal\"\n  variant=\"tertiary\"\n  accessibilityLabel=\"More actions\"\n  commandFor=\"more-actions-menu\"\n></s-button>\n\n<s-menu id=\"more-actions-menu\" accessibilityLabel=\"More actions\">\n  <s-button icon=\"edit\">Edit product</s-button>\n  <s-button icon=\"duplicate\">Duplicate product</s-button>\n  <s-button icon=\"archive\">Archive product</s-button>\n  <s-button icon=\"delete\" tone=\"critical\">Delete product</s-button>\n</s-menu>\n</s-box></body></html>",
                     "language": "preview"
                   }
                 ]
@@ -19270,7 +18874,7 @@
   {
     "name": "Modal",
     "description": "The modal component displays content in an overlay. Use to create a distraction-free experience such as a confirmation dialog or a settings panel.\n\nA button triggers the modal using the `commandFor` attribute. Content within the modal scrolls if it exceeds available height.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Overlays",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/modal.png",
@@ -19280,7 +18884,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.\n- Include a prominent and clear call to action.\n- Don't nest modals (avoid launching one modal from another).\n- Use specific action verbs: Label buttons with clear verbs like \"Delete\", \"Save\", or \"Continue\" rather than vague terms like \"Yes\", \"OK\", or \"Submit\".\n- For destructive actions, explain the consequences in the modal body.\n- Use thoughtfully and sparingly—don't create unnecessary interruptions.\n- Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly."
+        "sectionContent": "- **Focus on critical decisions**: Use for focused, specific tasks that require merchants to make a decision or acknowledge critical information.\n- **Avoid nesting modals**: Don't nest modals (avoid launching one modal from another).\n- **Use specific action verbs**: Label buttons with clear verbs like \"Delete,\" \"Save,\" or \"Continue\" rather than vague terms like \"Yes\" or \"OK.\"\n- **Explain destructive consequences**: For destructive actions, explain the consequences in the modal body.\n- **Reserve for important decisions**: Use as a last resort for important decisions, not for contextual tools or actions that could happen on the page directly."
       },
       {
         "title": "Limitations",
@@ -19303,7 +18907,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@abortController@7222",
+                "name": "__@abortController@7220",
                 "value": "AbortController",
                 "description": "",
                 "isPrivate": true,
@@ -19312,7 +18916,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@childrenRerenderObserver@7224",
+                "name": "__@childrenRerenderObserver@7222",
                 "value": "MutationObserver",
                 "description": "",
                 "isPrivate": true,
@@ -19321,7 +18925,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dialog@7216",
+                "name": "__@dialog@7214",
                 "value": "HTMLDialogElement",
                 "description": "",
                 "isPrivate": true,
@@ -19330,7 +18934,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@dismiss@7217",
+                "name": "__@dismiss@7215",
                 "value": "() => void",
                 "description": "",
                 "isPrivate": true,
@@ -19339,7 +18943,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@focusedElement@7218",
+                "name": "__@focusedElement@7216",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -19348,7 +18952,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@hasOpenChildModal@7212",
+                "name": "__@hasOpenChildModal@7210",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -19357,7 +18961,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@hide@7214",
+                "name": "__@hide@7212",
                 "value": "() => Promise<void>",
                 "description": "",
                 "isPrivate": true,
@@ -19366,7 +18970,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@isOpen@7215",
+                "name": "__@isOpen@7213",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -19375,7 +18979,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@nestedModals@7220",
+                "name": "__@nestedModals@7218",
                 "value": "Map<Modal, boolean>",
                 "description": "",
                 "isPrivate": true,
@@ -19384,7 +18988,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@onBackdropClick@7221",
+                "name": "__@onBackdropClick@7219",
                 "value": "(event: MouseEvent) => void",
                 "description": "",
                 "isPrivate": true,
@@ -19393,7 +18997,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@onChildModalChange@7223",
+                "name": "__@onChildModalChange@7221",
                 "value": "EventListenerOrEventListenerObject",
                 "description": "",
                 "isPrivate": true,
@@ -19402,7 +19006,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@onEscape@7219",
+                "name": "__@onEscape@7217",
                 "value": "(event: KeyboardEvent) => void",
                 "description": "",
                 "isPrivate": true,
@@ -19411,7 +19015,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -19420,7 +19024,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -19429,7 +19033,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true,
@@ -19438,7 +19042,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@shadowDomRerenderObserver@7225",
+                "name": "__@shadowDomRerenderObserver@7223",
                 "value": "MutationObserver",
                 "description": "",
                 "isPrivate": true,
@@ -19447,7 +19051,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@show@7213",
+                "name": "__@show@7211",
                 "value": "() => Promise<void>",
                 "description": "",
                 "isPrivate": true,
@@ -19637,7 +19241,7 @@
       },
       {
         "title": "Events",
-        "description": "The modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The modal component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "ModalEvents",
         "typeDefinitions": {
           "ModalEvents": {
@@ -19698,7 +19302,7 @@
       },
       {
         "title": "Slots",
-        "description": "The modal component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The modal component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "ModalSlots",
         "typeDefinitions": {
           "ModalSlots": {
@@ -19874,8 +19478,8 @@
   },
   {
     "name": "Money field",
-    "description": "The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/number-field).",
-    "category": "Polaris web components",
+    "description": "The money field component collects monetary values from users with built-in currency formatting and validation. Use money field for prices, costs, or financial amounts to provide proper currency symbols, decimal handling, and numeric validation.\n\nMoney fields support currency codes, automatic formatting, and min/max constraints to ensure users enter valid monetary values. For non-currency numeric input, use [number field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/number-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/moneyfield.png",
@@ -19908,7 +19512,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -20203,7 +19807,7 @@
       },
       {
         "title": "Events",
-        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "MoneyFieldEvents",
         "typeDefinitions": {
           "MoneyFieldEvents": {
@@ -20345,8 +19949,8 @@
   },
   {
     "name": "Number field",
-    "description": "The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/money-field).",
-    "category": "Polaris web components",
+    "description": "The number field component captures numeric input with built-in number validation. Use it to collect quantities, prices, or other numeric information.\n\nThe component supports min/max constraints and step increments for guided numeric entry. For monetary values with currency formatting, use [money field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/money-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/numberfield.png",
@@ -20356,7 +19960,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) instead.\n- **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.\n- **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.\n- **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter."
+        "sectionContent": "- **Use for numeric-only input:** Choose the component when you need strictly numeric values like quantities, measurements, or percentages. For values that might contain letters or symbols (like product codes or phone numbers), use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) instead.\n- **Provide context with units:** Display units of measurement using prefix or suffix to clarify what the number represents. Without context, merchants might not know if they're entering dollars, kilograms, or percentages.\n- **Set realistic constraints:** Define minimum and maximum values that reflect actual business rules. This guides merchants toward valid inputs and prevents unrealistic values before form submission.\n- **Validate and provide clear feedback:** Always validate numeric input and show specific error messages that explain what went wrong and how to fix it. Generic error messages don't help merchants understand what value to enter."
       },
       {
         "title": "Limitations",
@@ -20379,7 +19983,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -20717,7 +20321,7 @@
       },
       {
         "title": "Events",
-        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "NumberFieldEvents",
         "typeDefinitions": {
           "NumberFieldEvents": {
@@ -20860,9 +20464,9 @@
   },
   {
     "name": "Ordered list",
-    "description": "The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list).",
-    "category": "Polaris web components",
-    "subCategory": "Layout and structure",
+    "description": "The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.\n\nOrdered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list).",
+    "category": "Web components",
+    "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/ordered-list.png",
     "isVisualComponent": true,
@@ -20871,7 +20475,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
+        "sectionContent": "- **Use when order matters:** Ordered lists communicate sequence, priority, or ranking. Use them for step-by-step instructions, prioritized recommendations, or any content where the numbering provides meaningful information. When order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/unordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
       },
       {
         "title": "Limitations",
@@ -20883,7 +20487,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The ordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "OrderedListSlots",
         "typeDefinitions": {
           "OrderedListSlots": {
@@ -21040,7 +20644,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {
@@ -21112,7 +20716,7 @@
   {
     "name": "Page",
     "description": "The page component provides a styled page layout within your app, including breadcrumbs, page actions, and content areas with automatic spacing.\n\nUse page when you need a complete page layout with Polaris styling. For apps that need to set the Shopify admin's native title bar (title, breadcrumbs, actions) without a styled page layout, use the [title bar](/docs/api/{API_NAME}/{API_VERSION}/app-bridge-web-components/title-bar) App Bridge component instead.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "requires": "",
@@ -21123,7 +20727,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- Always provide a title that describes the current page.\n- Include breadcrumbs when the page is part of a flow.\n- Include page actions in the header only if they are relevant to the entire page.\n- Include no more than one primary action and 3 secondary actions per page.\n- Don't include any actions at the bottom of the page."
+        "sectionContent": "- **Use breadcrumbs for navigation**: Include breadcrumbs when the page is part of a flow.\n- **Scope header actions appropriately**: Include page actions in the header only if they are relevant to the entire page.\n- **Limit action count**: Include no more than one primary action and three secondary actions per page.\n- **Avoid bottom actions**: Don't include any actions at the bottom of the page."
       },
       {
         "title": "Limitations",
@@ -21286,7 +20890,7 @@
       },
       {
         "title": "Slots",
-        "description": "The page component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The page component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "PageSlots",
         "typeDefinitions": {
           "PageSlots": {
@@ -21461,8 +21065,8 @@
   },
   {
     "name": "Paragraph",
-    "description": "The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).",
-    "category": "Polaris web components",
+    "description": "The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.\n\nParagraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/text).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/paragraph.png",
@@ -21672,7 +21276,7 @@
       },
       {
         "title": "Slots",
-        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The paragraph component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ParagraphSlots",
         "typeDefinitions": {
           "ParagraphSlots": {
@@ -21828,8 +21432,8 @@
   },
   {
     "name": "Password field",
-    "description": "The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The password field component securely collects sensitive information from users. Use password field for password entry, where input characters are automatically masked for privacy.\n\nPassword fields support validation, help text, and accessibility features to create secure and user-friendly authentication experiences. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/passwordfield.png",
@@ -21862,7 +21466,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -22164,7 +21768,7 @@
       },
       {
         "title": "Events",
-        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "PasswordFieldEvents",
         "typeDefinitions": {
           "PasswordFieldEvents": {
@@ -22340,8 +21944,8 @@
   },
   {
     "name": "Popover",
-    "description": "The popover component displays contextual content in an overlay triggered by a button using the [`commandFor`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) attribute. Use for secondary actions, settings, or information that doesn't require a full modal.\n\nFor interactions that need more space or user focus, such as confirmations or complex forms, use [modal](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/overlays/modal) instead.",
-    "category": "Polaris web components",
+    "description": "The popover component displays contextual content in an overlay triggered by a button using the [`commandFor`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) attribute. Use for secondary actions, settings, or information that doesn't require a full modal.\n\nFor interactions that need more space or user focus, such as confirmations or complex forms, use [modal](/docs/api/{API_NAME}/{API_VERSION}/web-components/overlays/modal) instead.",
+    "category": "Web components",
     "subCategory": "Overlays",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/popover.png",
@@ -22351,7 +21955,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- Use for secondary or less important information and actions since they're hidden until triggered.\n- Contain actions that share a relationship to each other.\n- Be triggered by a clearly labeled default or tertiary button."
+        "sectionContent": "- **Reserve for secondary content**: Use for secondary or less important information and actions since they're hidden until triggered.\n- **Group related actions**: Contain actions that share a relationship to each other.\n- **Use clear trigger labels**: Be triggered by a clearly labeled default or tertiary button."
       },
       {
         "title": "Limitations",
@@ -22374,7 +21978,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@7169",
+                "name": "__@overlayActivator@7167",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -22383,7 +21987,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@7168",
+                "name": "__@overlayHidden@7166",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -22392,7 +21996,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@7170",
+                "name": "__@overlayHideFrameId@7168",
                 "value": "number",
                 "description": "",
                 "isPrivate": true,
@@ -22599,7 +22203,7 @@
       },
       {
         "title": "Events",
-        "description": "The popover component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The popover component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-web-components#handling-events).",
         "type": "PopoverEvents",
         "typeDefinitions": {
           "PopoverEvents": {
@@ -22676,7 +22280,7 @@
       },
       {
         "title": "Slots",
-        "description": "The popover component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The popover component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-web-components#slots).",
         "type": "PopoverSlots",
         "typeDefinitions": {
           "PopoverSlots": {
@@ -22803,7 +22407,7 @@
   {
     "name": "Query container",
     "description": "The query container component establishes a container query context for responsive design. Use query container to define an element as a containment context, enabling child components or styles to adapt based on the container's size rather than viewport width.\n\nQuery containers support modern responsive patterns where components respond to their container dimensions, creating more flexible and reusable layouts.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "requires": "",
@@ -22969,7 +22573,7 @@
       },
       {
         "title": "Slots",
-        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The query container component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "QueryContainerSlots",
         "typeDefinitions": {
           "QueryContainerSlots": {
@@ -23040,8 +22644,8 @@
   },
   {
     "name": "Search field",
-    "description": "The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The search field component captures search terms for filtering and search functionality. Use it to enable inline search within specific sections or lists, like filtering products or searching customers. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/searchfield.png",
@@ -23056,7 +22660,7 @@
     ],
     "definitions": [
       {
-        "title": "SearchField",
+        "title": "Properties",
         "description": "Configure the following properties on the search field component.",
         "type": "SearchField",
         "typeDefinitions": {
@@ -23068,7 +22672,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -23370,7 +22974,7 @@
       },
       {
         "title": "Events",
-        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The search field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "SearchFieldEvents",
         "typeDefinitions": {
           "SearchFieldEvents": {
@@ -23513,8 +23117,8 @@
   },
   {
     "name": "Section",
-    "description": "The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/divider).",
-    "category": "Polaris web components",
+    "description": "The section component groups related content into clearly-defined thematic areas with consistent styling and structure. Use section to organize page content into logical blocks, each with its own heading and visual container.\n\nSections automatically adapt their styling based on nesting depth and adjust heading levels to maintain meaningful, accessible page hierarchies. For simple visual separation without headings, use [divider](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/divider).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "isVisualComponent": true,
@@ -23695,7 +23299,7 @@
       },
       {
         "title": "Slots",
-        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The section component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "SectionSlots",
         "typeDefinitions": {
           "SectionSlots": {
@@ -23817,8 +23421,8 @@
   },
   {
     "name": "Select",
-    "description": "The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list).",
-    "category": "Polaris web components",
+    "description": "The select component allows users to choose one option from a dropdown menu. Use select when presenting four or more choices to keep interfaces uncluttered and scannable, or when space is limited.\n\nSelect components support option grouping, placeholder text, help text, and validation states to create clear selection interfaces. For more visual selection layouts with radio buttons or checkboxes, use [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/select.png",
@@ -23828,13 +23432,13 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.\n- **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.\n- **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.\n- **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.\n- **Provide clear validation feedback:** When selection is required or invalid, explain what the merchant needs to do. Context-specific error messages help merchants complete forms faster than generic validation messages."
+        "sectionContent": "- **Use for choosing from predefined options:** Select works best when merchants pick from a known list of options. When merchants need to enter custom values or search through many options, consider [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field) with autocomplete or a searchable dropdown pattern instead.\n- **Organize options thoughtfully:** The order of options affects how quickly merchants find what they need. Group related options together, put common choices first, or use alphabetical order when no natural hierarchy exists.\n- **Make options scannable:** Merchants should be able to quickly distinguish between options. Include enough context in each option label so merchants don't need to open and read multiple options to find the right one.\n- **Handle default selections appropriately:** Pre-select an option when there's a clear default choice, but use a placeholder when merchants should make an intentional selection. Avoid confusing merchants with unclear initial states.\n- **Provide clear validation feedback:** When selection is required or invalid, explain what the merchant needs to do. Context-specific error messages help merchants complete forms faster than generic validation messages."
       },
       {
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.\n- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/choice-list) with checkboxes or build a custom multi-select component.\n- Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.\n- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu).\n- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/menu) components."
+        "sectionContent": "- The component doesn't include search or filtering functionality. For option lists where merchants need to search (like country selection with 200+ countries), implement a custom autocomplete or searchable dropdown pattern.\n- The component only supports selecting one option at a time. For multi-select scenarios, use a [choice list](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/choice-list) with checkboxes or build a custom multi-select component.\n- Rendering 500+ options can cause performance issues, especially on mobile devices. The browser must render all options in the DOM even though only one's visible.\n- Browser native select dropdowns have limited styling capabilities. Dropdown appearance varies by browser and OS, and can't be fully customized with CSS. For custom-styled dropdowns, you must build a custom component using [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) and [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu).\n- Options only support plain text. You can't include icons, images, badges, or formatted text within option labels. For rich option content, build a custom dropdown using [menu](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/menu) components."
       }
     ],
     "definitions": [
@@ -23851,7 +23455,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@7443",
+                "name": "__@hasInitialValueSymbol@7441",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -23860,7 +23464,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -23869,7 +23473,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@7442",
+                "name": "__@usedFirstOptionSymbol@7440",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true,
@@ -24101,7 +23705,7 @@
       },
       {
         "title": "Events",
-        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "SelectEvents",
         "typeDefinitions": {
           "SelectEvents": {
@@ -24146,7 +23750,7 @@
       },
       {
         "title": "Slots",
-        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The select component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "SelectSlots",
         "typeDefinitions": {
           "SelectSlots": {
@@ -24338,7 +23942,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The option component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "OptionSlots",
         "typeDefinitions": {
           "OptionSlots": {
@@ -24360,7 +23964,7 @@
         }
       },
       {
-        "title": "OptionGroup",
+        "title": "Option group",
         "description": "Represents a group of options within a select component. Use only as a child of `s-select` components.",
         "type": "OptionGroup",
         "typeDefinitions": {
@@ -24512,7 +24116,7 @@
       },
       {
         "title": "Slots",
-        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The option group component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "OptionGroupSlots",
         "typeDefinitions": {
           "OptionGroupSlots": {
@@ -24667,8 +24271,8 @@
   },
   {
     "name": "Spinner",
-    "description": "The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.",
-    "category": "Polaris web components",
+    "description": "The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.\n\nSpinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) component instead.",
+    "category": "Web components",
     "subCategory": "Feedback and status indicators",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/spinner.png",
@@ -24684,7 +24288,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.\n- The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.\n- Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.\n- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) alongside the spinner."
+        "sectionContent": "- The component shows indeterminate loading only. It can't display progress percentage or time remaining. For operations with known duration or measurable progress, consider using a progress bar component or custom solution.\n- The component continues spinning indefinitely until you remove it. It doesn't automatically stop after a timeout or show error states. You must implement timeout logic and error handling yourself.\n- Rendering many spinners simultaneously (like in a table with 50+ rows each showing a spinner) can cause performance issues, especially on older mobile devices.\n- The component itself doesn't provide a way to cancel the loading operation. If merchants need to cancel, you must implement separate UI controls like a **Cancel** [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) alongside the spinner."
       }
     ],
     "definitions": [
@@ -24923,8 +24527,8 @@
   },
   {
     "name": "Stack",
-    "description": "The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/grid).",
-    "category": "Polaris web components",
+    "description": "The stack component organizes elements horizontally or vertically along the block or inline axis. Use stack to structure layouts, group related components, control spacing between elements, or create flexible arrangements that adapt to content.\n\nStacks support gap spacing, alignment, wrapping, and distribution properties to create consistent, responsive layouts without custom CSS. For complex multi-column layouts with precise grid positioning, use [grid](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/grid).",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/stack.png",
@@ -25105,7 +24709,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "columnGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25123,7 +24727,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "direction",
                 "value": "MaybeResponsive<\"inline\" | \"block\">",
-                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
+                "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
                 "defaultValue": "'block'",
                 "isOptional": true
               },
@@ -25150,7 +24754,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "gap",
                 "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -25222,7 +24826,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "padding",
                 "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'none'",
                 "isOptional": true
               },
@@ -25231,7 +24835,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlock",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25240,7 +24844,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25249,7 +24853,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingBlockStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25258,7 +24862,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInline",
                 "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25267,7 +24871,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineEnd",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25276,7 +24880,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "paddingInlineStart",
                 "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+                "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25294,7 +24898,7 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "rowGap",
                 "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+                "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
                 "defaultValue": "'' - meaning no override",
                 "isOptional": true
               },
@@ -25538,7 +25142,7 @@
       },
       {
         "title": "Slots",
-        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The stack component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "StackSlots",
         "typeDefinitions": {
           "StackSlots": {
@@ -25660,8 +25264,8 @@
   },
   {
     "name": "Switch",
-    "description": "The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/checkbox) instead.",
-    "category": "Polaris web components",
+    "description": "The switch component provides a clear way for users to toggle options or settings on and off. Use switch for binary controls that take effect immediately, like enabling features, activating settings, or controlling visibility.\n\nSwitches provide instant visual feedback and are ideal for settings that don't require a save action to apply changes. For selections that require explicit submission, use [checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/checkbox) instead.",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/switch.png",
@@ -25688,7 +25292,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -25930,7 +25534,7 @@
       },
       {
         "title": "Events",
-        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "SwitchEvents",
         "typeDefinitions": {
           "SwitchEvents": {
@@ -26108,7 +25712,7 @@
   {
     "name": "Table",
     "description": "The table component displays data clearly in rows and columns, helping users view, analyze, and compare structured information. Use table to present datasets, product lists, order details, or any tabular content that benefits from organized rows and columns.\n\nTables automatically adapt to screen size, rendering as lists on small screens and tables on larger ones for optimal readability across devices.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Layout and structure",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/table.png",
@@ -26141,7 +25745,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@7518",
+                "name": "__@actualTableVariantSymbol@7516",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true,
@@ -26150,7 +25754,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@7519",
+                "name": "__@tableHeadersSharedDataSymbol@7517",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true,
@@ -26388,7 +25992,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableSlots",
         "typeDefinitions": {
           "TableSlots": {
@@ -26419,7 +26023,7 @@
       },
       {
         "title": "Events",
-        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The table component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "TableEvents",
         "typeDefinitions": {
           "TableEvents": {
@@ -26598,7 +26202,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table body component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableBodySlots",
         "typeDefinitions": {
           "TableBodySlots": {
@@ -26632,7 +26236,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@7541",
+                "name": "__@headerFormatSymbol@7539",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true,
@@ -26771,7 +26375,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table cell component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableCellSlots",
         "typeDefinitions": {
           "TableCellSlots": {
@@ -26959,7 +26563,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table header component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableHeaderSlots",
         "typeDefinitions": {
           "TableHeaderSlots": {
@@ -27116,7 +26720,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table header row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableHeaderRowSlots",
         "typeDefinitions": {
           "TableHeaderRowSlots": {
@@ -27281,7 +26885,7 @@
       },
       {
         "title": "Slots",
-        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The table row component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TableRowSlots",
         "typeDefinitions": {
           "TableRowSlots": {
@@ -27420,8 +27024,8 @@
   },
   {
     "name": "Text",
-    "description": "The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).",
-    "category": "Polaris web components",
+    "description": "The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.\n\nText supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph).",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/text.png",
@@ -27437,7 +27041,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph) component or wrap in layout components.\n- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/heading) with line clamping if truncation is needed.\n- Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements."
+        "sectionContent": "- Text renders inline by default and flows with surrounding content. For block-level text with spacing, use the [paragraph](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/paragraph) component or wrap in layout components.\n- The component doesn't include text truncation or ellipsis. Long text will wrap or overflow depending on the container. Use other components like [heading](/docs/api/{API_NAME}/{API_VERSION}/web-components/typography-and-content/heading) with line clamping if truncation is needed.\n- Tone colors are optimized for light backgrounds. Using tones on dark or colored backgrounds might not meet accessibility contrast requirements."
       }
     ],
     "definitions": [
@@ -27639,7 +27243,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The text component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TextSlots",
         "typeDefinitions": {
           "TextSlots": {
@@ -27812,8 +27416,8 @@
   },
   {
     "name": "Text area",
-    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The text area component captures multi-line text input. Use it to collect descriptions, notes, comments, or other extended text content.\n\nThe component supports configurable height, character limits, and validation. For single-line text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/textarea.png",
@@ -27846,7 +27450,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -28157,7 +27761,7 @@
       },
       {
         "title": "Events",
-        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "TextAreaEvents",
         "typeDefinitions": {
           "TextAreaEvents": {
@@ -28317,8 +27921,8 @@
   },
   {
     "name": "Text field",
-    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/search-field).",
-    "category": "Polaris web components",
+    "description": "The text field component captures single-line text input. Use it to collect short, free-form information like names, titles, or identifiers.\n\nThe component supports various input configurations including placeholders, character limits, and validation. For multi-line text entry, use [text area](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-area). For specialized input types, use [email field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/email-field), [URL field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/url-field), [password field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/password-field), or [search field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/search-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/textfield.png",
@@ -28334,7 +27938,7 @@
         "title": "Limitations",
         "type": "Generic",
         "anchorLink": "limitations",
-        "sectionContent": "- The `maxLength` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed `maxLength`. Always validate length server-side.\n- The `accessory` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable) components with text content."
+        "sectionContent": "- The `maxLength` attribute prevents typing beyond the limit, but in some edge cases, pasted or programmatically set content might exceed `maxLength`. Always validate length server-side.\n- The `accessory` slot renders content at the end of the field. For best results, use [button](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/button) or [clickable](/docs/api/{API_NAME}/{API_VERSION}/web-components/actions/clickable) components with text content."
       }
     ],
     "definitions": [
@@ -28351,7 +27955,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -28687,7 +28291,7 @@
       },
       {
         "title": "Slots",
-        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TextFieldSlots",
         "typeDefinitions": {
           "TextFieldSlots": {
@@ -28710,7 +28314,7 @@
       },
       {
         "title": "Events",
-        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "TextFieldEvents",
         "typeDefinitions": {
           "TextFieldEvents": {
@@ -28887,36 +28491,30 @@
   },
   {
     "name": "Thumbnail",
-    "description": "The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).",
-    "category": "Polaris web components",
+    "description": "The thumbnail component displays small preview images representing content, products, or media items. Use thumbnail to provide visual identification in lists, tables, or cards where space is constrained and quick recognition is important.\n\nThumbnails support multiple sizes, alt text for accessibility, and fallback states for missing images. For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image). For user profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/avatar).",
+    "category": "Web components",
     "subCategory": "Media and visuals",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/thumbnail.png",
     "isVisualComponent": true,
     "subSections": [
       {
-        "title": "Useful for",
-        "type": "Generic",
-        "anchorLink": "useful-for",
-        "sectionContent": "- Identifying items visually in lists, tables, or cards.\n- Seeing a preview of images before uploading or publishing.\n- Distinguishing between similar items by their appearance.\n- Confirming the correct item is selected."
-      },
-      {
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- `small-200`: use in very small areas.\n- `small`: use in small areas.\n- `base`: use as the default size.\n- `large`: use when thumbnail is a focal point."
+        "sectionContent": "- **Design for square cropping:** Thumbnails automatically crop images to a 1:1 aspect ratio from the center. If your images aren't square, important content near the edges might be cut off.\n- **Maintain visual consistency in groups:** Use the same thumbnail size throughout a single list, table, or grid. Mixing sizes creates visual chaos and makes interfaces harder to scan.\n- **Always provide descriptive alternative text:** Write alt text that describes the image content, not generic labels like \"thumbnail\" or \"product image.\" Good alt text helps all merchants understand what they're looking at.\n- **Choose appropriate sizes for your context:** Smaller thumbnails work better in dense layouts like tables, while larger sizes suit product-focused interfaces. Consider the merchant's task and the information density when choosing a size."
       },
       {
-        "title": "Content guidelines",
+        "title": "Limitations",
         "type": "Generic",
-        "anchorLink": "content-guidelines",
-        "sectionContent": "Alternative text should be accurate, concise, and descriptive:\n- Use \"Image of\", \"Photo of\" prefix.\n- Be primary visual content: \"Image of a woman with curly brown hair smiling\".\n- Include relevant emotions: \"Image of a woman laughing with her hand on her face\"."
+        "anchorLink": "limitations",
+        "sectionContent": "- Thumbnails always render as 1:1 squares and will crop non-square images to fit. The component uses center cropping, which might cut off important image details.\n- Images can be loaded from remote URLs or local file resources. Cross-origin images require proper CORS headers from the image host.\n- The component shows a generic placeholder icon when images fail to load or no source is provided. Custom placeholder graphics or branded fallbacks aren't available.\n- Thumbnails don't include built-in lazy loading. In long lists with many thumbnails, all images load immediately, which might impact performance."
       }
     ],
     "definitions": [
       {
         "title": "Properties",
-        "description": "",
+        "description": "Configure the following properties on the thumbnail component.",
         "type": "Thumbnail",
         "typeDefinitions": {
           "Thumbnail": {
@@ -29076,7 +28674,7 @@
       },
       {
         "title": "Events",
-        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The thumbnail component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "ThumbnailEvents",
         "typeDefinitions": {
           "ThumbnailEvents": {
@@ -29204,7 +28802,7 @@
   {
     "name": "Tooltip",
     "description": "The tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.\n\nTooltips support keyboard accessibility, positioning options, and activation on both hover and focus for inclusive interaction patterns.",
-    "category": "Polaris web components",
+    "category": "Web components",
     "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/tooltip.png",
@@ -29226,7 +28824,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The tooltip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "TooltipSlots",
         "typeDefinitions": {
           "TooltipSlots": {
@@ -29330,8 +28928,8 @@
   },
   {
     "name": "URL field",
-    "description": "The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/text-field).",
-    "category": "Polaris web components",
+    "description": "The URL field component collects URLs from users with built-in formatting and validation. Use URL field for website addresses, link destinations, or any URL input to provide URL-specific keyboard layouts and automatic validation.\n\nURL fields support protocol prefixing, validation, and help text to guide users toward entering properly formatted web addresses. For general text input, use [text field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/text-field).",
+    "category": "Web components",
     "subCategory": "Forms",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/urlfield.png",
@@ -29364,7 +28962,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@6795",
+                "name": "__@internals$4@6793",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -29666,7 +29264,7 @@
       },
       {
         "title": "Events",
-        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).",
+        "description": "The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/app-ui/using-web-components#handling-events).",
         "type": "URLFieldEvents",
         "typeDefinitions": {
           "URLFieldEvents": {
@@ -29808,9 +29406,9 @@
   },
   {
     "name": "Unordered list",
-    "description": "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list).",
-    "category": "Polaris web components",
-    "subCategory": "Layout and structure",
+    "description": "The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.\n\nUnordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list).",
+    "category": "Web components",
+    "subCategory": "Typography and content",
     "related": [],
     "thumbnail": "/assets/templated-apis-screenshots/admin/components/unordered-list.png",
     "isVisualComponent": true,
@@ -29819,7 +29417,7 @@
         "title": "Best practices",
         "type": "Generic",
         "anchorLink": "best-practices",
-        "sectionContent": "- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
+        "sectionContent": "- **Use when order doesn't matter:** Unordered lists communicate a collection of related items without sequence or ranking. Use them for features, options, or benefits where the order isn't meaningful. When sequence matters, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/web-components/layout-and-structure/ordered-list) instead.\n- **Keep items parallel in structure:** Consistent grammar and structure across list items makes content easier to scan and understand. Mixing different writing styles within a list creates cognitive friction for readers.\n- **Write concise items:** List items work best as brief, scannable content. When items become long or complex, they lose the clarity and efficiency that makes lists valuable. Consider restructuring long items into separate sections.\n- **Limit nesting depth:** Nested lists help organize hierarchical content, but deep nesting becomes difficult to follow. When you find yourself nesting beyond two levels, the content structure might be too complex for a list format."
       },
       {
         "title": "Limitations",
@@ -29831,7 +29429,7 @@
     "definitions": [
       {
         "title": "Slots",
-        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The unordered list component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "UnorderedListSlots",
         "typeDefinitions": {
           "UnorderedListSlots": {
@@ -29988,7 +29586,7 @@
       },
       {
         "title": "Slots",
-        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).",
+        "description": "The list item component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).",
         "type": "ListItemSlots",
         "typeDefinitions": {
           "ListItemSlots": {
@@ -30083,7 +29681,7 @@
       "Settings"
     ],
     "defaultExample": {
-      "description": "Merchants need to connect or disconnect external services (e.g. marketing platforms, sales channels) from your app. This pattern displays account connection layout with a connect button and terms. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) aligns account information and button, the [section](/docs/api/app-home/polaris-web-components/layout-and-structure/section) provides padding, and the terms text below describes the connection agreement.",
+      "description": "Merchants need to connect or disconnect external services (e.g. marketing platforms, sales channels) from your app. This pattern displays account connection layout with a connect button and terms. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) aligns account information and button, the [section](/docs/api/app-home/web-components/layout-and-structure/section) provides padding, and the terms text below describes the connection agreement.",
       "codeblock": {
         "title": "Display connection status with connect button and terms",
         "tabs": [
@@ -30185,7 +29783,7 @@
       "Homepage"
     ],
     "defaultExample": {
-      "description": "Merchants can discover and install complementary apps that extend your app's functionality. This pattern displays a tappable app card with thumbnail and content layout. The [clickable](/docs/api/app-home/polaris-web-components/actions/clickable) component wraps the card, the [thumbnail](/docs/api/app-home/polaris-web-components/images/thumbnail) shows the app icon, and the [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) aligns the content.",
+      "description": "Merchants can discover and install complementary apps that extend your app's functionality. This pattern displays a tappable app card with thumbnail and content layout. The [clickable](/docs/api/app-home/web-components/actions/clickable) component wraps the card, the [thumbnail](/docs/api/app-home/web-components/images/thumbnail) shows the app icon, and the [grid](/docs/api/app-home/web-components/layout-and-structure/grid) aligns the content.",
       "codeblock": {
         "title": "Display a tappable app card with thumbnail and content",
         "tabs": [
@@ -30268,7 +29866,7 @@
       "Homepage"
     ],
     "defaultExample": {
-      "description": "Merchants can take action on new features or opportunities you highlight. This pattern presents a callout card that stacks content on smaller screens with a prominent illustration and call-to-action. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) uses responsive column templates. The illustration and button draw attention to important actions or promotions.",
+      "description": "Merchants can take action on new features or opportunities you highlight. This pattern presents a callout card that stacks content on smaller screens with a prominent illustration and call-to-action. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) uses responsive column templates. The illustration and button draw attention to important actions or promotions.",
       "codeblock": {
         "title": "Display a callout card with illustration and call-to-action",
         "tabs": [
@@ -30490,7 +30088,7 @@
       "Index"
     ],
     "defaultExample": {
-      "description": "Merchants need guidance and a clear next step when a list or page is empty. This pattern displays an empty state with centered content and primary and secondary actions. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) centers content vertically and horizontally. Use the [button group](/docs/api/app-home/polaris-web-components/actions/button-group) with `slot=\"primary-action\"` and `slot=\"secondary-actions\"` for clear next steps.",
+      "description": "Merchants need guidance and a clear next step when a list or page is empty. This pattern displays an empty state with centered content and primary and secondary actions. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) centers content vertically and horizontally. Use the [button group](/docs/api/app-home/web-components/actions/button-group) with `slot=\"primary-action\"` and `slot=\"secondary-actions\"` for clear next steps.",
       "codeblock": {
         "title": "Display an empty state with centered content and actions",
         "tabs": [
@@ -30589,7 +30187,7 @@
       "Settings"
     ],
     "defaultExample": {
-      "description": "Merchants can find documentation or support when they need more context than a page provides. This pattern displays centered help text with an external documentation link. The [stack](/docs/api/app-home/polaris-web-components/layout-and-structure/stack) uses `alignItems=\"center\"` to center the text, and the [link](/docs/api/app-home/polaris-web-components/navigation/link) uses `target=\"_blank\"` for links that open in a new tab.",
+      "description": "Merchants can find documentation or support when they need more context than a page provides. This pattern displays centered help text with an external documentation link. The [stack](/docs/api/app-home/web-components/layout-and-structure/stack) uses `alignItems=\"center\"` to center the text, and the [link](/docs/api/app-home/web-components/navigation/link) uses `target=\"_blank\"` for links that open in a new tab.",
       "codeblock": {
         "title": "Display centered help text with documentation link",
         "tabs": [
@@ -30819,7 +30417,7 @@
       "Index"
     ],
     "defaultExample": {
-      "description": "Merchants need to view, search, filter, and take bulk actions on collections of items. This pattern displays an index table with search, sort, and bulk actions. Key attributes include `slot=\"filters\"` on the [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) to place controls in the filters area, `clickDelegate` on [table rows](/docs/api/app-home/polaris-web-components/layout-and-structure/table) to connect clicks to checkboxes, and `listSlot` on [table headers](/docs/api/app-home/polaris-web-components/layout-and-structure/table) to control responsive stacking. Use the [Navigation API](/docs/api/app-home/apis/navigation) for programmatic navigation and the [Toast API](/docs/api/app-home/apis/toast) for confirming successful actions.",
+      "description": "Merchants need to view, search, filter, and take bulk actions on collections of items. This pattern displays an index table with search, sort, and bulk actions. Key attributes include `slot=\"filters\"` on the [grid](/docs/api/app-home/web-components/layout-and-structure/grid) to place controls in the filters area, `clickDelegate` on [table rows](/docs/api/app-home/web-components/layout-and-structure/table) to connect clicks to checkboxes, and `listSlot` on [table headers](/docs/api/app-home/web-components/layout-and-structure/table) to control responsive stacking. Use the [Navigation API](/docs/api/app-home/apis/navigation) for programmatic navigation and the [Toast API](/docs/api/app-home/apis/toast) for confirming successful actions.",
       "codeblock": {
         "title": "Display an index table with search, sort, and bulk actions",
         "tabs": [
@@ -30964,7 +30562,7 @@
       "Settings"
     ],
     "defaultExample": {
-      "description": "Merchants need clear paths to deeper pages (e.g. settings, features) without cluttering main navigation. This pattern displays a navigation menu with drill-down rows. [Clickable](/docs/api/app-home/polaris-web-components/actions/clickable) rows sit in a bordered [box](/docs/api/app-home/polaris-web-components/layout-and-structure/box). Each row uses the [icon](/docs/api/app-home/polaris-web-components/images/icon) with `name=\"chevron-right\"` to indicate navigation.",
+      "description": "Merchants need clear paths to deeper pages (e.g. settings, features) without cluttering main navigation. This pattern displays a navigation menu with drill-down rows. [Clickable](/docs/api/app-home/web-components/actions/clickable) rows sit in a bordered [box](/docs/api/app-home/web-components/layout-and-structure/box). Each row uses the [icon](/docs/api/app-home/web-components/images/icon) with `name=\"chevron-right\"` to indicate navigation.",
       "codeblock": {
         "title": "Display a navigation menu with drill-down rows",
         "tabs": [
@@ -31015,7 +30613,7 @@
       "Homepage"
     ],
     "defaultExample": {
-      "description": "Merchants can see visual content (images, illustrations) paired with actions, like tutorials or feature highlights. This pattern displays a media card with a tappable image and footer layout. The [box](/docs/api/app-home/polaris-web-components/layout-and-structure/box) uses `border` and `borderRadius` for the container, the [clickable](/docs/api/app-home/polaris-web-components/actions/clickable) component makes the image tappable, and the [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) lays out the footer with title and action button.",
+      "description": "Merchants can see visual content (images, illustrations) paired with actions, like tutorials or feature highlights. This pattern displays a media card with a tappable image and footer layout. The [box](/docs/api/app-home/web-components/layout-and-structure/box) uses `border` and `borderRadius` for the container, the [clickable](/docs/api/app-home/web-components/actions/clickable) component makes the image tappable, and the [grid](/docs/api/app-home/web-components/layout-and-structure/grid) lays out the footer with title and action button.",
       "codeblock": {
         "title": "Display a media card with tappable image and footer",
         "tabs": [
@@ -31157,7 +30755,7 @@
       "Index"
     ],
     "defaultExample": {
-      "description": "Merchants want to see key numbers and trends at a glance. This pattern displays metrics in a responsive grid with trend indicators. The [grid](/docs/api/app-home/polaris-web-components/layout-and-structure/grid) uses responsive column templates for side-by-side layout on large screens and stacked layout on small screens. The [badge](/docs/api/app-home/polaris-web-components/feedback/badge) component shows trend indicators.",
+      "description": "Merchants want to see key numbers and trends at a glance. This pattern displays metrics in a responsive grid with trend indicators. The [grid](/docs/api/app-home/web-components/layout-and-structure/grid) uses responsive column templates for side-by-side layout on large screens and stacked layout on small screens. The [badge](/docs/api/app-home/web-components/feedback/badge) component shows trend indicators.",
       "codeblock": {
         "title": "Display metrics in a responsive grid with trend indicators",
         "tabs": [
@@ -31246,7 +30844,7 @@
       "Details"
     ],
     "defaultExample": {
-      "description": "Merchants need to browse and select from a collection of items and navigate to details. This pattern provides search, filtering, and row selection for a resource list. The [text field](/docs/api/app-home/polaris-web-components/forms/text-field) uses `icon=\"search\"` for filtering, the [popover](/docs/api/app-home/polaris-web-components/overlays/popover) holds filter options, and the [checkbox](/docs/api/app-home/polaris-web-components/forms/checkbox) enables row selection.",
+      "description": "Merchants need to browse and select from a collection of items and navigate to details. This pattern provides search, filtering, and row selection for a resource list. The [text field](/docs/api/app-home/web-components/forms/text-field) uses `icon=\"search\"` for filtering, the [popover](/docs/api/app-home/web-components/overlays/popover) holds filter options, and the [checkbox](/docs/api/app-home/web-components/forms/checkbox) enables row selection.",
       "codeblock": {
         "title": "Provide search, filtering, and row selection for a resource list",
         "tabs": [
@@ -31508,7 +31106,7 @@
       "Homepage"
     ],
     "defaultExample": {
-      "description": "New merchants need an interactive checklist to complete onboarding or setup tasks. This pattern guides merchants through setup with expandable steps and completion tracking. The [checkbox](/docs/api/app-home/polaris-web-components/forms/checkbox) tracks completion status. Each step includes a heading, description, illustration, and action button, with a progress indicator for overall completion.",
+      "description": "New merchants need an interactive checklist to complete onboarding or setup tasks. This pattern guides merchants through setup with expandable steps and completion tracking. The [checkbox](/docs/api/app-home/web-components/forms/checkbox) tracks completion status. Each step includes a heading, description, illustration, and action button, with a progress indicator for overall completion.",
       "codeblock": {
         "title": "Guide merchants through setup with expandable steps",
         "tabs": [

--- a/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
+++ b/packages/ui-extensions/src/docs/shared/components/Tooltip.ts
@@ -6,7 +6,7 @@ const data: SharedReferenceEntityTemplateSchema = {
     'The tooltip component displays helpful information in a small overlay when users hover over or focus on an element. Use tooltip to provide additional context, explain functionality, or clarify terms without cluttering the interface with permanent text.' +
     '\n\nTooltips support keyboard accessibility, positioning options, and activation on both hover and focus for inclusive interaction patterns.',
   category: 'Web components',
-  subCategory: 'Overlays',
+  subCategory: 'Typography and content',
   related: [],
 };
 


### PR DESCRIPTION
### Background

The Polaris Tooltip component is listed in the docs under the Typography and content section, but the subcategory in the .ts file was `Overlays`. This is causing links to the page to 404.

### Solution

Updated `subCategory` to `Typography and content`

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
