### PR TITLE
[Checkout UI Ext 2025-10] Overlays component examples + descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.doc.ts
@@ -45,6 +45,37 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Ask the buyer to confirm before cancelling an order. This example demonstrates a small modal with a warning message, a critical-toned primary button, and a secondary button to keep the order.',
+        codeblock: {
+          title: 'Confirm a destructive action in a modal',
+          tabs: [
+            {
+              code: './examples/modal-with-actions.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+      {
+        description:
+          'Collect input inside a modal without leaving the checkout flow. This example demonstrates a gift message form with text fields, a text area, and a checkbox, using the action slots for save and cancel buttons.',
+        codeblock: {
+          title: 'Collect input with a form modal',
+          tabs: [
+            {
+              code: './examples/modal-with-form.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/examples/modal-with-actions.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/examples/modal-with-actions.example.html
@@ -1,0 +1,32 @@
+<s-stack gap="base">
+  <s-button tone="critical" command="--show" commandfor="delete-modal">
+    Cancel order
+  </s-button>
+
+  <s-modal id="delete-modal" heading="Cancel this order?" size="small">
+    <s-stack>
+      <s-text>Are you sure you want to cancel order #1042?</s-text>
+      <s-text tone="warning">
+        This will release all reserved inventory. This action cannot be undone.
+      </s-text>
+    </s-stack>
+
+    <s-button
+      slot="primary-action"
+      variant="primary"
+      tone="critical"
+      command="--hide"
+      commandfor="delete-modal"
+    >
+      Cancel order
+    </s-button>
+    <s-button
+      slot="secondary-actions"
+      variant="secondary"
+      command="--hide"
+      commandfor="delete-modal"
+    >
+      Keep order
+    </s-button>
+  </s-modal>
+</s-stack>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/examples/modal-with-form.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/examples/modal-with-form.example.html
@@ -1,0 +1,30 @@
+<s-stack gap="base">
+  <s-button command="--show" commandfor="gift-modal">
+    Add gift message
+  </s-button>
+
+  <s-modal id="gift-modal" heading="Gift message" size="base">
+    <s-stack>
+      <s-text-field label="Recipient name" required></s-text-field>
+      <s-text-area label="Message" rows={3} maxLength={200}></s-text-area>
+      <s-checkbox label="Include gift receipt"></s-checkbox>
+    </s-stack>
+
+    <s-button
+      slot="primary-action"
+      variant="primary"
+      command="--hide"
+      commandfor="gift-modal"
+    >
+      Save message
+    </s-button>
+    <s-button
+      slot="secondary-actions"
+      variant="secondary"
+      command="--hide"
+      commandfor="gift-modal"
+    >
+      Cancel
+    </s-button>
+  </s-modal>
+</s-stack>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.doc.ts
@@ -33,6 +33,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Constrain the popover height so long content scrolls within a fixed area. This example displays a size chart with `maxBlockSize` set to limit the overlay height.',
+        codeblock: {
+          title: 'Constrain popover height with a size limit',
+          tabs: [
+            {
+              code: './examples/popover-constrained.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover/examples/popover-constrained.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover/examples/popover-constrained.example.html
@@ -1,0 +1,25 @@
+<s-button commandFor="size-guide">Size guide</s-button>
+
+<s-popover id="size-guide" maxBlockSize="250px">
+  <s-stack padding="base">
+    <s-text type="strong">Size chart (chest measurement)</s-text>
+    <s-stack>
+      <s-stack direction="inline" justifyContent="space-between">
+        <s-text>S</s-text>
+        <s-text color="subdued">34-36 in</s-text>
+      </s-stack>
+      <s-stack direction="inline" justifyContent="space-between">
+        <s-text>M</s-text>
+        <s-text color="subdued">38-40 in</s-text>
+      </s-stack>
+      <s-stack direction="inline" justifyContent="space-between">
+        <s-text>L</s-text>
+        <s-text color="subdued">42-44 in</s-text>
+      </s-stack>
+      <s-stack direction="inline" justifyContent="space-between">
+        <s-text>XL</s-text>
+        <s-text color="subdued">46-48 in</s-text>
+      </s-stack>
+    </s-stack>
+  </s-stack>
+</s-popover>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.doc.ts
@@ -48,6 +48,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add decision buttons to a consent sheet for cookie preferences. This example demonstrates primary and secondary action slots with accept, reject, and learn-more buttons, plus an `accessibilityLabel` for screen readers.',
+        codeblock: {
+          title: 'Add action buttons to a consent sheet',
+          tabs: [
+            {
+              code: './examples/sheet-with-actions.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet/examples/sheet-with-actions.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet/examples/sheet-with-actions.example.html
@@ -1,0 +1,22 @@
+<!-- This component requires access to Customer Privacy API to be rendered. -->
+<s-button commandFor="consent-form">Manage preferences</s-button>
+
+<s-sheet
+  id="consent-form"
+  heading="Cookie preferences"
+  accessibilityLabel="Manage cookie consent preferences"
+>
+  <s-stack>
+    <s-paragraph>
+      We use cookies to personalize your experience and analyze site traffic.
+      You can change your preferences at any time.
+    </s-paragraph>
+    <s-checkbox defaultChecked label="Essential cookies (required)"></s-checkbox>
+    <s-checkbox label="Analytics cookies"></s-checkbox>
+    <s-checkbox label="Marketing cookies"></s-checkbox>
+  </s-stack>
+
+  <s-button variant="primary" slot="primary-actions">Save preferences</s-button>
+  <s-button variant="secondary" slot="primary-actions">Reject all</s-button>
+  <s-button variant="secondary" slot="secondary-actions">Learn more</s-button>
+</s-sheet>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.doc.ts
@@ -27,6 +27,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add tooltips to checkout details using info icons. This example displays two tooltips providing delivery and duty information, each paired with an `s-clickable` using `interestFor`.',
+        codeblock: {
+          title: 'Show a tooltip on inline text',
+          tabs: [
+            {
+              code: './examples/tooltip-on-text.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 };
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/examples/tooltip-on-text.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/examples/tooltip-on-text.example.html
@@ -1,0 +1,23 @@
+<s-stack>
+  <s-stack direction="inline" gap="small-400" alignItems="center">
+    <s-text>Estimated delivery: 3-5 business days</s-text>
+    <s-clickable interestFor="delivery-tooltip">
+      <s-icon type="info" />
+    </s-clickable>
+    <s-tooltip id="delivery-tooltip">
+      Based on standard shipping to your region.
+      Express options are available at checkout.
+    </s-tooltip>
+  </s-stack>
+
+  <s-stack direction="inline" gap="small-400" alignItems="center">
+    <s-text>Duties and taxes: included</s-text>
+    <s-clickable interestFor="duties-tooltip">
+      <s-icon type="info" />
+    </s-clickable>
+    <s-tooltip id="duties-tooltip">
+      All applicable duties and import taxes are calculated
+      and collected at checkout. No surprises on delivery.
+    </s-tooltip>
+  </s-stack>
+</s-stack>


### PR DESCRIPTION
Backport of #4179 (targeting 2026-04-rc) to the 2025-10 version branch.

## Summary

Adds 5 new HTML examples for Overlays components (Modal x2, Popover, Sheet, Tooltip). Manually adapted `.doc.ts` files for the 2025-10 format.

Closes part of https://github.com/shop/issues-learn/issues/1023

Made with [Cursor](https://cursor.com)