### PR TITLE
[Checkout UI Ext 2026-01] Layout and structure component examples + descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Box/Box.doc.ts
@@ -8,6 +8,24 @@ const data: ReferenceEntityTemplateSchema = createComponentDoc({
   definitions: {
     properties: true,
   },
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Uses `background="base"` with `border`, `borderRadius="large"`, and `padding="large"` to create a prominent callout. The `accessibilityLabel` provides context for assistive technology when the content alone is insufficient.',
+        codeblock: {
+          title: 'Highlight a callout with a bordered box',
+          tabs: [
+            {
+              code: './examples/box-callout.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   bestPractices: `
 - Use \`s-box\` when you need a container that preserves the natural size of its contents.
 - \`s-box\` is particularly useful in layout components like \`s-stack\` where you want to prevent children from stretching to fit.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Box/examples/box-callout.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Box/examples/box-callout.example.html
@@ -1,0 +1,11 @@
+<s-box
+  background="base"
+  border="base"
+  borderRadius="large"
+  padding="large"
+  accessibilityLabel="Order cutoff"
+>
+  <s-paragraph>
+    Same-day orders placed after 2 p.m. ship the next business day.
+  </s-paragraph>
+</s-box>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Details/Details.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Details/Details.doc.ts
@@ -7,6 +7,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true, events: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Set `toggleTransition="none"` to expand the disclosure instantly. This example shows a return policy summary that skips the default expand animation.',
+        codeblock: {
+          title: 'Show policy details without open animation',
+          tabs: [
+            {
+              code: './examples/details-no-animation.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subcomponent: {
     ...summarySharedContent,
     definitions: {properties: true},

--- a/packages/ui-extensions/src/surfaces/checkout/components/Details/examples/details-no-animation.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Details/examples/details-no-animation.example.html
@@ -1,0 +1,6 @@
+<s-details toggleTransition="none">
+  <s-summary>Return policy</s-summary>
+  <s-text>
+    Unopened items can be returned within 30 days. Opened consumables are not eligible.
+  </s-text>
+</s-details>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Use `direction="block"` to draw a rule along the block axis between vertically stacked content. This example shows a checkout summary with a divider between subtotal and tax.',
+        codeblock: {
+          title: 'Separate stacked labels with a block divider',
+          tabs: [
+            {
+              code: './examples/divider-block.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Divider/examples/divider-block.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Divider/examples/divider-block.example.html
@@ -1,0 +1,5 @@
+<s-stack direction="block" gap="small">
+  <s-text>Subtotal</s-text>
+  <s-divider direction="block"></s-divider>
+  <s-text>Estimated tax</s-text>
+</s-stack>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.doc.ts
@@ -7,6 +7,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Use `placeItems="center"` to align content on both axes. This example creates a two-column grid with centered text labels.',
+        codeblock: {
+          title: 'Center items in a two-column grid',
+          tabs: [
+            {
+              code: './examples/grid-centered.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subcomponent: {
     ...gridItemSharedContent,
     definitions: {properties: true},

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/examples/grid-centered.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/examples/grid-centered.example.html
@@ -1,0 +1,9 @@
+<s-grid
+  gridTemplateColumns="1fr 1fr"
+  gap="large"
+  placeItems="center"
+  padding="base"
+>
+  <s-text>Item</s-text>
+  <s-text>Qty</s-text>
+</s-grid>

--- a/packages/ui-extensions/src/surfaces/checkout/components/QueryContainer/QueryContainer.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QueryContainer/QueryContainer.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Set `containerName` to target `@container` queries to a specific ancestor. This example applies responsive padding that activates only when the named container exceeds 400px.',
+        codeblock: {
+          title: 'Name a container for targeted queries',
+          tabs: [
+            {
+              code: './examples/query-container-named.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   related: [
     {
       name: 'Responsive values',

--- a/packages/ui-extensions/src/surfaces/checkout/components/QueryContainer/examples/query-container-named.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QueryContainer/examples/query-container-named.example.html
@@ -1,0 +1,8 @@
+<s-query-container containerName="promo-banner">
+  <s-box
+    padding="@container promo-banner (inline-size > 400px) base, small"
+    background="subdued"
+  >
+    Wider viewports get more padding inside this named container.
+  </s-box>
+</s-query-container>

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox/ScrollBox.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox/ScrollBox.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Set `overflow="hidden"` to clip content that exceeds the container instead of showing a scrollbar. This example constrains a block of text to a fixed height.',
+        codeblock: {
+          title: 'Clip overflowing content without scrolling',
+          tabs: [
+            {
+              code: './examples/scroll-box-hidden.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox/examples/scroll-box-hidden.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox/examples/scroll-box-hidden.example.html
@@ -1,0 +1,7 @@
+<s-scroll-box maxBlockSize="80px" overflow="hidden">
+  <s-stack direction="block" gap="small">
+    <s-text>Line one</s-text>
+    <s-text>Line two</s-text>
+    <s-text>Line three</s-text>
+  </s-stack>
+</s-scroll-box>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Section/Section.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Section/Section.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Omit the `heading` prop and use `accessibilityLabel` to create a landmark region with no visible title. Screen readers announce the label so sighted users see only the section content.',
+        codeblock: {
+          title: 'Label a section for screen readers only',
+          tabs: [
+            {
+              code: './examples/section-accessible.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   usefulFor: `- Organizing your page in a logical structure based on nesting levels.
 - Creating consistency across pages.`,
   considerations: `- When adding headings inside sections they automatically use a specific style, which helps keep the content organized and clear.`,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Section/examples/section-accessible.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Section/examples/section-accessible.example.html
@@ -1,0 +1,6 @@
+<s-section accessibilityLabel="Loyalty program summary">
+  <s-paragraph>
+    Earn 10 points for every $1 spent. Redeem 100 points for $10 off your next
+    purchase.
+  </s-paragraph>
+</s-section>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stack/Stack.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stack/Stack.doc.ts
@@ -6,6 +6,24 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
+  extraExamples: {
+    description: '',
+    examples: [
+      {
+        description:
+          'Use `justifyContent="space-between"` with `direction="block"` to push the first and last items to opposite ends of the stack. This pattern is common in checkout summary rows.',
+        codeblock: {
+          title: 'Space items apart with block direction',
+          tabs: [
+            {
+              code: './examples/stack-space-between.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   usefulFor: `
 - Placing items in rows or columns when sections don't work for your layout.
 - Controlling the spacing between elements.`,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stack/examples/stack-space-between.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stack/examples/stack-space-between.example.html
@@ -1,0 +1,4 @@
+<s-stack direction="block" gap="small" justifyContent="space-between" minBlockSize="120px">
+  <s-text>Shipping</s-text>
+  <s-text>Free</s-text>
+</s-stack>


### PR DESCRIPTION
Backport to 2026-01.

## Summary

Adds 8 new HTML examples for Layout & Structure components.

Closes part of https://github.com/shop/issues-learn/issues/1027

Made with [Cursor](https://cursor.com)