### PR TITLE
[Checkout UI Ext 2026-01] Forms component examples + descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Show validation feedback when a required checkbox has not been accepted. This example shows a terms of service checkbox with `required` and `error` props.',
+        codeblock: {
+          title: 'Require agreement before checkout',
+          tabs: [
+            {
+              code: './examples/checkbox-required.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/examples/checkbox-required.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/examples/checkbox-required.example.html
@@ -1,0 +1,5 @@
+<s-checkbox
+  label="I agree to the terms of service"
+  required
+  error="You must accept the terms to continue"
+></s-checkbox>

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.doc.ts
@@ -5,6 +5,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Collect analytics consent by setting `policy` to `customer-privacy`. This example shows a consent checkbox configured for the customer privacy policy instead of SMS marketing.',
+        codeblock: {
+          title: 'Collect analytics consent',
+          tabs: [
+            {
+              code: './examples/consent-checkbox-privacy.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   requires:
     'enabling of the `sms_marketing` capability of the [Customer Privacy](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) capability group to work.',
   definitions: {properties: true, events: true},

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/examples/consent-checkbox-privacy.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/examples/consent-checkbox-privacy.example.html
@@ -1,0 +1,4 @@
+<s-consent-checkbox
+  label="Allow us to collect analytics data"
+  policy="customer-privacy"
+></s-consent-checkbox>

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.doc.ts
@@ -5,6 +5,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Validate that a phone number is provided before the buyer opts in to SMS marketing. This example shows a consent phone field with `required` and an error message for missing input.',
+        codeblock: {
+          title: 'Require a phone number for SMS consent',
+          tabs: [
+            {
+              code: './examples/consent-phone-field-required.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   requires:
     'enabling of the `sms_marketing` capability of the [Customer Privacy](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) capability group to work.',
   definitions: {properties: true, events: true, slots: true},

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/examples/consent-phone-field-required.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/examples/consent-phone-field-required.example.html
@@ -1,0 +1,6 @@
+<s-consent-phone-field
+  label="Phone number for SMS updates"
+  policy="sms-marketing"
+  required
+  error="Enter a phone number to receive order updates"
+></s-consent-phone-field>

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Restrict selectable dates by excluding past dates and specific days of the week. This example displays a delivery date field with `disallow="past"` and `disallowDays` set to exclude weekends.',
+        codeblock: {
+          title: 'Restrict selectable dates',
+          tabs: [
+            {
+              code: './examples/date-field-restricted.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField/examples/date-field-restricted.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField/examples/date-field-restricted.example.html
@@ -1,0 +1,5 @@
+<s-date-field
+  label="Delivery date"
+  disallow="past"
+  disallowDays="saturday,sunday"
+></s-date-field>

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Grey out past dates and specific days of the week on the calendar. This example shows a date picker with `disallow="past"` and `disallowDays` excluding Sundays.',
+        codeblock: {
+          title: 'Restrict selectable calendar dates',
+          tabs: [
+            {
+              code: './examples/date-picker-restricted.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/examples/date-picker-restricted.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/examples/date-picker-restricted.example.html
@@ -1,0 +1,5 @@
+<s-date-picker
+  defaultView="2025-11"
+  disallow="past"
+  disallowDays="sunday"
+></s-date-picker>

--- a/packages/ui-extensions/src/surfaces/checkout/components/DropZone/DropZone.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DropZone/DropZone.doc.ts
@@ -5,6 +5,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Accept multiple file uploads at once with a descriptive label. This example shows a drop zone for multiple image uploads with `accept="image/*"` and a `label`.',
+        codeblock: {
+          title: 'Accept multiple file uploads',
+          tabs: [
+            {
+              code: './examples/drop-zone-multiple.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   type: '',
   definitions: {properties: true, events: true},
   bestPractices: `

--- a/packages/ui-extensions/src/surfaces/checkout/components/DropZone/examples/drop-zone-multiple.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DropZone/examples/drop-zone-multiple.example.html
@@ -1,0 +1,5 @@
+<s-drop-zone
+  label="Upload product images"
+  accept="image/*"
+  multiple
+></s-drop-zone>

--- a/packages/ui-extensions/src/surfaces/checkout/components/EmailField/EmailField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/EmailField/EmailField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true, slots: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Validate that an email address is provided before the form can be submitted. This example shows a required email field with an error message for missing input.',
+        codeblock: {
+          title: 'Validate a required email address',
+          tabs: [
+            {
+              code: './examples/email-field-required.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/EmailField/examples/email-field-required.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/EmailField/examples/email-field-required.example.html
@@ -1,0 +1,5 @@
+<s-email-field
+  label="Email address"
+  required
+  error="Enter a valid email to receive your receipt"
+></s-email-field>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Group multiple input fields for submission using `s-form`. This example demonstrates a form with a text field, email field, text area, and a submit button.',
+        codeblock: {
+          title: 'Build a form with multiple fields',
+          tabs: [
+            {
+              code: './examples/form-with-fields.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   bestPractices: `
 - Wrap around all form input elements.
 - Forms can have only one submit button and it must be at the end of the form.`,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/examples/form-with-fields.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/examples/form-with-fields.example.html
@@ -1,0 +1,6 @@
+<s-form>
+  <s-text-field label="Full name" required />
+  <s-email-field label="Email address" required />
+  <s-text-area label="Special instructions" rows={3} />
+  <s-button type="submit" variant="primary">Submit request</s-button>
+</s-form>

--- a/packages/ui-extensions/src/surfaces/checkout/components/MoneyField/MoneyField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MoneyField/MoneyField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Constrain a monetary value to a valid range with specific increments. This example shows a tip amount field with `min`, `max`, and `step` props.',
+        codeblock: {
+          title: 'Constrain a money field to a range',
+          tabs: [
+            {
+              code: './examples/money-field-range.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/MoneyField/examples/money-field-range.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MoneyField/examples/money-field-range.example.html
@@ -1,0 +1,7 @@
+<s-money-field
+  label="Tip amount"
+  min={0}
+  max={100}
+  step={0.50}
+  defaultValue="5.00"
+></s-money-field>

--- a/packages/ui-extensions/src/surfaces/checkout/components/NumberField/NumberField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/NumberField/NumberField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true, slots: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add contextual labels around a numeric input for units of measurement. This example displays a weight field with a `prefix` and `suffix` for approximate kilograms.',
+        codeblock: {
+          title: 'Add a prefix and suffix to a number field',
+          tabs: [
+            {
+              code: './examples/number-field-prefix-suffix.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/NumberField/examples/number-field-prefix-suffix.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/NumberField/examples/number-field-prefix-suffix.example.html
@@ -1,0 +1,8 @@
+<s-number-field
+  label="Weight"
+  prefix="~"
+  suffix="kg"
+  defaultValue="2"
+  step={0.1}
+  min={0}
+></s-number-field>

--- a/packages/ui-extensions/src/surfaces/checkout/components/PasswordField/PasswordField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PasswordField/PasswordField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true, slots: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Enforce a minimum password length with validation feedback. This example shows a required password field with `minLength` set to 8 and an error message.',
+        codeblock: {
+          title: 'Enforce a minimum password length',
+          tabs: [
+            {
+              code: './examples/password-field-validation.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/PasswordField/examples/password-field-validation.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PasswordField/examples/password-field-validation.example.html
@@ -1,0 +1,6 @@
+<s-password-field
+  label="Create a password"
+  required
+  minLength={8}
+  error="Password must be at least 8 characters"
+></s-password-field>

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true, slots: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Validate that a phone number is provided with a message explaining why it is needed. This example shows a required contact number field with an error about delivery updates.',
+        codeblock: {
+          title: 'Require a phone number with validation',
+          tabs: [
+            {
+              code: './examples/phone-field-required.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/examples/phone-field-required.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/examples/phone-field-required.example.html
@@ -1,0 +1,5 @@
+<s-phone-field
+  label="Contact number"
+  required
+  error="A phone number is required for delivery updates"
+></s-phone-field>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.doc.ts
@@ -7,6 +7,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Display hint text when no option is selected to guide the buyer. This example displays a language select with `placeholder` prompting the user to choose.',
+        codeblock: {
+          title: 'Add placeholder text to a select',
+          tabs: [
+            {
+              code: './examples/select-placeholder.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subcomponent: {
     ...optionSharedContent,
     definitions: {properties: true},

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select/examples/select-placeholder.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select/examples/select-placeholder.example.html
@@ -1,0 +1,5 @@
+<s-select label="Preferred language" placeholder="Choose a language">
+  <s-option value="en">English</s-option>
+  <s-option value="fr">French</s-option>
+  <s-option value="es">Spanish</s-option>
+</s-select>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Switch/Switch.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Switch/Switch.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Pre-enable a setting by rendering the switch in its active state on first load. This example shows an order notifications switch with `defaultChecked` that the buyer can toggle off.',
+        codeblock: {
+          title: 'Pre-enable a switch',
+          tabs: [
+            {
+              code: './examples/switch-default-checked.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Switch/examples/switch-default-checked.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Switch/examples/switch-default-checked.example.html
@@ -1,0 +1,1 @@
+<s-switch label="Enable order notifications" defaultChecked></s-switch>

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextArea/TextArea.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextArea/TextArea.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Limit the character count and control the visible height of a text area. This example shows a gift message field with `maxLength` of 200 and 4 visible `rows`.',
+        codeblock: {
+          title: 'Limit character count and set visible rows',
+          tabs: [
+            {
+              code: './examples/text-area-character-limit.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextArea/examples/text-area-character-limit.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextArea/examples/text-area-character-limit.example.html
@@ -1,0 +1,5 @@
+<s-text-area
+  label="Gift message"
+  maxLength={200}
+  rows={4}
+></s-text-area>

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true, slots: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add contextual labels around input values using `prefix` and `suffix`. This example demonstrates a discount code field with a "PROMO-" prefix and a tip field with a "%" suffix.',
+        codeblock: {
+          title: 'Add a prefix and suffix to text fields',
+          tabs: [
+            {
+              code: './examples/text-field-prefix-suffix.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   bestPractices: `
 - Clearly label text fields so that it’s obvious what customers should enter.
 - Label text fields as optional when input isn’t required. For example, use the label <b>First name (optional)</b>.

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/examples/text-field-prefix-suffix.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/examples/text-field-prefix-suffix.example.html
@@ -1,0 +1,4 @@
+<s-stack>
+  <s-text-field label="Discount code" prefix="PROMO-"></s-text-field>
+  <s-text-field label="Tip amount" suffix="%"></s-text-field>
+</s-stack>

--- a/packages/ui-extensions/src/surfaces/checkout/components/UrlField/UrlField.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UrlField/UrlField.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true, slots: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Validate that a URL is provided with a message explaining what link is expected. This example shows a required return policy URL field with an error message.',
+        codeblock: {
+          title: 'Require a URL with validation',
+          tabs: [
+            {
+              code: './examples/url-field-required.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/UrlField/examples/url-field-required.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UrlField/examples/url-field-required.example.html
@@ -1,0 +1,5 @@
+<s-url-field
+  label="Return policy URL"
+  required
+  error="Provide a URL to your return policy"
+></s-url-field>


### PR DESCRIPTION
Backport of #4176 (targeting 2026-04-rc) to the 2026-01 version branch.

## Summary

Adds 17 new HTML examples for Forms components (Checkbox, ConsentCheckbox, ConsentPhoneField, DateField, DatePicker, DropZone, EmailField, Form, MoneyField, NumberField, PasswordField, PhoneField, Select, Switch, TextArea, TextField, UrlField). Cherry-picked from `2026-04-rc-forms-component-examples`.

Closes part of https://github.com/shop/issues-learn/issues/1026

Made with [Cursor](https://cursor.com)