### PR TITLE
[Checkout UI Ext 2025-10] Typography and content component examples + descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation/Abbreviation.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation/Abbreviation.doc.ts
@@ -27,6 +27,25 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description:
+      'Examples of additional ways to use the Abbreviation component.',
+    examples: [
+      {
+        description:
+          'Use `title` so screen readers announce the full phrase behind the abbreviation. This example expands a common shipping term that buyers might not recognize.',
+        codeblock: {
+          title: 'Expand a shipping acronym for screen readers',
+          tabs: [
+            {
+              code: './examples/abbreviation-shipping.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [],
 };
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation/examples/abbreviation-shipping.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation/examples/abbreviation-shipping.example.html
@@ -1,0 +1,1 @@
+<s-abbreviation title="Estimated time of arrival">ETA</s-abbreviation>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Chip/Chip.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Chip/Chip.doc.ts
@@ -33,6 +33,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: 'Examples of additional ways to use the Chip component.',
+    examples: [
+      {
+        description:
+          'Use the `graphic` slot with `s-icon` and `accessibilityLabel` for chips whose text alone doesn\'t convey the full meaning. The API restricts the `graphic` slot to icon elements.',
+        codeblock: {
+          title: 'Add an icon and a screen-reader label to a chip',
+          tabs: [
+            {
+              code: './examples/chip-icon.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [],
 };
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/Chip/examples/chip-icon.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Chip/examples/chip-icon.example.html
@@ -1,0 +1,4 @@
+<s-chip accessibilityLabel="Carbon neutral shipping">
+  <s-icon slot="graphic" type="check"></s-icon>
+  Carbon neutral
+</s-chip>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.doc.ts
@@ -27,6 +27,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: 'Examples of additional ways to use the Heading component.',
+    examples: [
+      {
+        description:
+          'Set `accessibilityRole="presentation"` to suppress heading semantics. Use this when a parent region already provides the heading and this element serves only as a visual title.',
+        codeblock: {
+          title: 'Use presentation role for visual-only headings',
+          tabs: [
+            {
+              code: './examples/heading-presentation.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       title: 'Useful for',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading/examples/heading-presentation.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading/examples/heading-presentation.example.html
@@ -1,0 +1,1 @@
+<s-heading accessibilityRole="presentation">Order summary</s-heading>

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/OrderedList.doc.ts
@@ -33,6 +33,25 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description:
+      'Examples of additional ways to use the OrderedList component.',
+    examples: [
+      {
+        description:
+          'Display a sequential checklist. This example uses a two-step process that contrasts with the three-step cart flow in the default sample.',
+        codeblock: {
+          title: 'List numbered checkout steps',
+          tabs: [
+            {
+              code: './examples/ordered-list-steps.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/examples/ordered-list-steps.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList/examples/ordered-list-steps.example.html
@@ -1,0 +1,4 @@
+<s-ordered-list>
+  <s-list-item>Enter shipping address</s-list-item>
+  <s-list-item>Choose delivery speed</s-list-item>
+</s-ordered-list>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Paragraph/Paragraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Paragraph/Paragraph.doc.ts
@@ -27,6 +27,25 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description:
+      'Examples of additional ways to use the Paragraph component.',
+    examples: [
+      {
+        description:
+          'Use `tone="warning"` for semantic intent and `color="subdued"` for de-emphasized text. This pattern pairs well with validation or delivery messaging.',
+        codeblock: {
+          title: 'Warn about address issues with tone and color',
+          tabs: [
+            {
+              code: './examples/paragraph-warning.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Paragraph/examples/paragraph-warning.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Paragraph/examples/paragraph-warning.example.html
@@ -1,0 +1,3 @@
+<s-paragraph tone="warning" color="subdued">
+  We can't ship to this address. Update your details to continue.
+</s-paragraph>

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph/SkeletonParagraph.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph/SkeletonParagraph.doc.ts
@@ -27,6 +27,25 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description:
+      'Examples of additional ways to use the SkeletonParagraph component.',
+    examples: [
+      {
+        description:
+          "Set the `content` prop to hidden placeholder text that drives the skeleton's block size. The content stays invisible until real data loads.",
+        codeblock: {
+          title: 'Size a skeleton to match final copy length',
+          tabs: [
+            {
+              code: './examples/skeleton-paragraph-sized.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [],
 };
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph/examples/skeleton-paragraph-sized.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph/examples/skeleton-paragraph-sized.example.html
@@ -1,0 +1,1 @@
+<s-skeleton-paragraph content="Your order will arrive in 3-5 business days."></s-skeleton-paragraph>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.doc.ts
@@ -27,6 +27,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: 'Examples of additional ways to use the Text component.',
+    examples: [
+      {
+        description:
+          'Use `type="strong"` for default strong emphasis and `tone="neutral"` for informational policy text without success or warning coloring.',
+        codeblock: {
+          title: 'Emphasize a legal or policy line',
+          tabs: [
+            {
+              code: './examples/text-strong.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       title: 'Useful for',
@@ -42,9 +60,9 @@ const data: ReferenceEntityTemplateSchema = {
       anchorLink: 'best-practices',
       sectionContent: `
 - Use plain and clear terms.
-- Don’t use jargon or technical language.
-- Don’t use different terms to describe the same thing.
-- Don’t duplicate content.`,
+- Don't use jargon or technical language.
+- Don't use different terms to describe the same thing.
+- Don't duplicate content.`,
     },
   ],
 };

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text/examples/text-strong.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text/examples/text-strong.example.html
@@ -1,0 +1,3 @@
+<s-text type="strong" tone="neutral">
+  By placing this order, you agree to our terms of sale.
+</s-text>

--- a/packages/ui-extensions/src/surfaces/checkout/components/Time/Time.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Time/Time.doc.ts
@@ -27,6 +27,24 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description: 'Examples of additional ways to use the Time component.',
+    examples: [
+      {
+        description:
+          'Set `dateTime` to an ISO value for machine-readable time and use human-friendly text as the display content. This contrasts with the full-date format in the default sample.',
+        codeblock: {
+          title: 'Show a same-day pickup window',
+          tabs: [
+            {
+              code: './examples/time-pickup.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Time/examples/time-pickup.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Time/examples/time-pickup.example.html
@@ -1,0 +1,1 @@
+<s-time dateTime="2025-03-26T14:00">Today, 2:00 p.m.</s-time>

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/UnorderedList.doc.ts
@@ -33,6 +33,25 @@ const data: ReferenceEntityTemplateSchema = {
       ],
     },
   },
+  examples: {
+    description:
+      'Examples of additional ways to use the UnorderedList component.',
+    examples: [
+      {
+        description:
+          'Show product inclusions as an unordered list. This contrasts with the store-policy focus in the default sample by showing product-specific content.',
+        codeblock: {
+          title: 'List items included in a product bundle',
+          tabs: [
+            {
+              code: './examples/unordered-list-bundle.example.html',
+              language: 'html',
+            },
+          ],
+        },
+      },
+    ],
+  },
   subSections: [
     {
       type: 'Generic',

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/examples/unordered-list-bundle.example.html
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList/examples/unordered-list-bundle.example.html
@@ -1,0 +1,4 @@
+<s-unordered-list>
+  <s-list-item>Protective case</s-list-item>
+  <s-list-item>Screen protector</s-list-item>
+</s-unordered-list>


### PR DESCRIPTION
Backport to 2025-10. Manually adapted .doc.ts files.

## Summary

Adds 9 new HTML examples for Typography & Content components.

Closes part of https://github.com/shop/issues-learn/issues/1025

Made with [Cursor](https://cursor.com)