### PR TITLE
[Checkout UI Ext 2026-01] Actions component examples + descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.doc.ts
@@ -9,6 +9,24 @@ const data: ReferenceEntityTemplateSchema = createComponentDoc({
     properties: true,
     events: true,
   },
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add a loading state to prevent duplicate submissions while an async operation completes. This example shows buttons with the `loading` prop across primary and secondary variants during checkout.',
+        codeblock: {
+          title: 'Show a loading state during async operations',
+          tabs: [
+            {
+              code: './examples/button-loading.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   bestPractices:
     '**Content Best Practices**\n\n- Clearly label each button to accurately represent the action associated with it.\n\n- Use strong actionable verbs at the beginning of button text to make it clear to the user what action will occur when the button is clicked.\n\n**Hierarchy Best Practices**\n\n- Establish a visual hierarchy between buttons to minimize confusion and help users understand which actions are most important.\n\n- Use only one high-emphasis button (primary button) per context to make it clear that other buttons have less importance.\n\n- Use lower-emphasis buttons for secondary calls to action.\n\n- Use primary buttons for actions that progress users through checkout such as “Pay now” or for concluding an action in a modal such as “Apply”.\n\n- Use secondary buttons to provide alternative actions to the primary button, without disrupting the primary flow such as “Track your order”.\n\n**When to Use Buttons**\n\n- Use buttons to communicate actions the user can take.\n\n- Use buttons to allow users to interact with the page.\n\n**When Not to Use Buttons**\n\n- Don’t use buttons as navigational elements. Use links instead when the desired action is to take the user to a new page.',
 });

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button/examples/button-loading.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button/examples/button-loading.example.html
@@ -1,0 +1,5 @@
+<!-- Payment processing -->
+<s-button loading variant="primary">Placing order...</s-button>
+
+<!-- Discount validation -->
+<s-button loading variant="secondary">Applying code...</s-button>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Clickable/Clickable.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Clickable/Clickable.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Wrap content in a styled clickable area that navigates like a link. This example displays a card-like wrapper with `padding`, `border`, and `borderRadius` around text that links to an external page.',
+        codeblock: {
+          title: 'Create a clickable card with custom styling',
+          tabs: [
+            {
+              code: './examples/clickable-link.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Clickable/examples/clickable-link.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Clickable/examples/clickable-link.example.html
@@ -1,0 +1,6 @@
+<s-clickable href="https://www.shopify.com" padding="base" border="base" borderRadius="base">
+  <s-stack>
+    <s-text type="strong">Learn more</s-text>
+    <s-text>Visit our website for details</s-text>
+  </s-stack>
+</s-clickable>

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip/ClickableChip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip/ClickableChip.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true, slots: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add a visual indicator alongside the chip label using the `graphic` slot with `s-icon`. This example shows a chip with a discount icon that links to a sale collection.',
+        codeblock: {
+          title: 'Add an icon and link to a chip',
+          tabs: [
+            {
+              code: './examples/clickable-chip-icon.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip/examples/clickable-chip-icon.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip/examples/clickable-chip-icon.example.html
@@ -1,0 +1,4 @@
+<s-clickable-chip href="/collections/sale">
+  <s-icon type="discount" slot="graphic"></s-icon>
+  On sale
+</s-clickable-chip>

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/ClipboardItem.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/ClipboardItem.doc.ts
@@ -7,6 +7,24 @@ const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   isVisualComponent: false,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Trigger a clipboard copy from a link instead of a button using `commandFor`. This example demonstrates an `s-link` that copies a tracking URL to the clipboard when clicked.',
+        codeblock: {
+          title: 'Copy a tracking link with a link trigger',
+          tabs: [
+            {
+              code: './examples/clipboard-link.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/examples/clipboard-link.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/examples/clipboard-link.example.html
@@ -1,0 +1,2 @@
+<s-link commandFor="tracking-url">Copy tracking link</s-link>
+<s-clipboard-item id="tracking-url" text="https://example.com/track/ABC123"></s-clipboard-item>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Open external URLs in a new tab by setting `target="_blank"`. This example shows a terms of service link that navigates outside the checkout flow.',
+        codeblock: {
+          title: 'Open an external link in a new tab',
+          tabs: [
+            {
+              code: './examples/link-external.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   bestPractices: `
 - Use links primarily for navigation and use buttons primarily for actions.
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link/examples/link-external.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link/examples/link-external.example.html
@@ -1,0 +1,1 @@
+<s-link href="https://www.shopify.com/legal/terms" target="_blank">Terms of service</s-link>

--- a/packages/ui-extensions/src/surfaces/checkout/components/PressButton/PressButton.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PressButton/PressButton.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Pre-select a toggle button by setting `defaultPressed` so it renders in its active state on first load. The buyer can still toggle it off.',
+        codeblock: {
+          title: 'Pre-select a press button',
+          tabs: [
+            {
+              code: './examples/press-button-default-pressed.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/PressButton/examples/press-button-default-pressed.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PressButton/examples/press-button-default-pressed.example.html
@@ -1,0 +1,1 @@
+<s-press-button defaultPressed>Gift wrapping included</s-press-button>


### PR DESCRIPTION
Backport of #4175 (targeting 2026-04-rc) to the 2026-01 version branch.

## Summary

Adds 6 new HTML examples for Actions components (Button, Clickable, ClickableChip, ClipboardItem, Link, PressButton). Cherry-picked from `2026-04-rc-actions-component-examples`.

Closes part of https://github.com/shop/issues-learn/issues/1030

Made with [Cursor](https://cursor.com)