### PR TITLE
[Checkout UI Ext 2025-10] Feedback and status indicators component examples + descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Announcement/Announcement.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Announcement/Announcement.doc.ts
@@ -34,13 +34,31 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Display a short promotional message without a modal. This example uses inline text to announce a discount code that fits in the default collapsed state.',
+        codeblock: {
+          title: 'Display a promotional discount announcement',
+          tabs: [
+            {
+              code: './examples/announcement-discount.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',
       anchorLink: 'best-practices',
       title: 'Best Practices',
       sectionContent: `- Prioritize the default state: The most effective use of the announcement bar is when content is short enough to display entirely in its default state, with no need for expansion. This provides the best user experience.
-- Handle content truncation: The component has a strict maximum height. Content that exceeds the expanded state’s height will be cut off with no scrolling capability. Ensure your application’s logic handles excessively long content gracefully to prevent truncation.
+- Handle content truncation: The component has a strict maximum height. Content that exceeds the expanded state's height will be cut off with no scrolling capability. Ensure your application's logic handles excessively long content gracefully to prevent truncation.
 - Provide a modal alternative: If your application needs to display more than a few lines of content, avoid cramming it into the announcement bar. Instead, use the bar as a teaser that links to a modal. This is the recommended pattern for displaying surveys, detailed offers, or other longer-form content.`,
     },
   ],

--- a/packages/ui-extensions/src/surfaces/checkout/components/Announcement/examples/announcement-discount.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Announcement/examples/announcement-discount.example.html
@@ -1,0 +1,6 @@
+<s-announcement>
+  <s-stack direction="inline" gap="small-100" alignItems="center">
+    <s-text>Members save 10% on this order.</s-text>
+    <s-text color="subdued">Use code SAVE10 at payment.</s-text>
+  </s-stack>
+</s-announcement>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.doc.ts
@@ -27,6 +27,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add an icon alongside a badge label to reinforce status meaning. This example uses the `icon` and `iconPosition` properties with a `neutral` tone and `small` size to display a compact delivery estimate.',
+        codeblock: {
+          title: 'Add an icon to a delivery status badge',
+          tabs: [
+            {
+              code: './examples/badge-icon.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [],
 };
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge/examples/badge-icon.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge/examples/badge-icon.example.html
@@ -1,0 +1,3 @@
+<s-badge tone="neutral" size="small" icon="delivery" iconPosition="start">
+  Arrives Wed
+</s-badge>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.doc.ts
@@ -33,6 +33,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Show a warning banner that buyers can dismiss or expand. This example uses the `warning` tone with `dismissible` and `collapsible` properties to display an address verification message with expandable details.',
+        codeblock: {
+          title: 'Show a dismissible warning with collapsible details',
+          tabs: [
+            {
+              code: './examples/banner-warning-dismissible.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner/examples/banner-warning-dismissible.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner/examples/banner-warning-dismissible.example.html
@@ -1,0 +1,11 @@
+<s-banner
+  heading="Action needed for delivery"
+  tone="warning"
+  dismissible
+  collapsible
+>
+  <s-paragraph>
+    We could not verify your apartment number. Update your address or confirm
+    the building name so we can ship your order.
+  </s-paragraph>
+</s-banner>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.doc.ts
@@ -27,6 +27,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Track a spending goal with a labeled progress bar. This example uses the `max` and `value` properties alongside `accessibilityLabel` to show how close a buyer is to qualifying for free shipping.',
+        codeblock: {
+          title: 'Track progress toward free shipping',
+          tabs: [
+            {
+              code: './examples/progress-free-shipping.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress/examples/progress-free-shipping.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress/examples/progress-free-shipping.example.html
@@ -1,0 +1,8 @@
+<s-stack gap="small-100">
+  <s-text>Add $12 more for free shipping</s-text>
+  <s-progress
+    max="100"
+    value="76"
+    accessibilityLabel="Progress toward free shipping"
+  ></s-progress>
+</s-stack>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.doc.ts
@@ -27,6 +27,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Display a large spinner with descriptive text while an operation completes. This example uses the `size` and `accessibilityLabel` properties and pairs the spinner with visible text to communicate the loading state.',
+        codeblock: {
+          title: 'Display a loading spinner with descriptive text',
+          tabs: [
+            {
+              code: './examples/spinner-with-text.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [],
 };
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner/examples/spinner-with-text.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner/examples/spinner-with-text.example.html
@@ -1,0 +1,4 @@
+<s-stack direction="inline" gap="small" alignItems="center">
+  <s-spinner size="large" accessibilityLabel="Applying your discount"></s-spinner>
+  <s-text>Updating your total</s-text>
+</s-stack>


### PR DESCRIPTION
Backport to the 2025-10 version branch. Manually adapted `.doc.ts` files for the 2025-10 format.

## Summary

Adds 5 new HTML examples for Feedback and Status Indicators components (Announcement, Badge, Banner, Progress, Spinner).

Closes part of https://github.com/shop/issues-learn/issues/1029

Made with [Cursor](https://cursor.com)