### PR TITLE
[Checkout UI Ext 2026-01] Media and visuals component examples + descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Display icons with semantic tones and custom sizes to convey status. This example uses the `tone` property for success, warning, and info states alongside the `size` property for emphasis.',
+        codeblock: {
+          title: 'Show status icons with tone and size',
+          tabs: [
+            {
+              code: './examples/icon-status.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/examples/icon-status.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/examples/icon-status.example.html
@@ -1,0 +1,3 @@
+<s-icon type="check" tone="success" size="large"></s-icon>
+<s-icon type="alert" tone="warning" size="small"></s-icon>
+<s-icon type="info" tone="info"></s-icon>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Display a banner-style image with controlled proportions. This example uses `aspectRatio` and `objectFit="cover"` to crop the image, `inlineSize="fill"` to span the container, and `loading="lazy"` for below-the-fold performance.',
+        codeblock: {
+          title: 'Display a banner image with aspect ratio and cover fit',
+          tabs: [
+            {
+              code: './examples/image-banner.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   bestPractices: `
 - Use high-resolution images to ensure a professional and high-quality experience.
 - Use optimized images so your app loads as fast as possible.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/examples/image-banner.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/examples/image-banner.example.html
@@ -1,0 +1,8 @@
+<s-image
+  src="https://cdn.shopify.com/YOUR_IMAGE_HERE"
+  alt="Campaign banner showing summer collection"
+  aspectRatio="16/9"
+  objectFit="cover"
+  inlineSize="fill"
+  loading="lazy"
+></s-image>

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Provide custom accessible names for payment method icons. This example uses `accessibilityLabel` to supply localized or descriptive names for screen readers when the default icon label is insufficient.',
+        codeblock: {
+          title: 'Label payment icons for screen readers',
+          tabs: [
+            {
+              code: './examples/payment-icon-labeled.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/examples/payment-icon-labeled.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/examples/payment-icon-labeled.example.html
@@ -1,0 +1,2 @@
+<s-payment-icon type="ideal" accessibilityLabel="iDEAL bank transfer"></s-payment-icon>
+<s-payment-icon type="bancontact" accessibilityLabel="Bancontact"></s-payment-icon>

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Render a small product image for compact line-item layouts. This example uses `size="small"` and a descriptive `alt` attribute for accessibility.',
+        codeblock: {
+          title: 'Display a compact product thumbnail',
+          tabs: [
+            {
+              code: './examples/product-thumbnail-compact.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/examples/product-thumbnail-compact.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/examples/product-thumbnail-compact.example.html
@@ -1,0 +1,5 @@
+<s-product-thumbnail
+  src="https://cdn.shopify.com/YOUR_IMAGE_HERE"
+  alt="Insulated water bottle, 750ml, ocean blue"
+  size="small"
+></s-product-thumbnail>

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Add center branding and a screen-reader label to a QR code. This example uses `logo` for visual identity, `accessibilityLabel` for assistive technology, and `border` for a visible frame.',
+        codeblock: {
+          title: 'Add a branded QR code with an accessibility label',
+          tabs: [
+            {
+              code: './examples/qr-code-branded.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   bestPractices: `
 - Always test that the QR code is scannable from a smartphone.
 - Include a square logo if that’s what your customers are familiar with.

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/examples/qr-code-branded.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/examples/qr-code-branded.example.html
@@ -1,0 +1,7 @@
+<s-qr-code
+  content="https://shopify.com/install"
+  accessibilityLabel="Scan to open the app install page"
+  logo="https://cdn.shopify.com/YOUR_LOGO_HERE"
+  border="base"
+  size="base"
+></s-qr-code>


### PR DESCRIPTION
Backport to the 2026-01 version branch.

## Summary

Adds 5 new HTML examples for Media & Visuals components (Icon, Image, PaymentIcon, ProductThumbnail, QRCode).

Closes part of https://github.com/shop/issues-learn/issues/1028

Made with [Cursor](https://cursor.com)