### PR TITLE
Enrich JSDoc for Checkout APIs property descriptions, 2026-04-rc

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
@@ -4,7 +4,10 @@ import type {CartLine} from '../standard/standard';
 /** @publicDocs */
 export interface CartLineItemApi {
   /**
-   * The cart line the extension is attached to. Until version `2023-04`, this property was a `ReadonlySignalLike<PresentmentCartLine>`.
+   * The cart line that this extension is attached to. Use this to read the
+   * line item's merchandise, quantity, cost, and attributes.
+   *
+   * > Note: Until version `2023-04`, this property was a `ReadonlySignalLike<PresentmentCartLine>`.
    */
   target: SubscribableSignalLike<CartLine>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -6,280 +6,331 @@ import type {
 } from '../shared';
 
 /**
- * Removes a note
+ * Clears the buyer's note from the checkout. Pass this to `applyNoteChange()` to remove any existing note.
  */
 export interface NoteRemoveChange {
   /**
-   * The type of the `NoteRemoveChange` API.
+   * Identifies this as a note removal. Set this when creating a change to clear the buyer's note.
    */
   type: 'removeNote';
 }
 
 /**
- * An Update to a note on the order.
- * for example, the buyer could request detailed packaging instructions in an order note
+ * Sets or replaces the buyer's note on the checkout. Pass this to `applyNoteChange()` to update the note.
  */
 export interface NoteUpdateChange {
   /**
-   * The type of the `NoteUpdateChange` API.
+   * Identifies this as a note update. Set this when creating a change to set or replace the buyer's note.
    */
   type: 'updateNote';
   /**
-   * The new value of the note.
+   * The text to set as the buyer's note. This replaces any existing note entirely rather than appending to it.
    */
   note: string;
 }
 
+/**
+ * The input for `applyNoteChange()`. Pass either a `NoteUpdateChange` (with `type: 'updateNote'`) to set the note or a `NoteRemoveChange` (with `type: 'removeNote'`) to clear it.
+ */
 export type NoteChange = NoteRemoveChange | NoteUpdateChange;
 
+/**
+ * The result of a successful note change. The `type` property is `'success'`.
+ */
 export interface NoteChangeResultSuccess {
   /**
-   * The type of the `NoteChangeResultSuccess` API.
+   * Indicates that the note change was applied successfully.
    */
   type: 'success';
 }
 
+/**
+ * The result of a failed note change. Check the `message` property for details about what went wrong.
+ */
 export interface NoteChangeResultError {
   /**
-   * The type of the `NoteChangeResultError` API.
+   * Indicates that the note change couldn't be applied. Check the `message` property for details.
    */
   type: 'error';
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
+/**
+ * The result of calling `applyNoteChange()`. Use the `type` property to determine whether the change succeeded or failed.
+ */
 export type NoteChangeResult = NoteChangeResultSuccess | NoteChangeResultError;
 
 /**
- * Updates an attribute on the order. If an attribute with the
- * provided key does not already exist, it gets created.
+ * Updates an attribute on the cart and checkout. If an attribute with the
+ * provided key doesn't already exist, then it gets created.
  */
 export interface AttributeUpdateChange {
   /**
-   * The type of the `AttributeUpdateChange` API.
+   * Identifies this as an attribute update or creation. Set this when creating a change to add or replace an attribute value.
    */
   type: 'updateAttribute';
 
   /**
-   * Key of the attribute to add or update
+   * The key of the attribute to add or update. If an attribute with this key
+   * already exists, then its value is replaced.
    */
   key: string;
 
   /**
-   * Value for the attribute to add or update
+   * The new value for the attribute.
    */
   value: string;
 }
 
 /**
- * Removes an attribute on the order if an attribute with the
- * provided key already exists.
+ * Removes an attribute from the checkout. Pass this to `applyAttributeChange()` to delete an attribute by key. If the key doesn't exist, then the change has no effect.
  */
 export interface AttributeRemoveChange {
   /**
-   * The type of the `AttributeRemoveChange` API.
+   * Identifies this as an attribute removal. Set this when creating a change to delete an attribute by key.
    */
   type: 'removeAttribute';
 
   /**
-   * Key of the attribute to remove
+   * The key of the attribute to remove.
    */
   key: string;
 }
 
+/**
+ * The input for `applyAttributeChange()`. Pass either an `AttributeUpdateChange` (with `type: 'updateAttribute'`) to set the attribute or an `AttributeRemoveChange` (with `type: 'removeAttribute'`) to delete it.
+ */
 export type AttributeChange = AttributeUpdateChange | AttributeRemoveChange;
 
 /**
- * The returned result of a successful update to an attribute.
+ * The result of a successful attribute change. The `type` property is `'success'`.
  */
 export interface AttributeChangeResultSuccess {
   /**
-   * The type of the `AttributeChangeResultSuccess` API.
+   * Indicates that the attribute change was applied successfully.
    */
   type: 'success';
 }
 
 /**
- * The returned result of an unsuccessful update to an attribute
- * with a message detailing the type of error that occurred.
+ * The result of a failed attribute change. Check the `message` property for details about what went wrong.
  */
 export interface AttributeChangeResultError {
   /**
-   * The type of the `AttributeChangeResultError` API.
+   * Indicates that the attribute change couldn't be applied. Check the `message` property for details.
    */
   type: 'error';
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
+/**
+ * The result of calling `applyAttributeChange()`. Use the `type` property to determine whether the change succeeded or failed.
+ */
 export type AttributeChangeResult =
   | AttributeChangeResultSuccess
   | AttributeChangeResultError;
 
+/**
+ * The result of a successful cart line change. The `type` property is `'success'`.
+ */
 export interface CartLineChangeResultSuccess {
   /**
-   * Indicates that the line item was changed successfully.
+   * Indicates that the cart line change was applied successfully.
    */
   type: 'success';
 }
 
+/**
+ * The result of a failed cart line change. Check the `message` property for details about what went wrong.
+ */
 export interface CartLineChangeResultError {
   /**
-   * Indicates that the line item was not changed successfully. Refer to the `message` property for details about the error.
+   * Indicates that the line item wasn't changed successfully. Refer to the `message` property for details about the error.
    */
   type: 'error';
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
+/**
+ * The result of calling `applyCartLinesChange()`. Use the `type` property to determine whether the change succeeded or failed.
+ */
 export type CartLineChangeResult =
   | CartLineChangeResultSuccess
   | CartLineChangeResultError;
 
+/**
+ * The input for `applyCartLinesChange()`. Use the `type` property to specify the operation.
+ *
+ * - `CartLineAddChange` (`type: 'addCartLine'`) - Adds a new line item to the cart.
+ * - `CartLineRemoveChange` (`type: 'removeCartLine'`) - Removes an existing line item.
+ * - `CartLineUpdateChange` (`type: 'updateCartLine'`) - Updates an existing line item's quantity, variant, or attributes.
+ */
 export type CartLineChange =
   | CartLineAddChange
   | CartLineRemoveChange
   | CartLineUpdateChange;
 
+/**
+ * Adds a new line item to the cart. Pass this to `applyCartLinesChange()` to add a product variant with a specified quantity and optional attributes.
+ */
 export interface CartLineAddChange {
   /**
-   * An identifier for changes that add line items.
+   * Identifies this as a line item addition. Set this when creating a change to add a new product to the cart.
    */
   type: 'addCartLine';
 
   /**
-   * The merchandise ID being added.
+   * The globally-unique identifier of the product variant to add.
    * @example 'gid://shopify/ProductVariant/123'
    */
   merchandiseId: string;
 
   /**
-   * The quantity of the merchandise being added.
+   * The number of items to add. Must be a positive integer.
    */
   quantity: number;
 
   /**
-   * The attributes associated with the line item.
+   * Custom key-value attributes to attach to the new line item.
    */
   attributes?: Attribute[];
 
   /**
-   * The identifier of the selling plan that the merchandise is being purchased
-   * with.
+   * The identifier of the [selling plan](/docs/apps/build/purchase-options/subscriptions) to associate with this line item, such as a subscription or pre-order plan.
    */
   sellingPlanId?: SellingPlan['id'];
 
   /**
-   * The identifier for the associated parent cart line.
+   * The parent cart line to associate the new item with, identified by either `lineId` or `merchandiseId`. Use this when adding child items to a bundle.
    */
   parent?: {lineId: string} | {merchandiseId: string};
 }
 
+/**
+ * Removes an existing line item from the cart. Pass this to `applyCartLinesChange()` to remove a specified quantity of a line item.
+ */
 export interface CartLineRemoveChange {
   /**
-   * An identifier for changes that remove line items.
+   * Identifies this as a line item removal. Set this when creating a change to remove a product from the cart.
    */
   type: 'removeCartLine';
 
   /**
-   * Line Item ID.
+   * The unique identifier of the cart line to remove. Look up the current ID from `lines` before calling, because cart line IDs aren't stable.
    * @example 'gid://shopify/CartLine/123'
    */
   id: string;
 
   /**
-   * The quantity being removed for this line item.
+   * The number of items to remove from this line.
    */
   quantity: number;
 }
 
+/**
+ * Updates an existing line item in the cart. Pass this to `applyCartLinesChange()` to change a line item's quantity, variant, selling plan, or attributes.
+ */
 export interface CartLineUpdateChange {
   /**
-   * An identifier for changes that update line items.
+   * Identifies this as a line item update. Set this when creating a change to modify a line item's quantity, variant, or attributes.
    */
   type: 'updateCartLine';
 
   /**
-   * Line Item ID.
+   * The unique identifier of the cart line to update. Look up the current ID from `lines` before calling, because cart line IDs aren't stable.
    * @example 'gid://shopify/CartLine/123'
    */
   id: string;
 
   /**
-   * The new merchandise ID for the line item.
+   * The new product variant to swap in for this line item. Only provide this if you want to change the variant.
    * @example 'gid://shopify/ProductVariant/123'
    */
 
   merchandiseId?: string;
   /**
-   * The new quantity for the line item.
+   * The new quantity for this line item. Only provide this if you want to change the quantity.
    */
   quantity?: number;
 
   /**
-   * The new attributes for the line item.
+   * The new custom key-value attributes for this line item. Replaces all existing attributes when provided.
    */
   attributes?: Attribute[];
 
   /**
-   * The identifier of the selling plan that the merchandise is being purchased
-   * with or `null` to remove the the product from the selling plan.
+   * The [selling plan](/docs/apps/build/purchase-options/subscriptions) to associate with this line item. Pass `null` to remove the item from its current selling plan.
    */
   sellingPlanId?: SellingPlan['id'] | null;
 
   /**
-   * The identifier for the associated parent cart line.
+   * The parent cart line to associate this item with. Use this when updating the parent relationship for bundled items.
    */
   parent?: {lineId: string} | {merchandiseId: string};
 }
 
+/**
+ * The input for `applyDiscountCodeChange()`. Pass either a `DiscountCodeAddChange` (with `type: 'addDiscountCode'`) to apply a code or a `DiscountCodeRemoveChange` (with `type: 'removeDiscountCode'`) to remove it.
+ */
 export type DiscountCodeChange =
   | DiscountCodeAddChange
   | DiscountCodeRemoveChange;
 
+/**
+ * The result of calling `applyDiscountCodeChange()`. Use the `type` property to determine whether the change succeeded or failed.
+ */
 export type DiscountCodeChangeResult =
   | DiscountCodeChangeResultSuccess
   | DiscountCodeChangeResultError;
 
+/**
+ * Applies a discount code to the checkout. Pass this to `applyDiscountCodeChange()` to add a code.
+ */
 export interface DiscountCodeAddChange {
   /**
-   * The type of the `DiscountCodeChange` API.
+   * Identifies this as a discount code addition. Set this when creating a change to apply a discount code to the checkout.
    */
   type: 'addDiscountCode';
 
   /**
-   * The code for the discount (case-insensitive)
+   * The discount code to apply. Codes are case-insensitive.
    */
   code: string;
 }
 
+/**
+ * Removes a discount code from the checkout. Pass this to `applyDiscountCodeChange()` to remove a code.
+ */
 export interface DiscountCodeRemoveChange {
   /**
-   * The type of the `DiscountCodeChange` API.
+   * Identifies this as a discount code removal. Set this when creating a change to remove a discount code from the checkout.
    */
   type: 'removeDiscountCode';
 
   /**
-   * The code for the discount (case-insensitive)
+   * The discount code to remove. Codes are case-insensitive.
    */
   code: string;
 }
 
+/**
+ * The result of a successful discount code change. The `type` property is `'success'`.
+ */
 export interface DiscountCodeChangeResultSuccess {
   /**
    * Indicates that the discount code change was applied successfully.
@@ -287,50 +338,68 @@ export interface DiscountCodeChangeResultSuccess {
   type: 'success';
 }
 
+/**
+ * The result of a failed discount code change. Check the `message` property for details about what went wrong.
+ */
 export interface DiscountCodeChangeResultError {
   /**
-   * Indicates that the discount code change failed.
+   * Indicates that the discount code change couldn't be applied. Check the `message` property for details.
    */
   type: 'error';
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
+/**
+ * The input for `applyGiftCardChange()`. Pass either a `GiftCardAddChange` (with `type: 'addGiftCard'`) to apply a gift card or a `GiftCardRemoveChange` (with `type: 'removeGiftCard'`) to remove it.
+ */
 export type GiftCardChange = GiftCardAddChange | GiftCardRemoveChange;
 
+/**
+ * The result of calling `applyGiftCardChange()`. Use the `type` property to determine whether the change succeeded or failed.
+ */
 export type GiftCardChangeResult =
   | GiftCardChangeResultSuccess
   | GiftCardChangeResultError;
 
+/**
+ * Applies a gift card to the checkout. Pass this to `applyGiftCardChange()` to add a gift card.
+ */
 export interface GiftCardAddChange {
   /**
-   * The type of the `GiftCardChange` API.
+   * Identifies this as a gift card addition. Set this when creating a change to apply a gift card to the checkout.
    */
   type: 'addGiftCard';
 
   /**
-   * Gift card code.
+   * The full gift card code to apply to the checkout.
    */
   code: string;
 }
 
+/**
+ * Removes a gift card from the checkout. Pass this to `applyGiftCardChange()` to remove a gift card.
+ */
 export interface GiftCardRemoveChange {
   /**
-   * The type of the `GiftCardChange` API.
+   * Identifies this as a gift card removal. Set this when creating a change to remove a gift card from the checkout.
    */
   type: 'removeGiftCard';
 
   /**
-   * The full gift card code, or the last four digits of the code.
+   * The gift card code to remove. You can pass either the full code or
+   * just the last four characters.
    */
   code: string;
 }
 
+/**
+ * The result of a successful gift card change. The `type` property is `'success'`.
+ */
 export interface GiftCardChangeResultSuccess {
   /**
    * Indicates that the gift card change was applied successfully.
@@ -338,24 +407,26 @@ export interface GiftCardChangeResultSuccess {
   type: 'success';
 }
 
+/**
+ * The result of a failed gift card change. Check the `message` property for details about what went wrong.
+ */
 export interface GiftCardChangeResultError {
   /**
-   * Indicates that the gift card change failed.
+   * Indicates that the gift card change couldn't be applied. Check the `message` property for details.
    */
   type: 'error';
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
-/** Removes a cart metafield. */
+/** Removes a cart [metafield](/docs/apps/build/custom-data/metafields). Pass this to `applyMetafieldChange()` to delete a metafield by key and namespace. */
 export interface MetafieldRemoveCartChange {
   /**
-   * The type of the `MetafieldRemoveCartChange` API.
+   * Identifies this as a cart metafield removal. Set this when creating a change to delete an existing metafield by key and namespace.
    */
   type: 'removeCartMetafield';
 
@@ -371,20 +442,22 @@ export interface MetafieldRemoveCartChange {
 }
 
 /**
- * Updates a cart metafield. If a metafield with the
- * provided key and namespace does not already exist, it gets created.
+ * Creates or updates a cart [metafield](/docs/apps/build/custom-data/metafields). Pass this to `applyMetafieldChange()` to set a metafield value. If a metafield with the provided key and namespace doesn't already exist, then it gets created.
  */
 export interface MetafieldUpdateCartChange {
   /**
-   * The type of the `MetafieldUpdateCartChange` API.
+   * Identifies this as a cart metafield creation or update. Set this when creating a change to set a metafield value.
    */
   type: 'updateCartMetafield';
 
+  /**
+   * The metafield data to set on the cart. If a metafield with this key and namespace already exists, then its value is replaced.
+   */
   metafield: {
     /** The name of the metafield to update. */
     key: string;
 
-    /** The namespace of the metafield to add. */
+    /** The namespace of the metafield to update. */
     namespace?: string;
 
     /** The new information to store in the metafield. */
@@ -392,173 +465,191 @@ export interface MetafieldUpdateCartChange {
 
     /**
      * The metafield’s information type.
-     * See the [`metafields documentation`](https://shopify.dev/docs/apps/custom-data/metafields/types) for a list of supported types.
+     * See the [metafield types documentation](/docs/apps/build/custom-data/metafields/list-of-data-types) for a list of supported types.
      */
     type: string;
   };
 }
 
+/**
+ * The input for `applyMetafieldChange()`. Use the `type` property to specify the operation.
+ *
+ * - `MetafieldRemoveCartChange` (`type: 'removeCartMetafield'`) - Removes an existing cart [metafield](/docs/apps/build/custom-data/metafields).
+ * - `MetafieldUpdateCartChange` (`type: 'updateCartMetafield'`) - Creates or updates a cart metafield.
+ */
 export type MetafieldChange =
   | MetafieldRemoveCartChange
   | MetafieldUpdateCartChange;
 
+/**
+ * The result of a successful metafield change. The `type` property is `'success'`.
+ */
 export interface MetafieldChangeResultSuccess {
   /**
-   * The type of the `MetafieldChangeResultSuccess` API.
+   * Indicates that the metafield change was applied successfully.
    */
   type: 'success';
 }
 
+/**
+ * The result of a failed metafield change. Check the `message` property for details about what went wrong.
+ */
 export interface MetafieldChangeResultError {
   /**
-   * The type of the `MetafieldChangeResultError` API.
+   * Indicates that the metafield change couldn't be applied. Check the `message` property for details.
    */
   type: 'error';
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
+/**
+ * The result of calling `applyMetafieldChange()`. Use the `type` property to determine whether the change succeeded or failed.
+ */
 export type MetafieldChangeResult =
   | MetafieldChangeResultSuccess
   | MetafieldChangeResultError;
 
+/**
+ * Updates the buyer's shipping address on the checkout. Pass this to `applyShippingAddressChange()` to modify specific address fields without replacing the entire address.
+ */
 export interface ShippingAddressUpdateChange {
   /**
-   * The type of the `ShippingAddressUpdateChange` API.
+   * Identifies this as a shipping address update. This is the only supported change type for `applyShippingAddressChange()`.
    */
   type: 'updateShippingAddress';
 
   /**
    * Fields to update in the shipping address. You only need to provide
-   * values for the fields you want to update — any fields you do not list
-   * will keep their current values.
+   * values for the fields you want to update. Any fields you don't list
+   * keep their current values.
    */
   address: Partial<ShippingAddress>;
 }
 
+/**
+ * The input for `applyShippingAddressChange()`. Currently only supports `ShippingAddressUpdateChange` (with `type: 'updateShippingAddress'`).
+ */
 export type ShippingAddressChange = ShippingAddressUpdateChange;
 
 /**
- * The returned result of a successful update to the shipping address.
+ * The result of a successful shipping address change. The `type` property is `'success'` and `errors` is `null`.
  */
 export interface ShippingAddressChangeResultSuccess {
   /**
-   * The type of the `ShippingAddressChangeResultSuccess` API.
+   * Indicates that the shipping address change was applied successfully.
    */
   type: 'success';
 
+  /**
+   * Always `null` for a successful address change. Present so that you can
+   * check `result.errors` without narrowing the union type first.
+   */
   errors: null;
 }
 
 /**
- * An error corresponding to a particular field from a given change
+ * An error corresponding to a particular field from a given change. Use the `field` property to determine which address field caused the error.
  */
 export interface ShippingAddressChangeFieldError {
   /**
-   * field key from MailingAddress where the error occurred
+   * The `MailingAddress` field that caused the error, such as `'countryCode'` or `'zip'`. The value is `undefined` if the error isn't specific to a single field.
    */
   field?: keyof MailingAddress;
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
 /**
- * The returned result of an update to the shipping address
- * with a messages detailing the type of errors that occurred.
+ * The result of a failed shipping address change. Check the `errors` array for field-level details about what went wrong.
  */
 export interface ShippingAddressChangeResultError {
   /**
-   * The type of the `ShippingAddressChangeResultError` API.
+   * Indicates that the shipping address change couldn't be applied. Check the `errors` array for field-level details.
    */
   type: 'error';
 
   /**
-   * The errors corresponding to particular fields from a given change
+   * The list of field-level errors that prevented the address change. Each entry identifies which address field failed and why.
    */
   errors: ShippingAddressChangeFieldError[];
 }
 
+/**
+ * The result of calling `applyShippingAddressChange()`. Use the `type` property to determine whether the change succeeded or failed. On failure, the `errors` array contains field-level details.
+ */
 export type ShippingAddressChangeResult =
   | ShippingAddressChangeResultSuccess
   | ShippingAddressChangeResultError;
 
-/** @publicDocs */
+/**
+ * @publicDocs
+ * Methods for modifying the checkout, including cart lines, discount codes, gift cards, metafields, notes, attributes, and the shipping address. Each method returns a promise that resolves with a result indicating success or failure.
+ */
 export interface CheckoutApi {
   /**
-   * Performs an update on an attribute attached to the cart and checkout. If
-   * successful, this mutation results in an update to the value retrieved
-   * through the [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property.
+   * Updates or removes an attribute on the cart and checkout. On success, the
+   * [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property updates to reflect the change.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    *
-   * @deprecated - Consumers should use cart metafields instead.
+   * @deprecated Use cart metafields instead.
    */
   applyAttributeChange(change: AttributeChange): Promise<AttributeChangeResult>;
 
   /**
-   * Performs an update on the merchandise line items. It resolves when the new
-   * line items have been negotiated and results in an update to the value
-   * retrieved through the
-   * [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines)
-   * property.
+   * Adds, removes, or updates line items in the cart. The returned promise resolves when the change has been negotiated, and the [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines) property updates with the new state.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyCartLinesChange(change: CartLineChange): Promise<CartLineChangeResult>;
 
   /**
-   * Performs an update on the discount codes.
-   * It resolves when the new discount codes have been negotiated and results in an update
-   * to the value retrieved through the [`discountCodes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property.
+   * Adds or removes a discount code on the checkout. The returned promise resolves when the change has been negotiated, and the [`discountCodes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property updates with the new state.
    *
    * > Caution:
    * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyDiscountCodeChange(
     change: DiscountCodeChange,
   ): Promise<DiscountCodeChangeResult>;
 
   /**
-   * Performs an update on the gift cards.
-   * It resolves when gift card change have been negotiated and results in an update
-   * to the value retrieved through the [`appliedGiftCards`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property.
+   * Adds or removes a gift card from the checkout. The returned promise resolves when the change has been negotiated, and the [`appliedGiftCards`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property updates with the new state.
    *
    * > Caution:
    * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.
    *
-   * > Note: This method will return an error if the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyGiftCardChange(change: GiftCardChange): Promise<GiftCardChangeResult>;
 
   /**
-   * Performs an update on a piece of metadata attached to the checkout. If
-   * successful, this mutation results in an update to the value retrieved
-   * through the [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property.
+   * Creates, updates, or removes a cart metafield on the checkout. On success, the
+   * [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property updates to reflect the change.
    *
-   * Cart metafields will be copied to order metafields at order creation time if there is a matching order metafield definition with the [`cart to order copyable`](https://shopify.dev/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.
+   * Cart metafields are copied to order metafields at order creation time if there's a matching order metafield definition with the [`cart to order copyable`](https://shopify.dev/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyMetafieldChange(change: MetafieldChange): Promise<MetafieldChangeResult>;
 
   /**
-   * Performs an update on the note attached to the cart and checkout. If
-   * successful, this mutation results in an update to the value retrieved
-   * through the [`note`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note) property.
+   * Sets or removes the buyer's note on the checkout. On success, the
+   * [`note`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note)
+   * property updates to reflect the change.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyNoteChange(change: NoteChange): Promise<NoteChangeResult>;
 
@@ -568,12 +659,11 @@ export interface CheckoutApi {
   experimentalIsShopAppStyle?: boolean;
 
   /**
-   * Performs an update of the shipping address. Shipping address changes will
-   * completely overwrite the existing shipping address added by the user without
-   * any prompts. If successful, this mutation results in an update to the value
-   * retrieved through the `shippingAddress` property.
+   * Updates the buyer's shipping address on the checkout. The new values completely
+   * overwrite the existing address without prompting the buyer. On success, the
+   * `shippingAddress` property updates to reflect the change.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -176,9 +176,9 @@ export type CartLineChangeResult =
 /**
  * The input for `applyCartLinesChange()`. Use the `type` property to specify the operation.
  *
- * - `CartLineAddChange` (`type: 'addCartLine'`) - Adds a new line item to the cart.
- * - `CartLineRemoveChange` (`type: 'removeCartLine'`) - Removes an existing line item.
- * - `CartLineUpdateChange` (`type: 'updateCartLine'`) - Updates an existing line item's quantity, variant, or attributes.
+ * - `CartLineAddChange` (`type: 'addCartLine'`): Adds a new line item to the cart.
+ * - `CartLineRemoveChange` (`type: 'removeCartLine'`): Removes an existing line item.
+ * - `CartLineUpdateChange` (`type: 'updateCartLine'`): Updates an existing line item's quantity, variant, or attributes.
  */
 export type CartLineChange =
   | CartLineAddChange
@@ -474,8 +474,8 @@ export interface MetafieldUpdateCartChange {
 /**
  * The input for `applyMetafieldChange()`. Use the `type` property to specify the operation.
  *
- * - `MetafieldRemoveCartChange` (`type: 'removeCartMetafield'`) - Removes an existing cart [metafield](/docs/apps/build/custom-data/metafields).
- * - `MetafieldUpdateCartChange` (`type: 'updateCartMetafield'`) - Creates or updates a cart metafield.
+ * - `MetafieldRemoveCartChange` (`type: 'removeCartMetafield'`): Removes an existing cart [metafield](/docs/apps/build/custom-data/metafields).
+ * - `MetafieldUpdateCartChange` (`type: 'updateCartMetafield'`): Creates or updates a cart metafield.
  */
 export type MetafieldChange =
   | MetafieldRemoveCartChange
@@ -597,38 +597,38 @@ export type ShippingAddressChangeResult =
 export interface CheckoutApi {
   /**
    * Updates or removes an attribute on the cart and checkout. On success, the
-   * [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property updates to reflect the change.
+   * [`attributes`](/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property updates to reflect the change.
    *
-   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    *
    * @deprecated Use cart metafields instead.
    */
   applyAttributeChange(change: AttributeChange): Promise<AttributeChangeResult>;
 
   /**
-   * Adds, removes, or updates line items in the cart. The returned promise resolves when the change has been negotiated, and the [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines) property updates with the new state.
+   * Adds, removes, or updates line items in the cart. The returned promise resolves when the change has been applied by the server, and the [`lines`](/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines) property updates with the new state.
    *
-   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyCartLinesChange(change: CartLineChange): Promise<CartLineChangeResult>;
 
   /**
-   * Adds or removes a discount code on the checkout. The returned promise resolves when the change has been negotiated, and the [`discountCodes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property updates with the new state.
+   * Adds or removes a discount code on the checkout. The returned promise resolves when the change has been applied by the server, and the [`discountCodes`](/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property updates with the new state.
    *
    * > Caution:
-   * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.
+   * > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.
    *
-   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyDiscountCodeChange(
     change: DiscountCodeChange,
   ): Promise<DiscountCodeChangeResult>;
 
   /**
-   * Adds or removes a gift card from the checkout. The returned promise resolves when the change has been negotiated, and the [`appliedGiftCards`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property updates with the new state.
+   * Adds or removes a gift card from the checkout. The returned promise resolves when the change has been applied by the server, and the [`appliedGiftCards`](/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property updates with the new state.
    *
    * > Caution:
-   * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.
+   * > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.
    *
    * > Note: This method returns an error if the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
@@ -636,20 +636,20 @@ export interface CheckoutApi {
 
   /**
    * Creates, updates, or removes a cart metafield on the checkout. On success, the
-   * [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property updates to reflect the change.
+   * [`metafields`](/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property updates to reflect the change.
    *
-   * Cart metafields are copied to order metafields at order creation time if there's a matching order metafield definition with the [`cart to order copyable`](https://shopify.dev/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.
+   * Cart metafields are copied to order metafields at order creation time if there's a matching order metafield definition with the [`cart to order copyable`](/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.
    *
-   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyMetafieldChange(change: MetafieldChange): Promise<MetafieldChangeResult>;
 
   /**
    * Sets or removes the buyer's note on the checkout. On success, the
-   * [`note`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note)
+   * [`note`](/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note)
    * property updates to reflect the change.
    *
-   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyNoteChange(change: NoteChange): Promise<NoteChangeResult>;
 
@@ -659,11 +659,11 @@ export interface CheckoutApi {
   experimentalIsShopAppStyle?: boolean;
 
   /**
-   * Updates the buyer's shipping address on the checkout. The new values completely
-   * overwrite the existing address without prompting the buyer. On success, the
-   * `shippingAddress` property updates to reflect the change.
+   * Updates the buyer's shipping address on the checkout. The provided fields
+   * are merged into the existing address without prompting the buyer. On success,
+   * the `shippingAddress` property updates to reflect the change.
    *
-   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -211,7 +211,7 @@ export interface CartLineAddChange {
   attributes?: Attribute[];
 
   /**
-   * The identifier of the [selling plan](/docs/apps/build/purchase-options/subscriptions) to associate with this line item, such as a subscription or pre-order plan.
+   * The identifier of the [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions) to associate with this line item, such as a subscription or pre-order plan.
    */
   sellingPlanId?: SellingPlan['id'];
 
@@ -274,7 +274,7 @@ export interface CartLineUpdateChange {
   attributes?: Attribute[];
 
   /**
-   * The [selling plan](/docs/apps/build/purchase-options/subscriptions) to associate with this line item. Pass `null` to remove the item from its current selling plan.
+   * The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions) to associate with this line item. Pass `null` to remove the item from its current selling plan.
    */
   sellingPlanId?: SellingPlan['id'] | null;
 
@@ -423,7 +423,7 @@ export interface GiftCardChangeResultError {
   message: string;
 }
 
-/** Removes a cart [metafield](/docs/apps/build/custom-data/metafields). Pass this to `applyMetafieldChange()` to delete a metafield by key and namespace. */
+/** Removes a cart [metafield](https://shopify.dev/docs/apps/build/custom-data/metafields). Pass this to `applyMetafieldChange()` to delete a metafield by key and namespace. */
 export interface MetafieldRemoveCartChange {
   /**
    * Identifies this as a cart metafield removal. Set this when creating a change to delete an existing metafield by key and namespace.
@@ -442,7 +442,7 @@ export interface MetafieldRemoveCartChange {
 }
 
 /**
- * Creates or updates a cart [metafield](/docs/apps/build/custom-data/metafields). Pass this to `applyMetafieldChange()` to set a metafield value. If a metafield with the provided key and namespace doesn't already exist, then it gets created.
+ * Creates or updates a cart [metafield](https://shopify.dev/docs/apps/build/custom-data/metafields). Pass this to `applyMetafieldChange()` to set a metafield value. If a metafield with the provided key and namespace doesn't already exist, then it gets created.
  */
 export interface MetafieldUpdateCartChange {
   /**
@@ -465,7 +465,7 @@ export interface MetafieldUpdateCartChange {
 
     /**
      * The metafield’s information type.
-     * See the [metafield types documentation](/docs/apps/build/custom-data/metafields/list-of-data-types) for a list of supported types.
+     * See the [metafield types documentation](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types) for a list of supported types.
      */
     type: string;
   };
@@ -474,7 +474,7 @@ export interface MetafieldUpdateCartChange {
 /**
  * The input for `applyMetafieldChange()`. Use the `type` property to specify the operation.
  *
- * - `MetafieldRemoveCartChange` (`type: 'removeCartMetafield'`): Removes an existing cart [metafield](/docs/apps/build/custom-data/metafields).
+ * - `MetafieldRemoveCartChange` (`type: 'removeCartMetafield'`): Removes an existing cart [metafield](https://shopify.dev/docs/apps/build/custom-data/metafields).
  * - `MetafieldUpdateCartChange` (`type: 'updateCartMetafield'`): Creates or updates a cart metafield.
  */
 export type MetafieldChange =
@@ -597,38 +597,38 @@ export type ShippingAddressChangeResult =
 export interface CheckoutApi {
   /**
    * Updates or removes an attribute on the cart and checkout. On success, the
-   * [`attributes`](/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property updates to reflect the change.
+   * [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/attributes#standardapi-propertydetail-attributes) property updates to reflect the change.
    *
-   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    *
    * @deprecated Use cart metafields instead.
    */
   applyAttributeChange(change: AttributeChange): Promise<AttributeChangeResult>;
 
   /**
-   * Adds, removes, or updates line items in the cart. The returned promise resolves when the change has been applied by the server, and the [`lines`](/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines) property updates with the new state.
+   * Adds, removes, or updates line items in the cart. The returned promise resolves when the change has been applied by the server, and the [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-lines#standardapi-propertydetail-lines) property updates with the new state.
    *
-   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyCartLinesChange(change: CartLineChange): Promise<CartLineChangeResult>;
 
   /**
-   * Adds or removes a discount code on the checkout. The returned promise resolves when the change has been applied by the server, and the [`discountCodes`](/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property updates with the new state.
+   * Adds or removes a discount code on the checkout. The returned promise resolves when the change has been applied by the server, and the [`discountCodes`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/discounts#standardapi-propertydetail-discountcodes) property updates with the new state.
    *
    * > Caution:
-   * > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.
+   * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#network-access) if your extension retrieves discount codes through a network call.
    *
-   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyDiscountCodeChange(
     change: DiscountCodeChange,
   ): Promise<DiscountCodeChangeResult>;
 
   /**
-   * Adds or removes a gift card from the checkout. The returned promise resolves when the change has been applied by the server, and the [`appliedGiftCards`](/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property updates with the new state.
+   * Adds or removes a gift card from the checkout. The returned promise resolves when the change has been applied by the server, and the [`appliedGiftCards`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property updates with the new state.
    *
    * > Caution:
-   * > See [security considerations](/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.
+   * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#network-access) if your extension retrieves gift card codes through a network call.
    *
    * > Note: This method returns an error if the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
@@ -636,20 +636,20 @@ export interface CheckoutApi {
 
   /**
    * Creates, updates, or removes a cart metafield on the checkout. On success, the
-   * [`metafields`](/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property updates to reflect the change.
+   * [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/metafields#standardapi-propertydetail-metafields) property updates to reflect the change.
    *
-   * Cart metafields are copied to order metafields at order creation time if there's a matching order metafield definition with the [`cart to order copyable`](/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.
+   * Cart metafields are copied to order metafields at order creation time if there's a matching order metafield definition with the [`cart to order copyable`](https://shopify.dev/docs/apps/build/metafields/use-metafield-capabilities#cart-to-order-copyable) capability enabled.
    *
-   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyMetafieldChange(change: MetafieldChange): Promise<MetafieldChangeResult>;
 
   /**
    * Sets or removes the buyer's note on the checkout. On success, the
-   * [`note`](/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note)
+   * [`note`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/note#standardapi-propertydetail-note)
    * property updates to reflect the change.
    *
-   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyNoteChange(change: NoteChange): Promise<NoteChangeResult>;
 
@@ -663,9 +663,9 @@ export interface CheckoutApi {
    * are merged into the existing address without prompting the buyer. On success,
    * the `shippingAddress` property updates to reflect the change.
    *
-   * > Note: This method returns an error if the [cart instruction](/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
+   * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   applyShippingAddressChange?(
     change: ShippingAddressChange,

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
@@ -3,15 +3,18 @@ import type {SubscribableSignalLike} from '../../shared';
 export interface OrderConfirmation {
   order: {
     /**
-     * A globally unique identifier for the order. This becomes the `Order`
-     * resource ID in the Admin API once the order is fully created.
+     * A globally unique identifier for the order. This becomes the
+     * [`Order`](/docs/api/admin-graphql/latest/objects/Order) object ID in the
+     * GraphQL Admin API after the order is created.
      *
      * @example 'gid://shopify/Order/123'
      */
     id: string;
   };
   /**
-   * A randomly generated alpha-numeric identifier for the order, distinct from the `order.id`. The value is `undefined` for orders created before 2024; all orders from 2024 onward always have a number.
+   * A randomly generated alpha-numeric identifier for the order, distinct
+   * from `order.id`. The value is `undefined` for orders that were created
+   * before this field was introduced. All recent orders have a number.
    */
   number?: string;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
@@ -4,7 +4,7 @@ export interface OrderConfirmation {
   order: {
     /**
      * A globally unique identifier for the order. This becomes the
-     * [`Order`](/docs/api/admin-graphql/latest/objects/Order) object ID in the
+     * [`Order`](https://shopify.dev/docs/api/admin-graphql/latest/objects/Order) object ID in the
      * GraphQL Admin API after the order is created.
      *
      * @example 'gid://shopify/Order/123'

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
@@ -3,18 +3,20 @@ import type {SubscribableSignalLike} from '../../shared';
 export interface OrderConfirmation {
   order: {
     /**
-     * The globally-uniqueID of the OrderConfirmation. This will be the ID of the Order once successfully created.
+     * A globally unique identifier for the order. This becomes the `Order`
+     * resource ID in the Admin API once the order is fully created.
+     *
+     * @example 'gid://shopify/Order/123'
      */
     id: string;
   };
   /**
-   * A randomly generated alpha-numeric identifier for the order.
-   * For orders created in 2024 and onwards, the number will always be present. For orders created before that date, the number might not be present.
+   * A randomly generated alpha-numeric identifier for the order, distinct from the `order.id`. The value is `undefined` for orders created before 2024; all orders from 2024 onward always have a number.
    */
   number?: string;
 
   /**
-   * Whether this is the customer's first order.
+   * Whether this is the customer's first completed order with this shop. `true` means the buyer hasn't placed an order here before. Use this to show first-purchase messaging or trigger welcome offers.
    */
   isFirstOrder: boolean;
 }
@@ -22,7 +24,7 @@ export interface OrderConfirmation {
 /** @publicDocs */
 export interface OrderConfirmationApi {
   /**
-   * Order information that's available post-checkout.
+   * The order details available after the buyer completes checkout, including the order ID, order number, and whether it's the buyer's first purchase.
    */
   orderConfirmation: SubscribableSignalLike<OrderConfirmation>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
@@ -4,12 +4,12 @@ import type {PickupLocationOption} from '../standard/standard';
 /** @publicDocs */
 export interface PickupLocationItemApi {
   /**
-   * The pickup location the extension is attached to.
+   * The pickup location that this extension is attached to. Use this to read the location's name, address, and other details.
    */
   target: SubscribableSignalLike<PickupLocationOption>;
 
   /**
-   * Whether the pickup location is currently selected.
+   * Whether the pickup location this extension is attached to is currently selected by the buyer. When `true`, the buyer has chosen this location. When `false`, the buyer has selected a different pickup location.
    */
   isTargetSelected: SubscribableSignalLike<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
@@ -9,7 +9,7 @@ export interface PickupLocationItemApi {
   target: SubscribableSignalLike<PickupLocationOption>;
 
   /**
-   * Whether the pickup location this extension is attached to is currently selected by the buyer. When `true`, the buyer has chosen this location. When `false`, the buyer has selected a different pickup location.
+   * Whether the buyer has selected the target pickup location. When `true`, the target location is the buyer's active choice. When `false`, the buyer has chosen a different pickup location.
    */
   isTargetSelected: SubscribableSignalLike<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-list.ts
@@ -3,7 +3,9 @@ import type {SubscribableSignalLike} from '../../shared';
 /** @publicDocs */
 export interface PickupLocationListApi {
   /**
-   * Whether the customer location input form is shown to the buyer.
+   * Whether the location search form is currently visible to the buyer.
+   * Use this to conditionally render UI that depends on the buyer actively
+   * searching for pickup locations.
    */
   isLocationFormVisible: SubscribableSignalLike<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
@@ -3,7 +3,9 @@ import type {SubscribableSignalLike} from '../../shared';
 /** @publicDocs */
 export interface PickupPointListApi {
   /**
-   * Whether the customer location input form is shown to the buyer.
+   * Whether the location search form is currently visible to the buyer.
+   * Use this to conditionally render UI that depends on the buyer actively
+   * searching for pickup points.
    */
   isLocationFormVisible: SubscribableSignalLike<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -14,14 +14,14 @@ export interface ValidationError {
    *
    * @example '$.cart.deliveryGroups[0].deliveryAddress.countryCode'
    *
-   * See the [supported targets](https://shopify.dev/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)
+   * See the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)
    * for more information.
    */
   target?: string;
 }
 
 /**
- * A [selling plan](/docs/apps/build/purchase-options/subscriptions) represents a recurring or deferred purchasing option for a product, such as a subscription, pre-order, or try-before-you-buy plan. Selling plans are configured by the merchant and define how and when the buyer is charged.
+ * A [selling plan](/docs/apps/build/purchase-options/subscriptions) represents a recurring or deferred purchasing option for a product, such as a subscription, pre-order, or try-before-you-buy plan. The merchant configures selling plans to define how and when the buyer is charged.
  */
 export interface SellingPlan {
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -2,13 +2,17 @@ import type {CountryCode} from '../../../shared';
 
 export interface ValidationError {
   /**
-   * Error message to be displayed to the buyer.
+   * The error message to display to the buyer. Use this to explain what
+   * went wrong and how to fix it.
    */
   message: string;
   /**
-   * The checkout UI field that the error is associated with.
+   * The checkout UI field that the error is associated with. When provided,
+   * checkout highlights the matching field so the buyer knows where to fix
+   * the issue. The value is `undefined` if the error isn't tied to a
+   * specific field.
    *
-   * Example: `$.cart.deliveryGroups[0].deliveryAddress.countryCode`
+   * @example '$.cart.deliveryGroups[0].deliveryAddress.countryCode'
    *
    * See the [supported targets](https://shopify.dev/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)
    * for more information.
@@ -16,34 +20,51 @@ export interface ValidationError {
   target?: string;
 }
 
+/**
+ * A [selling plan](/docs/apps/build/purchase-options/subscriptions) represents a recurring or deferred purchasing option for a product, such as a subscription, pre-order, or try-before-you-buy plan. Selling plans are configured by the merchant and define how and when the buyer is charged.
+ */
 export interface SellingPlan {
   /**
-   * A globally-unique identifier.
+   * A globally-unique identifier for the selling plan in the format
+   * `gid://shopify/SellingPlan/<id>`. Use this to reference the specific
+   * selling plan associated with a line item.
+   *
    * @example 'gid://shopify/SellingPlan/1'
    */
   id: string;
 
   /**
-   * Whether purchasing the selling plan will result in multiple deliveries.
+   * Whether purchasing through this selling plan results in multiple
+   * deliveries. `true` for subscription plans with recurring fulfillment,
+   * `false` for one-time pre-orders or try-before-you-buy plans.
    */
   recurringDeliveries: boolean;
 }
 
 export interface Attribute {
   /**
-   * The key for the attribute.
+   * The identifier for the attribute. Each key must be unique within the
+   * set of attributes on the cart or checkout. If you call
+   * `applyAttributeChange()` with a key that already exists, then the
+   * existing value is replaced.
+   *
+   * @example 'gift_wrapping'
    */
   key: string;
 
   /**
-   * The value for the attribute.
+   * The value associated with the attribute key. This is a freeform string
+   * that can store any information the buyer or app provides.
+   *
+   * @example 'Please use red wrapping paper'
    */
   value: string;
 }
 
 export interface MailingAddress {
   /**
-   * The buyer's full name.
+   * The buyer's full name, typically a combination of first and last name.
+   * The value is `undefined` if the buyer didn't provide a name.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -52,7 +73,10 @@ export interface MailingAddress {
   name?: string;
 
   /**
-   * The buyer's first name.
+   * The buyer's first name. Use this alongside `lastName` when you need to
+   * display or process name parts separately. The value is `undefined` if
+   * the buyer didn't provide a first name or the store doesn't collect
+   * split names.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -61,7 +85,10 @@ export interface MailingAddress {
   firstName?: string;
 
   /**
-   * The buyer's last name.
+   * The buyer's last name. Use this alongside `firstName` when you need to
+   * display or process name parts separately. The value is `undefined` if
+   * the buyer didn't provide a last name or the store doesn't collect
+   * split names.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -70,7 +97,8 @@ export interface MailingAddress {
   lastName?: string;
 
   /**
-   * The buyer's company name.
+   * The buyer's company name. The value is `undefined` if the buyer didn't
+   * enter a company or the store doesn't collect company names.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -79,7 +107,8 @@ export interface MailingAddress {
   company?: string;
 
   /**
-   * The first line of the buyer's address, including street name and number.
+   * The first line of the street address, including the street number and
+   * name. The value is `undefined` if the buyer hasn't entered an address yet.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -88,7 +117,9 @@ export interface MailingAddress {
   address1?: string;
 
   /**
-   * The second line of the buyer's address, like apartment number, suite, etc.
+   * The second line of the buyer's address, such as apartment number, suite,
+   * or unit. The value is `undefined` if the buyer didn't provide a second
+   * address line.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -97,7 +128,8 @@ export interface MailingAddress {
   address2?: string;
 
   /**
-   * The buyer's city.
+   * The city, town, or village of the address. The value is `undefined` if
+   * the buyer hasn't entered a city yet.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -106,7 +138,9 @@ export interface MailingAddress {
   city?: string;
 
   /**
-   * The buyer's postal or ZIP code.
+   * The postal code or ZIP code of the address, used for mail sorting and
+   * delivery routing. The value is `undefined` if the buyer hasn't entered
+   * one yet or the country doesn't use postal codes.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -115,7 +149,9 @@ export interface MailingAddress {
   zip?: string;
 
   /**
-   * The ISO 3166 Alpha-2 format for the buyer's country. Refer to https://www.iso.org/iso-3166-country-codes.html.
+   * The two-letter country code in [ISO 3166 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+   * format. The value is `undefined` if the buyer hasn't selected a country
+   * yet.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -124,7 +160,9 @@ export interface MailingAddress {
   countryCode?: CountryCode;
 
   /**
-   * The buyer's province code, such as state, province, prefecture, or region.
+   * The province, state, prefecture, or region code of the address. The
+   * format varies by country. The value is `undefined` if the buyer hasn't
+   * selected one yet or the country doesn't have provinces.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -133,18 +171,23 @@ export interface MailingAddress {
   provinceCode?: string;
 
   /**
-   * The buyer's phone number.
+   * The phone number associated with the address, typically in international
+   * format. The value is `undefined` if the buyer didn't provide a phone
+   * number or the store doesn't collect phone numbers.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
-   * @example '+1 613 111 2222'.
+   * @example '+1 613 111 2222'
    */
   phone?: string;
 }
 
 export interface ShippingAddress extends MailingAddress {
   /**
-   * Specifies whether the address should be saved to the buyer's account.
+   * Controls whether the address is saved to the buyer's account. When
+   * `true`, the address won't be saved and is only used for this checkout.
+   * When `false` or `undefined`, the address might be saved to the buyer's
+   * account for future use.
    */
   oneTimeUse?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -14,14 +14,14 @@ export interface ValidationError {
    *
    * @example '$.cart.deliveryGroups[0].deliveryAddress.countryCode'
    *
-   * See the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)
+   * See the [supported targets](https://shopify.dev/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)
    * for more information.
    */
   target?: string;
 }
 
 /**
- * A [selling plan](/docs/apps/build/purchase-options/subscriptions) represents a recurring or deferred purchasing option for a product, such as a subscription, pre-order, or try-before-you-buy plan. The merchant configures selling plans to define how and when the buyer is charged.
+ * A [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions) represents a recurring or deferred purchasing option for a product, such as a subscription, pre-order, or try-before-you-buy plan. The merchant configures selling plans to define how and when the buyer is charged.
  */
 export interface SellingPlan {
   /**
@@ -66,7 +66,7 @@ export interface MailingAddress {
    * The buyer's full name, typically a combination of first and last name.
    * The value is `undefined` if the buyer didn't provide a name.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'John Doe'
    */
@@ -78,7 +78,7 @@ export interface MailingAddress {
    * the buyer didn't provide a first name or the store doesn't collect
    * split names.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'John'
    */
@@ -90,7 +90,7 @@ export interface MailingAddress {
    * the buyer didn't provide a last name or the store doesn't collect
    * split names.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'Doe'
    */
@@ -100,7 +100,7 @@ export interface MailingAddress {
    * The buyer's company name. The value is `undefined` if the buyer didn't
    * enter a company or the store doesn't collect company names.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'Shopify'
    */
@@ -110,7 +110,7 @@ export interface MailingAddress {
    * The first line of the street address, including the street number and
    * name. The value is `undefined` if the buyer hasn't entered an address yet.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example '151 O'Connor Street'
    */
@@ -121,7 +121,7 @@ export interface MailingAddress {
    * or unit. The value is `undefined` if the buyer didn't provide a second
    * address line.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'Ground floor'
    */
@@ -131,7 +131,7 @@ export interface MailingAddress {
    * The city, town, or village of the address. The value is `undefined` if
    * the buyer hasn't entered a city yet.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'Ottawa'
    */
@@ -142,7 +142,7 @@ export interface MailingAddress {
    * delivery routing. The value is `undefined` if the buyer hasn't entered
    * one yet or the country doesn't use postal codes.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'K2P 2L8'
    */
@@ -153,7 +153,7 @@ export interface MailingAddress {
    * format. The value is `undefined` if the buyer hasn't selected a country
    * yet.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'CA' for Canada.
    */
@@ -164,7 +164,7 @@ export interface MailingAddress {
    * format varies by country. The value is `undefined` if the buyer hasn't
    * selected one yet or the country doesn't have provinces.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'ON' for Ontario.
    */
@@ -175,7 +175,7 @@ export interface MailingAddress {
    * format. The value is `undefined` if the buyer didn't provide a phone
    * number or the store doesn't collect phone numbers.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example '+1 613 111 2222'
    */

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -4,17 +4,17 @@ import type {ShippingOption} from '../standard/standard';
 /** @publicDocs */
 export interface ShippingOptionItemApi {
   /**
-   * The shipping option the extension is attached to.
+   * The shipping option that this extension is attached to. Use this to read the option's cost, carrier, delivery estimate, and other details.
    */
   target: SubscribableSignalLike<ShippingOption>;
 
   /**
-   * Whether the shipping option the extension is attached to is currently selected in the UI.
+   * Whether the shipping option this extension is attached to is currently selected by the buyer. When `true`, the buyer has chosen this option. When `false`, the buyer has selected a different shipping option.
    */
   isTargetSelected: SubscribableSignalLike<boolean>;
 
   /**
-   * The render mode of the shipping option.
+   * The render mode of this shipping option, indicating how the extension is displayed in the checkout UI.
    */
   renderMode: ShippingOptionItemRenderMode;
 }
@@ -24,7 +24,7 @@ export interface ShippingOptionItemApi {
  */
 export interface ShippingOptionItemRenderMode {
   /**
-   * Whether the shipping option is rendered in an overlay.
+   * Whether the shipping option is rendered in an overlay. When `true`, the extension appears in a modal or sheet on top of the checkout page. When `false`, the extension renders inline within the shipping options list.
    */
   overlay: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -9,7 +9,7 @@ export interface ShippingOptionItemApi {
   target: SubscribableSignalLike<ShippingOption>;
 
   /**
-   * Whether the shipping option this extension is attached to is currently selected by the buyer. When `true`, the buyer has chosen this option. When `false`, the buyer has selected a different shipping option.
+   * Whether the buyer has selected the target shipping option. When `true`, the target option is the buyer's active choice. When `false`, the buyer has chosen a different shipping option.
    */
   isTargetSelected: SubscribableSignalLike<boolean>;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
@@ -28,7 +28,7 @@ export interface DeliveryGroupList {
    * The type of delivery groups in this list. This is the same `DeliveryGroupType` used on `DeliveryGroup.groupType`.
    *
    * - `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.
-   * - `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.
+   * - `'subscription'`: Items bought through a [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.
    */
   groupType: DeliveryGroupType;
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-list.ts
@@ -9,11 +9,11 @@ import type {
 /** @publicDocs */
 export interface ShippingOptionListApi {
   /**
-   * The delivery group list the extension is attached to. The target will be undefined when there are no groups for a given type.
+   * The delivery group list that this extension is attached to. Use this to access all delivery groups and their options. The value is `undefined` when there aren't any delivery groups for the given type.
    */
   target: SubscribableSignalLike<DeliveryGroupList | undefined>;
   /**
-   * The list of selection groups available to the buyers. The property will be undefined when no such groups are available.
+   * The list of delivery selection groups available to the buyer, which let buyers choose between grouped delivery options. The value is `undefined` when no selection groups are available.
    */
   deliverySelectionGroups: SubscribableSignalLike<
     DeliverySelectionGroup[] | undefined
@@ -21,45 +21,48 @@ export interface ShippingOptionListApi {
 }
 
 /**
- * The delivery group list the extension is associated to.
+ * A collection of delivery groups that share the same group type.
  */
 export interface DeliveryGroupList {
   /**
-   * The group type of the delivery group list.
+   * The type of delivery groups in this list. This is the same `DeliveryGroupType` used on `DeliveryGroup.groupType`.
+   *
+   * - `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.
+   * - `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.
    */
   groupType: DeliveryGroupType;
   /**
-   * The delivery groups that compose this list.
+   * The delivery groups in this list. Each group contains cart lines and available delivery options for those items.
    */
   deliveryGroups: DeliveryGroup[];
 }
 
 /**
- * A selection group for delivery options.
+ * A named group of delivery options that the buyer can select as a unit.
  */
 export interface DeliverySelectionGroup {
   /**
-   * The handle of the selection group.
+   * A unique identifier for this selection group.
    */
   handle: string;
   /**
-   * If the selection group is selected.
+   * Whether the buyer has selected this delivery selection group. When `true`, the associated delivery options are active. When `false`, the buyer has selected a different group.
    */
   selected: boolean;
   /**
-   * The localized title of the selection group.
+   * The localized display title of this selection group, suitable for rendering in the checkout UI.
    */
   title: string;
   /**
-   * The associated delivery option handles with the selection group. The handles will match the delivery group's delivery option handles.
+   * The delivery options that belong to this selection group. Each reference's `handle` matches a delivery option handle in the associated delivery group.
    */
   associatedDeliveryOptions: DeliveryOptionReference[];
   /**
-   * The sum of each delivery option's cost.
+   * The combined cost of all delivery options in this group before discounts.
    */
   cost: Money;
   /**
-   * The sum of each delivery option's cost after discounts.
+   * The combined cost of all delivery options in this group after discounts have been applied. This is what the buyer actually pays.
    */
   costAfterDiscounts: Money;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1911,10 +1911,9 @@ export interface VisitorConsent {
    */
   preferences?: boolean;
   /**
-   * Whether the visitor has opted out of the sale or sharing of their personal
-   * data with third parties. `true` means the visitor has opted out, `false`
-   * means they haven't opted out, and `undefined` means no decision has been
-   * made yet.
+   * The visitor's consent for the sale or sharing of their personal data with
+   * third parties. `true` means the visitor actively granted consent, `false`
+   * means actively denied, and `undefined` means no decision has been made yet.
    */
   saleOfData?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -24,7 +24,7 @@ export type {ApiVersion, Capability} from '../../../../shared';
 /**
  * A key-value storage object for the extension.
  *
- * Stored data is only available to this specific extension
+ * Stored data is available only to this specific extension
  * and any of its instances.
  *
  * The storage backend is implemented with `localStorage` and
@@ -78,7 +78,7 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.
    *
-   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that will be honored on Shopify-managed services.
+   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that are honored on Shopify-managed services.
    *
    * * [`iframe.sources`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe.
    */
@@ -87,7 +87,7 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * Information about the editor where the extension is being rendered.
    *
-   * If the value is undefined, then the extension is not running in an editor.
+   * If the value is undefined, then the extension isn't running in an editor.
    */
   editor?: Editor;
 
@@ -95,7 +95,7 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
    * A Boolean to show whether your extension is currently rendered to the screen.
    *
    * Shopify might render your extension before it's visible in the UI,
-   * typically to pre-render extensions that will appear on a later step of the
+   * typically to pre-render extensions that appear on a later step of the
    * checkout.
    *
    * Your extension might also continue to run after the customer has navigated away
@@ -110,9 +110,9 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
   scriptUrl: string;
 
   /**
-   * The identifier that specifies where in Shopify’s UI your code is being
-   * injected. This will be one of the targets you have included in your
-   * extension’s configuration file.
+   * The identifier that specifies where in Shopify's UI your code is being
+   * injected. This is one of the targets you've included in your
+   * extension's configuration file.
    *
    * @example 'purchase.checkout.block.render'
    * @see https://shopify.dev/docs/api/checkout-ui-extensions/latest/extension-targets-overview
@@ -132,86 +132,129 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
 
 export interface Editor {
   /**
-   * Indicates whether the extension is rendering in the checkout editor.
+   * Indicates whether the extension is rendering in the [checkout editor](/docs/apps/checkout). Always `'checkout'`.
    */
   type: 'checkout';
 }
 
 /**
- * Metadata associated with the checkout.
+ * Metadata associated with the checkout. See the [metafields documentation](/docs/apps/build/custom-data/metafields) for more information on how metafields work.
  */
 export interface Metafield {
   /**
-   * The name of the metafield. It must be between 3 and 30 characters in
+   * The name of the metafield. It must be between three and 30 characters in
    * length (inclusive).
+   *
+   * @example 'delivery_instructions'
    */
   key: string;
 
   /**
    * A container for a set of metafields. You need to define a custom
    * namespace for your metafields to distinguish them from the metafields
-   * used by other apps. This must be between 2 and 20 characters in length (inclusive).
+   * used by other apps. This must be between two and 20 characters in length (inclusive).
+   *
+   * @example 'my_app'
    */
   namespace: string;
 
   /**
-   * The information to be stored as metadata. Always stored as a string, regardless of the metafield's type.
+   * The information to be stored as metadata.
    */
   value: string | number;
 
-  /** The metafield’s information type. */
+  /**
+   * The metafield's information type.
+   *
+   * - `'integer'`: A whole number value.
+   * - `'string'`: A plain text value.
+   * - `'json_string'`: A JSON-encoded string value.
+   */
   valueType: 'integer' | 'string' | 'json_string';
 }
 
 /**
- * Represents a custom metadata attached to a resource.
+ * Represents a custom [metafield](/docs/apps/build/custom-data/metafields) attached to a resource such as a product, variant, customer, or shop.
  */
 export interface AppMetafield {
-  /** The key name of a metafield. */
+  /**
+   * The identifier for the metafield within its namespace, such as `'ingredients'` or `'shipping_weight'`.
+   */
   key: string;
 
   /**
-   * The namespace for a metafield.
+   * The namespace that the metafield belongs to. Namespaces group related metafields and prevent naming collisions between different apps.
    *
    * App owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.
    */
   namespace: string;
 
-  /** The value of a metafield. */
+  /**
+   * The value of a metafield, stored as a string regardless of the underlying type. For JSON metafields, parse the string to access structured data.
+   */
   value: string;
 
-  /** The metafield’s information type. */
+  /**
+   * The metafield's information type.
+   *
+   * - `'boolean'`: A true or false value.
+   * - `'float'`: A decimal number value.
+   * - `'integer'`: A whole number value.
+   * - `'json_string'`: A JSON-encoded string value.
+   * - `'string'`: A plain text value.
+   */
   valueType: 'boolean' | 'float' | 'integer' | 'json_string' | 'string';
 
-  /** The metafield's type name. */
+  /**
+   * The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`. This is the full type identifier, whereas `valueType` is a simplified category.
+   */
   type: string;
 }
 
 /**
- * Represents a custom metadata attached to a resource.
+ * Represents a custom metadata attached to the cart. Unlike `AppMetafield`, cart metafield values are always strings and don't include a `valueType` discriminator.
+ *
+ * Cart [metafields](/docs/apps/build/custom-data/metafields) are set by extensions using `applyMetafieldChange()` and can be copied to order metafields at order creation time.
  */
 export interface CartMetafield {
-  /** The key name of a metafield. */
+  /**
+   * The key name of a metafield, such as `'delivery_instructions'` or `'gift_message'`. Together with `namespace`, this uniquely identifies the metafield on the cart.
+   */
   key: string;
 
-  /** The namespace for a metafield. */
+  /**
+   * The namespace for a metafield, such as `'custom'` or `'my_app'`. Together with `key`, this uniquely identifies the metafield on the cart.
+   */
   namespace: string;
 
-  /** The value of a metafield. */
+  /**
+   * The string value stored in the cart metafield. Unlike `AppMetafield`, cart metafield values are always strings.
+   */
   value: string;
 
-  /** The metafield's type name. */
+  /**
+   * The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`.
+   */
   type: string;
 }
 
 /**
- * The metafield owner.
+ * The Shopify resource that a metafield is attached to. Each entry identifies a specific resource by its type and globally-unique ID, so your extension can determine where the metafield data originates.
  */
 export interface AppMetafieldEntryTarget {
   /**
-   * The type of the metafield owner.
+   * The kind of Shopify resource this metafield belongs to:
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.
+   * - `'customer'`: The customer who placed the order.
+   * - `'product'`: A product in the merchant's catalog.
+   * - `'shop'`: The merchant's shop.
+   * - `'shopUser'`: A staff member or collaborator account on the shop.
+   * - `'variant'`: A specific variant of a product.
+   * - `'company'`: A [B2B](/docs/apps/build/b2b) company associated with the order.
+   * - `'companyLocation'`: A location belonging to a [B2B](/docs/apps/build/b2b) company.
+   * - `'cart'`: The cart associated with the checkout.
+   *
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.
    */
   type:
     | 'customer'
@@ -223,22 +266,28 @@ export interface AppMetafieldEntryTarget {
     | 'companyLocation'
     | 'cart';
 
-  /** The numeric owner ID that is associated with the metafield. */
+  /**
+   * The globally-unique identifier of the Shopify resource, in [GID](https://shopify.dev/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the GraphQL API.
+   *
+   * @example 'gid://shopify/Product/123'
+   */
   id: string;
 }
 
 /**
- * A metafield associated with the shop or a resource on the checkout.
+ * An entry that pairs a Shopify resource with one of its [metafields](/docs/apps/build/custom-data/metafields). Each entry contains a `target` identifying which resource the metafield belongs to and a `metafield` object with the actual data.
  */
 export interface AppMetafieldEntry {
   /**
-   * The target that is associated to the metadata.
+   * The Shopify resource that this metafield is attached to, including the resource type (such as `'product'` or `'customer'`) and its globally-unique ID.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.
    */
   target: AppMetafieldEntryTarget;
 
-  /** The metadata information. */
+  /**
+   * The metafield data, including the namespace, key, value, and content type. Use the `namespace` and `key` together to uniquely identify the metafield within its resource.
+   */
   metafield: AppMetafield;
 }
 
@@ -266,7 +315,7 @@ export interface I18n {
    * This function behaves like the standard `Intl.NumberFormat()`
    * with a style of `decimal` applied. It uses the buyer's locale by default.
    *
-   * @param options.inExtensionLocale - if true, use the extension's locale
+   * @param options.inExtensionLocale - If true, uses the extension's locale.
    */
   formatNumber: (
     number: number | bigint,
@@ -279,7 +328,7 @@ export interface I18n {
    * This function behaves like the standard `Intl.NumberFormat()`
    * with a style of `currency` applied. It uses the buyer's locale by default.
    *
-   * @param options.inExtensionLocale - if true, use the extension's locale
+   * @param options.inExtensionLocale - If true, uses the extension's locale.
    */
   formatCurrency: (
     number: number | bigint,
@@ -296,7 +345,7 @@ export interface I18n {
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat0
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options
    *
-   * @param options.inExtensionLocale - if true, use the extension's locale
+   * @param options.inExtensionLocale - If true, uses the extension's locale.
    */
   formatDate: (
     date: Date,
@@ -317,80 +366,63 @@ export interface I18n {
 
 export interface Language {
   /**
-   * The BCP-47 language tag. It may contain a dash followed by an ISO 3166-1 alpha-2 region code.
-   *
-   * @example 'en' for English, or 'en-US' for English local to United States.
-   * @see https://en.wikipedia.org/wiki/IETF_language_tag
-   * @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+   * The [BCP-47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag that identifies the language. This is a standardized code that might include a base language and an optional region subtag separated by a dash. For example, `'en'` represents English and `'en-US'` represents English as used in the United States. The region subtag follows the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) standard.
    */
   isoCode: string;
 }
 
 export interface Currency {
   /**
-   * The ISO-4217 code for this currency.
-   * @see https://www.iso.org/iso-4217-currency-codes.html
+   * The three-letter currency code in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) format, such as `'USD'`, `'EUR'`, or `'CAD'`.
    */
   isoCode: CurrencyCode;
 }
 
+/**
+ * A [Shopify Market](/docs/apps/build/markets) that represents a group of one or more regions for international selling.
+ */
 export interface Market {
   /**
-   * A globally-unique identifier for a market.
+   * A globally-unique identifier for the market in the format `gid://shopify/Market/<id>`.
    */
   id: string;
 
   /**
-   * The human-readable, shop-scoped identifier for the market.
+   * The human-readable, shop-scoped identifier for the market, such as `'us'` or `'eu'`. Merchants define these handles when configuring [Shopify Markets](/docs/apps/build/markets).
    */
   handle: string;
 }
 
 export interface Localization {
   /**
-   * The currency that the customer sees for money amounts in the checkout.
+   * The currency that the buyer sees for money amounts in the checkout. Use this value to format prices and totals in the buyer's expected currency.
    */
   currency: SubscribableSignalLike<Currency>;
 
   /**
-   * The buyer’s time zone.
+   * The buyer's time zone, derived from their browser or account settings. Use this value to format dates and times relative to the buyer's local time.
    */
   timezone: SubscribableSignalLike<Timezone>;
 
   /**
-   * The language the customer sees in the checkout.
+   * The language the buyer sees in the checkout. This reflects the language selected by the buyer or determined by their browser settings, and might differ from the languages your extension supports.
    */
   language: SubscribableSignalLike<Language>;
 
   /**
-   * This is the customer's language, as supported by the extension.
-   * If the customer's actual language is not supported by the extension,
-   * then this is the language that is used for translations.
-   *
-   * For example, if the customer's language is 'fr-CA' but your extension
-   * only supports translations for 'fr', then the `isoCode` for this
-   * language is 'fr'. If your extension does not provide french
-   * translations at all, then this value is the default locale for your
-   * extension (that is, the one matching your .default.json file).
+   * The best available language match for your extension based on the buyer's language. If the buyer's language is `'fr-CA'` but your extension supports only `'fr'`, this returns `'fr'`. If your extension doesn't support any variant of the buyer's language, this falls back to your extension's default locale (the `.default.json` translation file). Use this value to load the correct translation file for your extension.
    */
   extensionLanguage: SubscribableSignalLike<Language>;
 
   /**
-   * The country context of the checkout. This value carries over from the
-   * context of the cart, where it was used to contextualize the storefront
-   * experience. It will update if the buyer changes the country of their
-   * shipping address. If the country is unknown, then the value is undefined.
+   * The country context of the checkout, carried over from the cart context where it was used to contextualize the storefront experience. It updates when the buyer changes the country of their shipping address. Use this value to display region-specific content such as local support information or regional policies. The value is `undefined` if the buyer's country is unknown.
    */
   country: SubscribableSignalLike<Country | undefined>;
 
   /**
-   * The [market](https://shopify.dev/docs/apps/markets) context of the
-   * checkout. This value carries over from the context of the cart, where it
-   * was used to contextualize the storefront experience. It will update if the
-   * buyer changes the country of their shipping address.  If the market is unknown,
-   * then the value is undefined.
+   * The [market](/docs/apps/build/markets) context of the checkout, carried over from the cart context. Markets group countries and regions with shared pricing, languages, and domains. It updates when the buyer changes the country of their shipping address. The value is `undefined` if the market is unknown.
    *
-   * > Caution: This field is deprecated and will be removed in a future version.
+   * > Caution: This field is deprecated and is removed in a future version.
    *
    * @deprecated Deprecated as of version `2025-04`
    */
@@ -398,8 +430,23 @@ export interface Localization {
 }
 
 export interface LocalizedField {
+  /**
+   * The identifier for the localized field, indicating the type of information
+   * collected (for example, a tax credential or shipping credential for a
+   * specific country).
+   */
   key: LocalizedFieldKey;
+
+  /**
+   * The localized display label for the field, suitable for rendering in the UI.
+   *
+   * @example 'CPF/CNPJ' for a Brazilian tax credential
+   */
   title: string;
+
+  /**
+   * The current value entered by the buyer for this field.
+   */
   value: string;
 }
 
@@ -411,7 +458,7 @@ export interface BuyerJourney {
    * Installs a function for intercepting and preventing progress on checkout.
    *
    * This returns a promise that resolves to a teardown function. Calling the
-   * teardown function will remove the interceptor.
+   * teardown function removes the interceptor.
    *
    * To block checkout progress, you must set the [block_progress](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress)
    * capability in your extension's configuration.
@@ -419,23 +466,21 @@ export interface BuyerJourney {
    * If you do, then you're expected to inform the buyer why navigation was blocked,
    * either by passing validation errors to the checkout UI or rendering the errors in your extension.
    *
-   * It is good practice to show a warning in the checkout editor when the merchant has not given permission for your extension
+   * It's good practice to show a warning in the checkout editor when the merchant hasn't given permission for your extension
    * to block checkout progress.
    */
   intercept(interceptor: Interceptor): Promise<() => void>;
 
   /**
-   * This subscribable value will be true if the buyer completed submitting their order.
-   *
-   * For example, when viewing the **Order status** page after submitting payment, the buyer will have completed their order.
+   * Whether the buyer has completed submitting their order. When `true`, the buyer is on the order status page after submitting payment. When `false`, the buyer is still in the checkout flow.
    */
   completed: SubscribableSignalLike<boolean>;
   /**
-   * All possible steps a buyer can take to complete the checkout. These steps may vary depending on the type of checkout or the shop's configuration.
+   * All possible steps the buyer can take to complete checkout. These steps vary depending on whether the checkout is one-page or three-page, and on the shop's configuration.
    */
   steps: SubscribableSignalLike<BuyerJourneyStep[]>;
   /**
-   * What step of checkout the buyer is currently on.
+   * The step of checkout the buyer is currently on. The value is `undefined` if the current step can't be determined.
    */
   activeStep: SubscribableSignalLike<BuyerJourneyStepReference | undefined>;
 }
@@ -467,29 +512,32 @@ type BuyerJourneyStepHandle =
  */
 interface BuyerJourneyStepReference {
   /**
-   * The handle that uniquely identifies the buyer journey step.
+   * The handle identifying which step the buyer is on, such as `'information'`,
+   * `'shipping'`, or `'payment'`. See `BuyerJourneyStepHandle` for all values.
    */
   handle: BuyerJourneyStepHandle;
 }
 
 export interface BuyerJourneyStep {
   /**
-   * The handle that uniquely identifies the buyer journey step.
+   * The handle that uniquely identifies the buyer journey step, such as `'information'`, `'shipping'`, or `'payment'`.
    */
   handle: BuyerJourneyStepHandle;
   /**
-   * The localized label of the buyer journey step.
+   * The localized label of the buyer journey step, suitable for rendering in navigation UI.
    */
   label: string;
   /**
-   * The url of the buyer journey step. This property leverages the `shopify:` protocol
-   * E.g. `shopify:cart` or `shopify:checkout/information`.
+   * The URL of the buyer journey step, using the `shopify:` protocol.
+   *
+   * @example 'shopify:cart'
+   * @example 'shopify:checkout/information'
    */
   to: string;
   /**
-   * The disabled state of the buyer journey step. This value will be true if the buyer has not reached the step yet.
+   * Whether this step is disabled. When `true`, the buyer hasn't reached this step yet and can't navigate to it. When `false`, the step is accessible.
    *
-   * For example, if the buyer has not reached the `shipping` step yet, `shipping` would be disabled.
+   * For example, if the buyer hasn't reached the `shipping` step yet, then `shipping` is disabled.
    */
   disabled: boolean;
 }
@@ -502,19 +550,21 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   analytics: Analytics;
 
   /**
-   * Gift Cards that have been applied to the checkout.
+   * The gift cards that have been applied to the checkout. Each entry includes
+   * the last four characters of the gift card code, the amount used at
+   * checkout, and the card's remaining balance.
    */
   appliedGiftCards: SubscribableSignalLike<AppliedGiftCard[]>;
 
   /**
    * The cart instructions used to create the checkout and possibly limit extension capabilities.
    *
-   * These instructions should be checked prior to performing any actions that may be affected by them.
+   * These instructions should be checked before performing any actions that might be affected by them.
    *
    * For example, if you intend to add a discount code via the `applyDiscountCodeChange` method,
    * check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.
    *
-   * > Caution: As of version `2024-07`, UI extension code must check for instructions before calling select APIs in case those APIs are not available.
+   * > Caution: As of version `2024-07`, UI extension code must check for instructions before calling select APIs in case those APIs aren't available.
    *  See the [update guide](/docs/api/checkout-ui-extensions/apis/cart-instructions#examples) for more information.
    *
    */
@@ -526,31 +576,31 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * file. These metafields are updated when there's a change in the merchandise items
    * being purchased by the customer.
    *
-   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` is not supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.
+   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` isn't supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   appMetafields: SubscribableSignalLike<AppMetafieldEntry[]>;
 
   /**
-   * The custom attributes left by the customer to the merchant, either in their cart or during checkout.
+   * The custom key-value attributes attached to the cart or checkout. These are set by the buyer or by an extension using `applyAttributeChange()`. The list is empty if no attributes have been added.
    */
   attributes: SubscribableSignalLike<Attribute[]>;
 
   /**
-   * All available payment options.
+   * All payment options available to the buyer for this checkout, such as credit cards, wallets, and local payment methods. The list depends on the shop's payment configuration and the buyer's region.
    */
   availablePaymentOptions: SubscribableSignalLike<PaymentOption[]>;
 
   /**
-   * Information about the buyer that is interacting with the checkout.
+   * Information about the buyer that's interacting with the checkout.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   buyerIdentity?: BuyerIdentity;
 
   /**
-   * Provides details on the buyer's progression through the checkout.
+   * Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.
    *
    * Refer to [buyer journey](https://shopify.dev/docs/api/checkout-ui-extensions/apis/buyer-journey#examples)
    * examples for more information.
@@ -565,28 +615,32 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * A stable ID that represents the current checkout.
    *
+   * The value is `undefined` when the checkout hasn't been created on the server yet.
+   *
+   * Use this to correlate checkout sessions across your extension, web pixels, and backend systems.
+   *
    * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](https://shopify.dev/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)
    * and the `checkout_token` field in the [REST Admin API `Order` resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
    */
   checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;
 
   /**
-   * Details on the costs the buyer will pay for this checkout.
+   * The cost breakdown for the current checkout, including subtotal, shipping, tax, and total amounts. These values update as the buyer progresses through checkout and new costs are negotiated.
    */
   cost: CartCost;
 
   /**
-   * A list of delivery groups containing information about the delivery of the items the customer intends to purchase.
+   * The delivery groups for this checkout. Each group contains one or more cart lines and the available delivery options (shipping, pickup point, or pickup location) for those items.
    */
   deliveryGroups: SubscribableSignalLike<DeliveryGroup[]>;
 
   /**
-   * A list of discount codes currently applied to the checkout.
+   * The discount codes currently applied to the checkout. The list is empty if no discount codes have been applied. Use `applyDiscountCodeChange()` to add or remove codes.
    */
   discountCodes: SubscribableSignalLike<CartDiscountCode[]>;
 
   /**
-   * Discounts that have been applied to the entire cart.
+   * The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from Shopify Functions. Each allocation indicates how much was discounted and how the discount was triggered.
    */
   discountAllocations: SubscribableSignalLike<CartDiscountAllocation[]>;
 
@@ -596,9 +650,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   extension: Extension<Target>;
 
   /**
-   * The identifier that specifies where in Shopify’s UI your code is being
-   * injected. This will be one of the targets you have included in your
-   * extension’s configuration file.
+   * The identifier that specifies where in Shopify's UI your code is being
+   * injected. This is one of the targets you've included in your
+   * extension's configuration file.
    *
    * @example 'purchase.checkout.block.render'
    * @see https://shopify.dev/docs/api/checkout-ui-extensions/latest/extension-targets-overview
@@ -619,7 +673,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   i18n: I18n;
 
   /**
-   * A list of lines containing information about the items the customer intends to purchase.
+   * The list of line items the buyer intends to purchase. Each entry includes the merchandise, quantity, cost, and any custom attributes. Use `applyCartLinesChange()` to add, remove, or update line items.
    */
   lines: SubscribableSignalLike<CartLine[]>;
 
@@ -633,6 +687,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * A note left by the customer to the merchant, either in their cart or during checkout.
+   *
+   * The value is `undefined` if the buyer hasn't entered a note. Use this to display or react to order-level instructions such as delivery preferences or gift messages.
    */
   note: SubscribableSignalLike<string | undefined>;
 
@@ -647,16 +703,16 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
 
   /**
-   * Payment options selected by the buyer.
+   * The payment options the buyer has currently selected. This updates as the buyer changes their payment method. The array can contain multiple entries when the buyer splits payment across methods (for example, a gift card and a credit card).
    */
   selectedPaymentOptions: SubscribableSignalLike<SelectedPaymentOption[]>;
 
   /**
    * The session token providing a set of claims as a signed JSON Web Token (JWT).
    *
-   * The token has a TTL of 5 minutes.
+   * The token has a TTL of five minutes.
    *
-   * If the previous token expires, this value will reflect a new session token with a new signature and expiry.
+   * If the previous token expires, this value reflects a new session token with a new signature and expiry.
    *
    * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
    */
@@ -668,15 +724,15 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    *  Refer to [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.
    *
-   * > Note: When an extension is being installed in the editor, the settings will be empty until
-   * a merchant sets a value. In that case, this object will be updated in real time as a merchant fills in the settings.
+   * > Note: When an extension is being installed in the editor, the settings are empty until
+   * a merchant sets a value. In that case, this object updates in real time as a merchant fills in the settings.
    */
   settings: SubscribableSignalLike<ExtensionSettings>;
 
   /**
    * The proposed customer shipping address. During the information step, the address
    * updates when the field is committed (on change) rather than every keystroke.
-   * An address value is only present if delivery is required. Otherwise, the
+   * An address value is present only if delivery is required. Otherwise, the
    * subscribable value is undefined.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
@@ -719,7 +775,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   customerPrivacy: SubscribableSignalLike<CustomerPrivacy>;
 
   /**
-   * Allows setting and updating customer privacy consent settings and tracking consent metafields.
+   * Enables setting and updating customer privacy consent settings and tracking consent metafields.
    *
    * > Note: Requires the [`customer_privacy` capability](https://shopify.dev/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be set to `true`.
    *
@@ -728,8 +784,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   applyTrackingConsentChange: ApplyTrackingConsentChangeType;
 
   /**
-   * The API for reading additional fields that are required in checkout under certain circumstances.
-   * For example, some countries require additional fields for customs information or tax identification numbers.
+   * Additional region-specific fields required during checkout, such as tax identification numbers (Brazil's CPF/CNPJ) or customs credentials. The value is `undefined` if the current checkout doesn't require any localized fields.
    */
   localizedFields?: SubscribableSignalLike<LocalizedField[]>;
 }
@@ -738,15 +793,20 @@ export interface SessionToken {
   /**
    * Requests a session token that hasn't expired. You should call this method every
    * time you need to make a request to your backend in order to get a valid token.
-   * This method will return cached tokens when possible, so you don’t need to worry
+   * This method returns cached tokens when possible, so you don't need to worry
    * about storing these tokens yourself.
    */
   get(): Promise<string>;
 }
 
+/**
+ * Information about the buyer who is completing the checkout.
+ *
+ * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data). The `customer` and `purchasingCompany` properties require level 1 access. The `email` and `phone` properties require level 2 access.
+ */
 export interface BuyerIdentity {
   /**
-   * The buyer's customer account. The value is undefined if the buyer isn’t a
+   * The buyer's customer account, including their ID and whether they've accepted marketing. The value is `undefined` if the buyer isn't a
    * known customer for this shop or if they haven't logged in yet.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
@@ -754,25 +814,21 @@ export interface BuyerIdentity {
   customer: SubscribableSignalLike<Customer | undefined>;
 
   /**
-   * The email address of the buyer that is interacting with the cart.
-   * The value is `undefined` if the app does not have access to customer data.
+   * The email address associated with the checkout. This is the email the buyer provided during checkout for order confirmation and communication. The value is `undefined` if the app doesn't have access to customer data.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   email: SubscribableSignalLike<string | undefined>;
 
   /**
-   * The phone number of the buyer that is interacting with the cart.
-   * The value is `undefined` if the app does not have access to customer data.
+   * The phone number the buyer provided during checkout. The value is `undefined` if no phone number was provided or the app doesn't have access to customer data.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   phone: SubscribableSignalLike<string | undefined>;
 
   /**
-   * Provides details of the company and the company location that the business customer is purchasing on behalf of.
-   * This includes information that can be used to identify the company and the company location that the business
-   * customer belongs to.
+   * The company and company location that a B2B (business-to-business) customer is purchasing on behalf of. Use this to identify the business context of the order. The value is `undefined` if the buyer isn't a B2B customer.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -780,17 +836,17 @@ export interface BuyerIdentity {
 }
 
 /**
- * The information about a company that the business customer is purchasing on behalf of.
+ * The company and location that the [B2B](/docs/apps/build/b2b) customer is purchasing on behalf of. This is present only when the buyer is logged in as a business customer.
  */
 export interface PurchasingCompany {
   /**
-   * Includes information of the company that the business customer is purchasing on behalf of.
+   * The company the B2B customer belongs to.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   company: Company;
   /**
-   * Includes information of the company location that the business customer is purchasing on behalf of.
+   * The specific company location associated with this B2B purchase.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -799,19 +855,21 @@ export interface PurchasingCompany {
 
 export interface Company {
   /**
-   * The company ID.
+   * A globally-unique identifier for the company in the format `gid://shopify/Company/<id>`.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   *
+   * @example 'gid://shopify/Company/123'
    */
   id: string;
   /**
-   * The name of the company.
+   * The company's display name.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   name: string;
   /**
-   * The external ID of the company that can be set by the merchant.
+   * A merchant-defined external identifier for the company. The value is `undefined` if the merchant hasn't set one.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -820,19 +878,21 @@ export interface Company {
 
 export interface CompanyLocation {
   /**
-   * The company location ID.
+   * A globally-unique identifier for the company location in the format `gid://shopify/CompanyLocation/<id>`.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   *
+   * @example 'gid://shopify/CompanyLocation/123'
    */
   id: string;
   /**
-   * The name of the company location.
+   * The display name of the company location.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   name: string;
   /**
-   * The external ID of the company location that can be set by the merchant.
+   * A merchant-defined external identifier for the company location. The value is `undefined` if the merchant hasn't set one.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -841,115 +901,109 @@ export interface CompanyLocation {
 
 export interface AppliedGiftCard {
   /**
-   * The last four characters of the applied gift card's code.
+   * The last four characters of the applied gift card's code. The full code isn't exposed for security reasons. Use this value to display which card is applied.
    */
   lastCharacters: string;
 
   /**
-   * The amount of the applied gift card that will be used when the checkout is completed.
+   * The amount of the applied gift card that's used when the checkout is completed. This might be less than `balance` if the order total is lower than the card's remaining balance.
    */
   amountUsed: Money;
 
   /**
-   * The current balance of the applied gift card prior to checkout completion.
+   * The current balance of the applied gift card before checkout completion. This reflects the full remaining value on the card, not just the amount being applied to this order.
    */
   balance: Money;
 }
 
 export interface Shop {
   /**
-   * The shop ID.
+   * A globally-unique identifier for the shop in the format `gid://shopify/Shop/<id>`.
+   *
    * @example 'gid://shopify/Shop/123'
    */
   id: string;
   /**
-   * The name of the shop.
+   * The display name of the shop as configured by the merchant in Shopify admin.
    */
   name: string;
   /**
-   * The primary storefront URL.
+   * The primary storefront URL for the shop, such as `'https://example.myshopify.com'`. Use this to build links back to the merchant's online store.
    *
    * > Caution:
-   * > As of version `2024-04` this value will no longer have a trailing slash.
+   * > As of version `2024-04` this value no longer has a trailing slash.
    */
   storefrontUrl?: string;
   /**
-   * The shop's myshopify.com domain.
+   * The shop's unique `.myshopify.com` subdomain, such as `'example.myshopify.com'`. This domain is permanent and doesn't change even if the merchant adds a custom domain.
    */
   myshopifyDomain: string;
 }
 
 export interface CartCost {
   /**
-   * A `Money` value representing the subtotal value of the items in the cart at the current
-   * step of checkout.
+   * The sum of all line item prices at the current step of checkout, before shipping and taxes are applied. Use this value to display the base cost of the items the buyer purchased.
    */
   subtotalAmount: SubscribableSignalLike<Money>;
 
   /**
-   * A `Money` value representing the total shipping a buyer can expect to pay at the current
-   * step of checkout. This value includes shipping discounts. Returns undefined if shipping
-   * has not been negotiated yet, such as on the information step.
+   * The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been negotiated yet, such as when the buyer is still on the information step.
    */
   totalShippingAmount: SubscribableSignalLike<Money | undefined>;
 
   /**
-   * A `Money` value representing the total tax a buyer can expect to pay at the current
-   * step of checkout or the total tax included in product and shipping prices. Returns
-   * undefined if taxes are unavailable.
+   * The total tax the buyer can expect to pay, or the total tax already included in product and shipping prices (for tax-inclusive regions). The value is `undefined` if taxes haven't been calculated yet.
    */
   totalTaxAmount: SubscribableSignalLike<Money | undefined>;
 
   /**
-   * A `Money` value representing the minimum a buyer can expect to pay at the current
-   * step of checkout. This value excludes amounts yet to be negotiated. For example,
-   * the information step might not have delivery costs calculated.
+   * The minimum total the buyer can expect to pay at the current step of checkout. This excludes amounts that haven't been negotiated yet. For example, on the information step this won't include delivery costs because the buyer hasn't selected a shipping method. Gift cards and store credits are excluded from this total.
    */
   totalAmount: SubscribableSignalLike<Money>;
 }
 
 export interface CartLine {
   /**
-   * These line item IDs are not stable at the moment, they might change after
-   * any operations on the line items. You should always look up for an updated
-   * ID before any call to `applyCartLinesChange` because you'll need the ID to
-   * create a `CartLineChange` object.
+   * A unique identifier for the cart line in the format `gid://shopify/CartLine/<id>`. This ID isn't stable and can change after any cart operation, so avoid persisting it. Always look up the current ID before calling `applyCartLinesChange()`, because you'll need it to create a `CartLineChange` object.
+   *
    * @example 'gid://shopify/CartLine/123'
    */
   id: string;
 
   /**
-   * The merchandise being purchased.
+   * The product variant or other merchandise associated with this line item. Use this to access product details such as the title, image, SKU, and selected options.
    */
   merchandise: Merchandise;
 
   /**
-   * The quantity of the merchandise being purchased.
+   * The number of units of this merchandise that the buyer purchased.
    */
   quantity: number;
 
   /**
-   * The details about the cost components attributed to the cart line.
+   * The cost breakdown for this line item, including the total price after any line-level discounts have been applied.
    */
   cost: CartLineCost;
 
   /**
-   * The line item additional custom attributes.
+   * Custom key-value attributes attached to this cart line, such as gift messages or engraving text. Use `applyCartLinesChange()` to update these values.
    */
   attributes: Attribute[];
 
   /**
-   * Discounts applied to the cart line.
+   * Discounts applied to this cart line, including code-based, automatic, and custom discounts. Each allocation shows the discounted amount and how the discount was triggered.
    */
   discountAllocations: CartDiscountAllocation[];
 
   /**
-   * Sub lines of the merchandise line. If no sub lines are present, this will be an empty array.
+   * The individual components of a [bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component represents a separate product within the bundle. Returns an empty array if the line item isn't a bundle.
    */
   lineComponents: CartLineComponentType[];
 
   /**
-   * The relationship details between cart lines.
+   * The parent line item that this line belongs to, or `null` if this is a
+   * top-level line item. Used to identify lines added as children of a bundle
+   * or other grouped product.
    */
   parentRelationship: CartLineParentRelationship | null;
 }
@@ -960,8 +1014,8 @@ export interface CartLineParentRelationship {
    */
   parent: {
     /**
-     * These line item IDs are not stable at the moment, they might change after
-     * any operations on the line items. You should always look up for an updated
+     * These line item IDs aren't stable at the moment, and they might change after
+     * any operations on the line items. Always look up an updated
      * ID before any call to `applyCartLinesChange` because you'll need the ID to
      * create a `CartLineChange` object.
      * @example 'gid://shopify/CartLine/123'
@@ -972,35 +1026,39 @@ export interface CartLineParentRelationship {
 
 type CartLineComponentType = CartBundleLineComponent;
 
+/**
+ * An individual component within a bundled cart line. Each `CartLine` that represents a bundle has a `lineComponents` array containing these components.
+ */
 export interface CartBundleLineComponent {
+  /**
+   * Identifies this as a bundle line component. This is currently the only component type.
+   */
   type: 'bundle';
 
   /**
-   * A unique identifier for the bundle line component.
-   *
-   * This ID is not stable. If an operation updates the line items in any way, all IDs could change.
+   * A unique identifier for this component within the bundle, in the format `gid://shopify/CartLineComponent/<id>`. This ID isn't stable and might change after any operation that updates the line items.
    *
    * @example 'gid://shopify/CartLineComponent/123'
    */
   id: string;
 
   /**
-   * The merchandise of this bundle line component.
+   * The product variant included in this bundle component. Use this to display product details for individual items within a bundle.
    */
   merchandise: Merchandise;
 
   /**
-   * The quantity of merchandise being purchased.
+   * The number of units of this component included in the bundle.
    */
   quantity: number;
 
   /**
-   * The cost attributed to this bundle line component.
+   * The cost breakdown for this bundle component, including the total amount after any per-item discounts.
    */
   cost: CartLineCost;
 
   /**
-   * Additional custom attributes for the bundle line component.
+   * Custom key-value pairs attached to this bundle component, such as personalization options specific to this item within the bundle.
    *
    * @example [{key: 'engraving', value: 'hello world'}]
    */
@@ -1009,19 +1067,19 @@ export interface CartBundleLineComponent {
 
 export interface CartLineCost {
   /**
-   * The total amount after reductions the buyer can expect to pay that is directly attributable to a single
-   * cart line.
+   * The total price the buyer pays for this line item after all line-level discounts have been applied, but before order-level discounts, taxes, and shipping.
    */
   totalAmount: Money;
 }
 
 export interface Money {
   /**
-   * The price amount.
+   * The decimal amount of the price. For example, `29.99` represents twenty-nine dollars and ninety-nine cents.
    */
   amount: number;
   /**
-   * The ISO 4217 format for the currency.
+   * The three-letter currency code in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) format.
+   *
    * @example 'CAD' for Canadian dollar
    */
   currencyCode: CurrencyCode;
@@ -1031,99 +1089,110 @@ export type Merchandise = ProductVariant;
 
 export interface BaseMerchandise {
   /**
-   * The merchandise ID.
+   * A globally unique identifier for the merchandise.
+   *
+   * @example 'gid://shopify/ProductVariant/123'
    */
   id: string;
 }
 
 export interface ProductVariant extends BaseMerchandise {
+  /**
+   * Identifies the merchandise as a product variant. This is currently the only merchandise type in checkout.
+   */
   type: 'variant';
 
   /**
-   * A globally-unique identifier.
+   * A globally-unique identifier for the product variant in the format `gid://shopify/ProductVariant/<id>`.
+   *
    * @example 'gid://shopify/ProductVariant/123'
    */
   id: string;
 
   /**
-   * The product variant’s title.
+   * The display title of the product variant, such as "Small" or "Red / Large". This is the variant-specific label, not the parent product title.
    */
   title: string;
 
   /**
-   * The product variant's subtitle.
+   * A secondary description for the variant that provides additional context, such as a color or size combination. The value is `undefined` if no subtitle is available.
    */
   subtitle?: string;
 
   /**
-   * Image associated with the product variant. This field falls back to the product
-   * image if no image is available.
+   * The image associated with the product variant. Falls back to the product image if the variant doesn't have its own. The value is `undefined` if neither the variant nor the product has an image.
    */
   image?: ImageDetails;
 
   /**
-   * List of product options applied to the variant.
+   * The product options applied to this variant, such as size, color, or material. Each entry contains the option name and the selected value.
    */
   selectedOptions: SelectedOption[];
 
   /**
-   * The product object that the product variant belongs to.
+   * The parent product that this variant belongs to. Use this to access the product's ID, vendor, and type.
    */
   product: Product;
 
   /**
-   * Whether or not the product requires shipping.
+   * Whether this product variant requires physical shipping. When `true`, the buyer must provide a shipping address. Returns `false` for digital products, gift cards, and services.
    */
   requiresShipping: boolean;
 
   /**
-   * The selling plan associated with the merchandise.
+   * The [selling plan](/docs/apps/build/purchase-options/subscriptions) associated with this variant, such as a subscription or pre-order plan. The value is `undefined` if the item isn't being purchased through a selling plan.
    */
   sellingPlan?: SellingPlan;
 
   /**
-   * The product variant's sku.
+   * The stock keeping unit (SKU) assigned to this variant by the merchant, used for inventory tracking. The value is `undefined` if no SKU has been set.
    */
   sku?: string;
 }
 
 export interface Product {
   /**
-   * A globally-unique identifier.
+   * A globally-unique identifier for the product in the format `gid://shopify/Product/<id>`.
+   *
+   * @example 'gid://shopify/Product/123'
    */
   id: string;
 
   /**
-   * The product’s vendor name.
+   * The name of the product's vendor or manufacturer, as set by the merchant in Shopify admin.
    */
   vendor: string;
 
   /**
-   * A categorization that a product can be tagged with, commonly used for filtering and searching.
+   * A merchant-defined categorization for the product, such as "Accessories" or "Clothing". Commonly used for filtering and organizing products in a storefront.
    */
   productType: string;
 }
 
 export interface ImageDetails {
   /**
-   * The image URL.
+   * The fully-qualified URL of the image. Use this to render the product or variant image in your extension.
    */
   url: string;
 
   /**
-   * The alternative text for the image.
+   * The alternative text for the image, used for accessibility. The value is `undefined` if the merchant hasn't provided alt text.
    */
   altText?: string;
 }
 
 export interface SelectedOption {
   /**
-   * The name of the merchandise option.
+   * The name of the product option, such as "Color" or "Size".
+   *
+   * @example 'Size'
    */
   name: string;
 
   /**
-   * The value of the merchandise option.
+   * The selected value for the product option, such as "Red" or "Large".
+   *
+   * @example 'Large'
    */
   value: string;
 }
@@ -1135,7 +1204,7 @@ export interface PaymentOption {
   /**
    * The type of the payment option.
    *
-   * Shops can be configured to support many different payment options. Some options are only available to buyers in specific regions.
+   * Shops can be configured to support many different payment options. Some options are available only to buyers in specific regions.
    *
    * | Type  | Description  |
    * |---|---|
@@ -1145,10 +1214,10 @@ export interface PaymentOption {
    * | `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |
    * | `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |
    * | `other`  |  Another type of payment not defined here.  |
-   * | `paymentOnDelivery`  |  A payment that will be collected on delivery.  |
+   * | `paymentOnDelivery`  |  A payment collected on delivery.  |
    * | `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |
-   * | `wallet`  |  An integrated wallet such as PayPal, Google Pay, Apple Pay, etc.  |
-   * | `customOnsite` | A custom payment option that is processed through a checkout extension with a payments app. |
+   * | `wallet`  |  An integrated wallet such as PayPal, Google Pay, or Apple Pay.  |
+   * | `customOnsite` | A custom payment option that's processed through a checkout extension with a payments app. |
    */
   type:
     | 'creditCard'
@@ -1163,21 +1232,29 @@ export interface PaymentOption {
     | 'customOnsite';
 
   /**
-   * The unique handle for the payment option.
-   *
-   * This is not a globally unique identifier. It may be an identifier specific to the given checkout session or the current shop.
+   * A session-scoped identifier for this payment option. This handle isn't globally unique; it's specific to the current checkout session or the shop.
    */
   handle: string;
 }
 
+/**
+ * A payment option that the buyer has actively selected. This is the same shape as `PaymentOption` and appears in `selectedPaymentOptions`.
+ */
 export type SelectedPaymentOption = PaymentOption;
 
 export interface CartDiscountCode {
   /**
-   * The code for the discount
+   * The discount code string entered by the buyer during checkout or applied programmatically, such as `"SAVE10"` or `"FREESHIP"`. Use this to display which discount codes were applied.
    */
   code: string;
 }
+/**
+ * A discount allocation applied to the cart. Use the `type` property to determine how the discount was triggered:
+ *
+ * - `CartCodeDiscountAllocation` (`type: 'code'`) - Triggered by a discount code the buyer entered.
+ * - `CartAutomaticDiscountAllocation` (`type: 'automatic'`) - Applied automatically based on merchant-configured rules.
+ * - `CartCustomDiscountAllocation` (`type: 'custom'`) - Applied by a [Shopify Function](/docs/apps/build/discounts).
+ */
 export type CartDiscountAllocation =
   | CartCodeDiscountAllocation
   | CartAutomaticDiscountAllocation
@@ -1185,19 +1262,19 @@ export type CartDiscountAllocation =
 
 export interface CartDiscountAllocationBase {
   /**
-   * The money amount that has been discounted from the order
+   * The monetary value that was deducted from the line item or order total by this discount allocation.
    */
   discountedAmount: Money;
 }
 
 export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {
   /**
-   * The code for the discount
+   * The discount code string that the buyer entered during checkout, such as `"SAVE10"` or `"FREESHIP"`.
    */
   code: string;
 
   /**
-   * The type of the code discount
+   * Identifies this as a code-based discount, triggered by a discount code the buyer entered at checkout.
    */
   type: 'code';
 }
@@ -1205,12 +1282,12 @@ export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {
 export interface CartAutomaticDiscountAllocation
   extends CartDiscountAllocationBase {
   /**
-   * The title of the automatic discount
+   * The merchant-defined title of the automatic discount as displayed to the buyer, such as "Summer Sale 10% Off".
    */
   title: string;
 
   /**
-   * The type of the automatic discount
+   * Identifies this as an automatic discount, applied based on merchant-configured rules without a code.
    */
   type: 'automatic';
 }
@@ -1218,12 +1295,12 @@ export interface CartAutomaticDiscountAllocation
 export interface CartCustomDiscountAllocation
   extends CartDiscountAllocationBase {
   /**
-   * The title of the custom discount
+   * The title of the custom discount, typically applied by a [Shopify Function](/docs/apps/build/discounts).
    */
   title: string;
 
   /**
-   * The type of the custom discount
+   * Identifies this as a custom discount applied by a [Shopify Function](/docs/apps/build/discounts).
    */
   type: 'custom';
 }
@@ -1240,7 +1317,7 @@ interface InterceptorResultAllow {
 interface InterceptorResultBlock {
   /**
    * Indicates that some part of the checkout UI intercepted and prevented
-   * the buyer’s progress. The buyer typically needs to take some action
+   * the buyer's progress. The buyer typically needs to take some action
    * to resolve this issue and to move on to the next step.
    */
   behavior: 'block';
@@ -1252,7 +1329,7 @@ export type InterceptorRequest =
 
 interface InterceptorRequestAllow {
   /**
-   * Indicates that the interceptor will allow the buyer's journey to continue.
+   * Indicates that the interceptor allows the buyer's journey to continue.
    */
   behavior: 'allow';
 
@@ -1267,13 +1344,13 @@ interface InterceptorRequestAllow {
 // The reason is used for tracing and debugging purposes.
 interface InterceptorRequestBlock {
   /**
-   * Indicates that the interceptor will block the buyer's journey from continuing.
+   * Indicates that the interceptor blocks the buyer's journey from continuing.
    */
   behavior: 'block';
 
   /**
    * The reason for blocking the interceptor request. This value isn't presented to
-   * the buyer, so it doesn't need to be localized. The value is used only for Shopify’s
+   * the buyer, so it doesn't need to be localized. The value is used only for Shopify's
    * own internal debugging and metrics.
    */
   reason: string;
@@ -1294,8 +1371,7 @@ interface InterceptorRequestBlock {
 
 export interface InterceptorProps {
   /**
-   * Whether the interceptor has the capability to block a buyer's progress through
-   * checkout. This ability might be granted by a merchant in differing checkout contexts.
+   * Whether the interceptor can block the buyer's progress through checkout. When `true`, the merchant has granted your extension the `block_progress` capability. When `false`, you can still validate but can't prevent the buyer from continuing.
    */
   canBlockProgress: boolean;
 }
@@ -1318,7 +1394,7 @@ export type Interceptor = (
  */
 export interface Customer {
   /**
-   * Customer ID.
+   * A globally-unique identifier for the customer in the format `gid://shopify/Customer/<id>`.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -1326,65 +1402,65 @@ export interface Customer {
    */
   id: string;
   /**
-   * The email of the customer.
+   * The email address associated with the customer's account. The value is `undefined` if the app doesn't have the required access level.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   email?: string;
   /**
-   * The phone number of the customer.
+   * The phone number associated with the customer's account. The value is `undefined` if no phone number is on file or the app doesn't have the required access level.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   phone?: string;
   /**
-   * The full name of the customer.
+   * The customer's full name, typically a combination of first and last name. The value is `undefined` if the app doesn't have the required access level.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   fullName?: string;
   /**
-   * The first name of the customer.
+   * The customer's first name. The value is `undefined` if the app doesn't have the required access level.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   firstName?: string;
   /**
-   * The last name of the customer.
+   * The customer's last name. The value is `undefined` if the app doesn't have the required access level.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   lastName?: string;
   /**
-   * The image associated with the customer.
+   * The customer's profile image, such as a Gravatar avatar. Use this to personalize the extension UI for the logged-in buyer.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   image: ImageDetails;
   /**
-   * Defines if the customer email accepts marketing activities.
+   * Whether the customer has opted in to receiving marketing communications from the merchant, such as email campaigns and promotional offers.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
-   * > Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
+   * > Caution: This field is deprecated and is removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
    *
    * @deprecated Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
    */
   acceptsMarketing: boolean;
   /**
-   * Defines if the customer accepts email marketing activities.
+   * Whether the customer has opted in to email marketing.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   acceptsEmailMarketing: boolean;
   /**
-   * Defines if the customer accepts SMS marketing activities.
+   * Whether the customer has opted in to SMS marketing.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   acceptsSmsMarketing: boolean;
   /**
-   * The Store Credit Accounts owned by the customer and usable during the checkout process.
+   * The store credit accounts owned by this customer that can be used as payment during checkout. Each account has a balance representing available store credit.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
@@ -1392,7 +1468,7 @@ export interface Customer {
    */
   storeCreditAccounts: StoreCreditAccount[];
   /**
-   * The number of previous orders made by this customer.
+   * The number of orders the customer has previously placed with this shop.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -1404,15 +1480,18 @@ export interface Customer {
  */
 export interface CheckoutSettings {
   /**
-   * The type of order that will be created once the buyer completes checkout.
+   * The type of order created when the buyer completes checkout.
+   *
+   * - `'DRAFT_ORDER'`: The checkout creates a draft order that the merchant must manually confirm before fulfillment. Common for B2B checkouts with deferred payment terms.
+   * - `'ORDER'`: The checkout creates a confirmed order immediately upon completion.
    */
   orderSubmission: 'DRAFT_ORDER' | 'ORDER';
   /**
-   * Represents the merchant configured payment terms.
+   * The payment terms configured by the merchant for B2B orders, such as net-30 or net-60. The value is `undefined` if no payment terms are configured.
    */
   paymentTermsTemplate?: PaymentTermsTemplate;
   /**
-   * Settings describing the behavior of the shipping address.
+   * Settings that control how the shipping address behaves during checkout, such as whether the buyer can edit the address.
    */
   shippingAddress: ShippingAddressSettings;
 }
@@ -1422,45 +1501,47 @@ export interface CheckoutSettings {
  */
 export interface ShippingAddressSettings {
   /**
-   * Describes whether the buyer can ship to any address during checkout.
+   * Whether the buyer is allowed to edit the shipping address during checkout. When `false`, the shipping address is locked and can't be changed, which is common for B2B orders with a predefined ship-to address.
    */
   isEditable: boolean;
 }
 
 /**
- * Represents the payment terms template object.
+ * A payment terms template configured by the merchant, defining when payment is due for B2B orders. Common examples include "Net 30" (due in 30 days) or "Due on receipt".
  */
 export interface PaymentTermsTemplate {
   /**
-   * A globally-unique ID.
+   * A globally-unique identifier for the payment terms template in the format `gid://shopify/PaymentTermsTemplate/<id>`.
+   *
    * @example 'gid://shopify/PaymentTermsTemplate/1'
    */
   id: string;
   /**
-   * The name of the payment terms translated to the buyer's current language. Refer to [localization.language](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-localization).
+   * The name of the payment terms translated to the buyer's current language, such as "Net 30" or "Due on receipt".
    */
   name: string;
   /**
-   * The due date for net payment terms as a ISO 8601 formatted string `YYYY-MM-DDTHH:mm:ss.sssZ`.
+   * The due date for payment in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DDTHH:mm:ss.sssZ`). The value is `undefined` if the payment terms don't have a fixed due date.
    */
   dueDate?: string;
   /**
-   * The number of days between the issued date and due date if using net payment terms.
+   * The number of days the buyer has to pay after the order is placed, such as `30` for "Net 30" terms. The value is `undefined` if the payment terms aren't net-based.
    */
   dueInDays?: number;
 }
 
 /**
- * Information about a Store Credit Account.
+ * A store credit account owned by the customer. Store credit is a form of payment that merchants can issue to customers for returns, refunds, or promotional purposes.
  */
 export interface StoreCreditAccount {
   /**
-   * A globally-unique identifier.
+   * A globally-unique identifier for the store credit account in the format `gid://shopify/StoreCreditAccount/<id>`.
+   *
    * @example 'gid://shopify/StoreCreditAccount/1'
    */
   id: string;
   /**
-   * The current balance of the Store Credit Account.
+   * The remaining balance available in this store credit account. This reflects the amount that can still be applied toward purchases.
    */
   balance: Money;
 }
@@ -1511,72 +1592,82 @@ export interface VisitorError {
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It's **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
 /**
- * Represents the delivery information and options available for one or
- * more cart lines.
+ * A group of cart lines that share the same set of delivery options. For example, physical items might form one delivery group while digital items form another.
  */
 export interface DeliveryGroup {
   /**
-   * The unique identifier of the delivery group. On the Thank You page this value is undefined.
+   * A unique identifier for the delivery group. The value is `undefined` on the Thank You page because delivery groups aren't available after order completion.
    */
   id?: string;
   /**
-   * The cart line references associated to the delivery group.
+   * The cart lines that belong to this delivery group. Each reference contains the cart line's `id`, which you can match against `lines` to get the full cart line details.
    */
   targetedCartLines: CartLineReference[];
 
   /**
-   * The delivery options available for the delivery group.
+   * The delivery options available for this group, including shipping, pickup point, and pickup location options. The buyer selects one of these to determine how their items are delivered.
    */
   deliveryOptions: DeliveryOption[];
 
   /**
-   * The selected delivery option for the delivery group.
+   * The delivery option the buyer has selected for this group. The value is `undefined` if the buyer hasn't selected a delivery option yet. Contains a `handle` you can match against `deliveryOptions` entries.
    */
   selectedDeliveryOption?: DeliveryOptionReference;
 
   /**
-   * The type of the delivery group.
+   * Whether this group contains items for a one-time purchase or a subscription.
+   * Subscription delivery groups might have different shipping options. See `DeliveryGroupType` for possible values.
    */
   groupType: DeliveryGroupType;
 
   /**
-   * Whether delivery is required for the delivery group.
+   * Whether physical delivery is required for the items in this group.
+   * Digital-only groups don't require delivery.
    */
   isDeliveryRequired: boolean;
 }
 
 /**
  * The possible types of a delivery group.
+ *
+ * - `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.
+ * - `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.
  */
 export type DeliveryGroupType = 'oneTimePurchase' | 'subscription';
 
 /**
- * Represents a reference to a cart line.
+ * A reference to a cart line within a delivery group, identified by the cart line's ID.
  */
 export interface CartLineReference {
   /**
-   * The unique identifier of the referenced cart line.
+   * The unique identifier of the referenced cart line. Match this against `CartLine.id` from the `lines` property to get the full line item details.
    */
   id: string;
 }
 
 /**
- * Represents a reference to a delivery option.
+ * A reference to the delivery option selected by the buyer for a delivery group.
  */
 export interface DeliveryOptionReference {
   /**
-   * The unique identifier of the referenced delivery option.
+   * The unique identifier of the referenced delivery option. Match this against `DeliveryOption.handle` from the `deliveryOptions` array to get the full option details.
    */
   handle: string;
 }
 
+/**
+ * A delivery option available to the buyer. Use the `type` property to determine which kind of option it is:
+ *
+ * - `ShippingOption` (`type: 'shipping' | 'local'`) - Items shipped by a carrier or delivered locally by the merchant.
+ * - `PickupPointOption` (`type: 'pickupPoint'`) - Items shipped to a third-party collection point for the buyer to pick up.
+ * - `PickupLocationOption` (`type: 'pickup'`) - Items picked up directly from a merchant's store or warehouse.
+ */
 export type DeliveryOption =
   | ShippingOption
   | PickupPointOption
@@ -1587,129 +1678,136 @@ export type DeliveryOption =
  */
 export interface DeliveryOptionBase {
   /**
-   * The unique identifier of the delivery option.
+   * The unique identifier of the delivery option. Use this to match against `DeliveryOptionReference.handle` or `DeliverySelectionGroup` entries.
    */
   handle: string;
 
   /**
-   * The title of the delivery option.
+   * The merchant-facing or carrier-provided display name for the delivery
+   * option, such as "Standard Shipping" or "Express".
    */
   title?: string;
 
   /**
-   * The description of the delivery option.
+   * Additional details about the delivery option provided by the carrier
+   * or merchant, such as estimated delivery windows or service level notes.
    */
   description?: string;
 
   /**
-   * The code of the delivery option.
+   * The carrier service code or rate identifier for this delivery option.
    */
   code: string;
 
   /**
-   * The metafields associated with this delivery option.
+   * Custom [metafields](/docs/apps/build/custom-data/metafields) attached to this delivery option by the carrier or a Shopify Function. Use these to display additional information about the option.
    */
   metafields: Metafield[];
 }
 
 /**
- * Represents a delivery option that is a shipping option.
+ * Represents a delivery option that's a shipping option.
  */
 export interface ShippingOption extends DeliveryOptionBase {
   /**
-   * The type of this delivery option.
+   * Identifies the delivery method. `'shipping'` means items are shipped by a carrier. `'local'` means the merchant handles delivery themselves, for example same-day local delivery.
    */
   type: 'shipping' | 'local';
 
   /**
-   * Information about the carrier.
+   * Information about the carrier providing this shipping option, including the carrier's display name.
    */
   carrier: ShippingOptionCarrier;
 
   /**
-   * The cost of the delivery.
+   * The cost of this delivery option before any shipping discounts are applied. Compare with `costAfterDiscounts` to show savings.
    */
   cost: Money;
 
   /**
-   * The cost of the delivery including discounts.
+   * The cost of this delivery option after shipping discounts have been applied. This is the price the buyer actually pays for shipping.
    */
   costAfterDiscounts: Money;
 
   /**
-   * Information about the estimated delivery time.
+   * The estimated delivery time for this shipping option. Use the `timeInTransit` range to display an estimated arrival window to the buyer.
    */
   deliveryEstimate: DeliveryEstimate;
 }
 
 export interface DeliveryEstimate {
   /**
-   * The estimated time in transit for the delivery in seconds.
+   * The estimated time in transit for the delivery, expressed as a range
+   * in seconds. Undefined when the carrier doesn't provide an estimate.
+   * When present, either the lower or upper bound of the range might still
+   * be omitted.
    */
   timeInTransit?: NumberRange;
 }
 
 export interface ShippingOptionCarrier {
   /**
-   * The name of the carrier.
+   * The display name of the shipping carrier, such as "Canada Post" or "UPS". The value is `undefined` if the carrier name isn't available.
    */
   name?: string;
 }
 
 export interface PickupPointOption extends DeliveryOptionBase {
   /**
-   * The type of this delivery option.
+   * Identifies this as a pickup point option, where items are shipped to a third-party collection point for the buyer to pick up.
    */
   type: 'pickupPoint';
 
   /**
-   * Information about the carrier that ships to the pickup point.
+   * Information about the carrier that ships items to this pickup point, including the carrier's name and code.
    */
   carrier: PickupPointCarrier;
 
   /**
-   * The cost to ship to this pickup point.
+   * The cost of this delivery option before any shipping discounts are applied. Compare with `costAfterDiscounts` to show savings.
    */
   cost: Money;
 
   /**
-   * The cost to ship to this pickup point including discounts.
+   * The cost of this delivery option after shipping discounts have been applied. This is the price the buyer actually pays for shipping.
    */
   costAfterDiscounts: Money;
 
   /**
-   * The location details of the pickup point.
+   * The physical location where the buyer picks up their order, including the address and display name of the collection point.
    */
   location: PickupPointLocation;
 }
 
 export interface PickupLocationOption extends DeliveryOptionBase {
   /**
-   * The type of this delivery option.
+   * Identifies this as a pickup location option, where the buyer picks up items directly from a merchant's store or warehouse.
    */
   type: 'pickup';
 
   /**
-   * The location details of the pickup location.
+   * The merchant's store or warehouse where the buyer picks up their order, including the address and display name.
    */
   location: PickupLocation;
 }
 
 interface PickupLocation {
   /**
-   * The name of the pickup location.
+   * The merchant-defined display name of the pickup location, such as a
+   * store name or warehouse label.
    */
   name?: string;
 
   /**
-   * The address of the pickup location.
+   * The physical address of the pickup location.
    */
   address: MailingAddress;
 }
 
 interface PickupPointLocation {
   /**
-   * The name of the pickup point.
+   * The display name of the pickup point, such as the name of the locker
+   * or collection point.
    */
   name?: string;
 
@@ -1719,31 +1817,34 @@ interface PickupPointLocation {
   handle: string;
 
   /**
-   * The address of the pickup point.
+   * The physical address of the pickup point.
    */
   address: MailingAddress;
 }
 
 interface PickupPointCarrier {
   /**
-   * The code identifying the carrier.
+   * The carrier's unique identifier code, used to distinguish between
+   * different carriers that deliver to pickup points.
    */
   code?: string;
 
   /**
-   * The name of the carrier.
+   * The display name of the carrier that delivers to this pickup point.
    */
   name?: string;
 }
 
 export interface NumberRange {
   /**
-   * The lower bound of the number range.
+   * The lower bound of the range. Undefined if only an upper bound is
+   * provided.
    */
   lower?: number;
 
   /**
-   * The upper bound of the number range.
+   * The upper bound of the range. Undefined if only a lower bound is
+   * provided.
    */
   upper?: number;
 }
@@ -1753,78 +1854,89 @@ export interface NumberRange {
  */
 export interface DeliveryGroupDetails extends DeliveryGroup {
   /**
-   * The selected delivery option for the delivery group.
+   * The full delivery option the buyer has selected for this group, with all cost and carrier details included. The value is `undefined` if the buyer hasn't selected an option yet. Unlike `DeliveryGroup.selectedDeliveryOption`, which is a reference, this contains the complete `DeliveryOption` object.
    */
   selectedDeliveryOption?: DeliveryOption;
 
   /**
-   * The cart lines associated to the delivery group.
+   * The full cart line objects associated with this delivery group, with all merchandise and cost details included. Unlike `DeliveryGroup.targetedCartLines`, which contains references, this contains the complete `CartLine` objects.
    */
   targetedCartLines: CartLine[];
 }
 
 export interface AllowedProcessing {
   /**
-   * Can collect customer analytics about how the shop was used and interactions made on the shop.
+   * Whether analytics data can be collected based on the visitor's consent,
+   * the merchant's privacy configuration, and the visitor's region. Analytics
+   * data includes how the shop was used and what interactions occurred.
    */
   analytics: boolean;
   /**
-   * Can collect customer preference for marketing, attribution and targeted advertising from the merchant.
+   * Whether marketing data can be collected based on the visitor's consent,
+   * the merchant's privacy configuration, and the visitor's region. Marketing
+   * data includes attribution and targeted advertising preferences.
    */
   marketing: boolean;
   /**
-   * Can collect customer preferences such as language, currency, size, and more.
+   * Whether preference data can be collected based on the visitor's consent,
+   * the merchant's privacy configuration, and the visitor's region. Preference
+   * data includes language, currency, and sizing choices.
    */
   preferences: boolean;
   /**
-   * Can collect customer preference for sharing data with third parties, usually for behavioral advertising.
+   * Whether data can be shared with third parties based on the visitor's
+   * consent, the merchant's privacy configuration, and the visitor's region.
+   * This typically applies to behavioral advertising data.
    */
   saleOfData: boolean;
 }
 
 export interface VisitorConsent {
   /**
-   * Visitor consents to recording data to understand how customers interact with the site.
+   * The visitor's consent for analytics tracking. `true` means the visitor
+   * actively granted consent, `false` means actively denied, and `undefined`
+   * means no decision has been made yet.
    */
   analytics?: boolean;
   /**
-   * Visitor consents to ads and marketing communications based on customer interests.
+   * The visitor's consent for marketing and targeted advertising. `true` means
+   * the visitor actively granted consent, `false` means actively denied, and
+   * `undefined` means no decision has been made yet.
    */
   marketing?: boolean;
   /**
-   * Visitor consent to remembering customer preferences, such as country or language, to personalize visits to the website.
+   * The visitor's consent for storing preferences such as language and currency.
+   * `true` means the visitor actively granted consent, `false` means actively
+   * denied, and `undefined` means no decision has been made yet.
    */
   preferences?: boolean;
   /**
-   * Opts the visitor out of data sharing / sales.
+   * Whether the visitor has opted out of the sale or sharing of their personal
+   * data with third parties. `true` means the visitor has opted out, `false`
+   * means they haven't opted out, and `undefined` means no decision has been
+   * made yet.
    */
   saleOfData?: boolean;
 }
 
 export interface TrackingConsentMetafield {
   /**
-   * The name of the metafield. It must be between 3 and 30 characters in
-   * length (inclusive).
+   * The identifier for the tracking consent metafield, such as `'analyticsType'` or `'marketingType'`.
    */
   key: string;
   /**
-   * The information to be stored as metadata.
-   *
-   * @example 'any string', '', or a stringified JSON object
+   * The value stored in the tracking consent metafield, such as `'granular'` or a stringified JSON object.
    */
   value: string;
 }
 
 export interface TrackingConsentMetafieldChange {
   /**
-   * The name of the metafield. It must be between 3 and 30 characters in
-   * length (inclusive).
+   * The identifier for the tracking consent metafield to update.
    */
   key: string;
   /**
-   * The information to be stored as metadata. If the value is `null`, the metafield will be deleted.
-   *
-   * @example 'any string', `null`, or a stringified JSON object
+   * The new value to store in the metafield. Set to `null` to delete the metafield.
    */
   value: string | null;
 }
@@ -1833,11 +1945,14 @@ export interface VisitorConsentChange extends VisitorConsent {
   /**
    * Tracking consent metafield data to be saved.
    *
-   * If the value is `null`, the metafield will be deleted.
+   * If the value is `null`, the metafield is deleted.
    *
    * @example `[{key: 'granularAnalytics', value: 'true'}, {key: 'granularMarketing', value: 'false'}]`
    */
   metafields?: TrackingConsentMetafieldChange[];
+  /**
+   * Identifies this as a visitor consent change. This is the only supported change type for `applyTrackingConsentChange()`.
+   */
   type: 'changeVisitorConsent';
 }
 
@@ -1847,40 +1962,36 @@ export type ApplyTrackingConsentChangeType = (
 
 export interface CustomerPrivacyRegion {
   /**
-   * The [ISO 3166 Alpha-2 format](https://www.iso.org/iso-3166-country-codes.html) for the buyer's country.
+   * The buyer's country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if geolocation failed.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
-   * @example 'CA' for Canada, 'US' for United States, 'GB' for Great Britain, or undefined if geolocation failed.
+   * @example 'CA' for Canada, 'US' for United States, 'GB' for Great Britain
    */
   countryCode?: CountryCode;
   /**
-   * The buyer's province code, such as state, province, prefecture, or region.
-   *
-   * Province codes can be found by clicking on the `Subdivisions assigned codes` column for countries listed [here](https://en.wikipedia.org/wiki/ISO_3166-2).
+   * The buyer's province, state, or region code in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format. The value is `undefined` if geolocation failed or only the country was detected.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
-   * @example 'ON' for Ontario, 'ENG' for England, 'CA' for California, or undefined if geolocation failed or only the country was detected.
+   * @example 'ON' for Ontario, 'ENG' for England, 'CA' for California
    */
   provinceCode?: string;
 }
 
 export interface CustomerPrivacy {
   /**
-   * An object containing flags for each consent property denoting whether they can be processed based on visitor consent, merchant configuration, and user location.
+   * Flags indicating whether each type of data processing is permitted, based on the visitor's consent, the merchant's privacy configuration, and the visitor's geographic location.
    */
   allowedProcessing: AllowedProcessing;
   /**
-   * Stored tracking consent metafield data.
+   * The tracking consent metafields that have been stored for this visitor. These contain app-specific consent data beyond the standard categories.
    *
    * @example `[{key: 'analyticsType', value: 'granular'}, {key: 'marketingType', value: 'granular'}]`, or `[]`
    */
   metafields: TrackingConsentMetafield[];
   /**
-   * An object containing the customer's current privacy consent settings.
-   * *
-   * @example `true` — the customer has actively granted consent, `false` — the customer has actively denied consent, or `undefined` — the customer has not yet made a decision.
+   * The visitor's current privacy consent settings. Each property represents a consent category and is `true` (actively granted), `false` (actively denied), or `undefined` (no decision made yet).
    */
   visitorConsent: VisitorConsent;
   /**
@@ -1890,11 +2001,11 @@ export interface CustomerPrivacy {
    */
   shouldShowBanner: boolean;
   /**
-   * Whether the visitor is in a region requiring data sale opt-outs.
+   * Whether the visitor is located in a region that requires an explicit opt-out option for the sale or sharing of personal data, such as California (CCPA) or other jurisdictions with similar regulations.
    */
   saleOfDataRegion: boolean;
   /**
-   * Details about the visitor's current location for use in evaluating if more granular consent controls should render.
+   * The visitor's geographic location, used to determine whether more granular consent controls should be displayed based on regional privacy regulations.
    *
    * @example `{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.
    *
@@ -1912,7 +2023,7 @@ export type TrackingConsentChangeResult =
  */
 export interface TrackingConsentChangeResultSuccess {
   /**
-   * The type of the `TrackingConsentChangeResultSuccess` API.
+   * Indicates that the tracking consent update was applied successfully.
    */
   type: 'success';
 }
@@ -1923,105 +2034,123 @@ export interface TrackingConsentChangeResultSuccess {
  */
 export interface TrackingConsentChangeResultError {
   /**
-   * The type of the `TrackingConsentChangeResultError` API.
+   * Indicates that the tracking consent update couldn't be applied. Check the `message` property for details.
    */
   type: 'error';
 
   /**
    * A message that explains the error. This message is useful for debugging.
-   * It is **not** localized, and therefore should not be presented directly
-   * to the buyer.
+   * It isn't localized and shouldn't be displayed to the buyer.
    */
   message: string;
 }
 
 export interface CartInstructions {
   /**
-   * Cart instructions related to cart attributes.
+   * Whether the extension can update custom attributes using `applyAttributeChange()`.
    */
   attributes: AttributesCartInstructions;
 
   /**
-   * Cart instructions related to delivery.
+   * Whether the extension can modify the shipping address using `applyShippingAddressChange()`.
    */
   delivery: DeliveryCartInstructions;
 
   /**
-   * Cart instructions related to discounts.
+   * Whether the extension can add or remove discount codes using `applyDiscountCodeChange()`.
    */
   discounts: DiscountsCartInstructions;
 
   /**
-   * Cart instructions related to cart lines.
+   * Whether the extension can add, remove, or update cart lines using `applyCartLinesChange()`.
    */
   lines: CartLinesCartInstructions;
 
   /**
-   * Cart instructions related to metafields.
+   * Whether the extension can add, update, or delete cart metafields using `applyMetafieldChange()`.
    */
   metafields: MetafieldsCartInstructions;
 
   /**
-   * Cart instructions related to notes.
+   * Whether the extension can update the order note using `applyNoteChange()`.
    */
   notes: NotesCartInstructions;
 }
 
 export interface AttributesCartInstructions {
   /**
-   * Indicates whether or not cart attributes can be updated.
+   * Whether attributes can be updated using `applyAttributeChange()`. When
+   * `false`, the checkout configuration doesn't allow attribute changes.
+   * Even when `true`, calls to `applyAttributeChange()` can still fail
+   * during accelerated checkout (Apple Pay, Google Pay).
    */
   canUpdateAttributes: boolean;
 }
 
 export interface DeliveryCartInstructions {
   /**
-   * Indicates whether a buyer can select a custom address.
-   *
-   * When true, this implies extensions can update the delivery address.
+   * Whether the shipping address can be modified using
+   * `applyShippingAddressChange()`. When `true`, the buyer is using a
+   * standard checkout flow where the shipping address can be changed
+   * programmatically.
    */
   canSelectCustomAddress: boolean;
 }
 
 export interface DiscountsCartInstructions {
   /**
-   * Indicates whether or not discount codes can be updated.
+   * Whether discount codes can be updated using `applyDiscountCodeChange()`.
+   * When `false`, the checkout configuration doesn't allow discount code
+   * changes. Even when `true`, calls to `applyDiscountCodeChange()` can
+   * still fail during accelerated checkout (Apple Pay, Google Pay).
    */
   canUpdateDiscountCodes: boolean;
 }
 
 export interface CartLinesCartInstructions {
   /**
-   * Indicates whether or not new cart lines can be added.
+   * Whether new cart lines can be added using `applyCartLinesChange()`. When
+   * `false`, the checkout configuration doesn't allow adding lines (for
+   * example, draft orders). Even when `true`, calls can still fail during
+   * accelerated checkout (Apple Pay, Google Pay).
    */
   canAddCartLine: boolean;
 
   /**
-   * Indicates whether or not cart lines can be removed.
+   * Whether cart lines can be removed using `applyCartLinesChange()`. When
+   * `false`, the checkout configuration doesn't allow removing lines.
+   * Even when `true`, calls can still fail during accelerated checkout.
    */
   canRemoveCartLine: boolean;
 
   /**
-   * Indicates whether or not cart lines can be updated.
+   * Whether cart lines can be updated using `applyCartLinesChange()`. When
+   * `false`, the checkout configuration doesn't allow updating lines.
+   * Even when `true`, calls can still fail during accelerated checkout.
    */
   canUpdateCartLine: boolean;
 }
 
 export interface MetafieldsCartInstructions {
   /**
-   * Indicates whether or not cart metafields can be added or updated.
+   * Whether the extension can add or update cart metafields using
+   * `applyMetafieldChange()`.
    */
   canSetCartMetafields: boolean;
 
   /**
-   * Indicates whether or not cart metafields can be deleted.
+   * Whether the extension can delete cart metafields using
+   * `applyMetafieldChange()`.
    */
   canDeleteCartMetafield: boolean;
 }
 
 export interface NotesCartInstructions {
   /**
-   * Indicates whether or not notes can be updated.
+   * Whether the order note can be updated using `applyNoteChange()`. When
+   * `false`, the checkout configuration doesn't allow note changes. Even
+   * when `true`, calls to `applyNoteChange()` can still fail during
+   * accelerated checkout (Apple Pay, Google Pay).
    */
   canUpdateNote: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -68,19 +68,19 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * The allowed capabilities of the extension, defined
-   * in your [shopify.extension.toml](/docs/api/checkout-ui-extensions/configuration) file.
+   * in your [shopify.extension.toml](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file.
    *
-   * * [`api_access`](/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.
+   * * [`api_access`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#api-access): the extension can access the Storefront API.
    *
-   * * [`network_access`](/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
+   * * [`network_access`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#network-access): the extension can make external network calls.
    *
-   * * [`block_progress`](/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.
+   * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.
    *
-   * * [`collect_buyer_consent.sms_marketing`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.
+   * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.
    *
-   * * [`collect_buyer_consent.customer_privacy`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that are honored on Shopify-managed services.
+   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#collect-buyer-consent): the extension can register customer consent decisions that are honored on Shopify-managed services.
    *
-   * * [`iframe.sources`](/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe.
+   * * [`iframe.sources`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#iframe): the extension can embed an external URL in an iframe.
    */
   capabilities: SubscribableSignalLike<Capability[]>;
 
@@ -115,8 +115,8 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
    * extension's configuration file.
    *
    * @example 'purchase.checkout.block.render'
-   * @see /docs/api/checkout-ui-extensions/latest/extension-targets-overview
-   * @see /docs/apps/app-extensions/configuration#targets
+   * @see https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/extension-targets-overview
+   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
    */
   target: Target;
 
@@ -132,13 +132,13 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
 
 export interface Editor {
   /**
-   * Indicates whether the extension is rendering in the [checkout editor](/docs/apps/checkout). Always `'checkout'`.
+   * Indicates whether the extension is rendering in the [checkout editor](https://shopify.dev/docs/apps/checkout). Always `'checkout'`.
    */
   type: 'checkout';
 }
 
 /**
- * Metadata associated with the checkout. See the [metafields documentation](/docs/apps/build/custom-data/metafields) for more information on how metafields work.
+ * Metadata associated with the checkout. See the [metafields documentation](https://shopify.dev/docs/apps/build/custom-data/metafields) for more information on how metafields work.
  */
 export interface Metafield {
   /**
@@ -173,7 +173,7 @@ export interface Metafield {
 }
 
 /**
- * Represents a custom [metafield](/docs/apps/build/custom-data/metafields) attached to a resource such as a product, variant, customer, or shop.
+ * Represents a custom [metafield](https://shopify.dev/docs/apps/build/custom-data/metafields) attached to a resource such as a product, variant, customer, or shop.
  */
 export interface AppMetafield {
   /**
@@ -184,7 +184,7 @@ export interface AppMetafield {
   /**
    * The namespace that the metafield belongs to. Namespaces group related metafields and prevent naming collisions between different apps.
    *
-   * App owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.
+   * App owned metafield namespaces are returned using the `$app` format. See [app owned metafields](https://shopify.dev/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.
    */
   namespace: string;
 
@@ -205,7 +205,7 @@ export interface AppMetafield {
   valueType: 'boolean' | 'float' | 'integer' | 'json_string' | 'string';
 
   /**
-   * The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`. This is the full type identifier, whereas `valueType` is a simplified category.
+   * The metafield's [type name](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`. This is the full type identifier, whereas `valueType` is a simplified category.
    */
   type: string;
 }
@@ -213,7 +213,7 @@ export interface AppMetafield {
 /**
  * Represents a custom metadata attached to the cart. Unlike `AppMetafield`, cart metafield values are always strings and don't include a `valueType` discriminator.
  *
- * Cart [metafields](/docs/apps/build/custom-data/metafields) are set by extensions using `applyMetafieldChange()` and can be copied to order metafields at order creation time.
+ * Cart [metafields](https://shopify.dev/docs/apps/build/custom-data/metafields) are set by extensions using `applyMetafieldChange()` and can be copied to order metafields at order creation time.
  */
 export interface CartMetafield {
   /**
@@ -232,7 +232,7 @@ export interface CartMetafield {
   value: string;
 
   /**
-   * The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`.
+   * The metafield's [type name](https://shopify.dev/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`.
    */
   type: string;
 }
@@ -249,11 +249,11 @@ export interface AppMetafieldEntryTarget {
    * - `'shop'`: The merchant's shop.
    * - `'shopUser'`: A staff member or collaborator account on the shop.
    * - `'variant'`: A specific variant of a product.
-   * - `'company'`: A [B2B](/docs/apps/build/b2b) company associated with the order.
-   * - `'companyLocation'`: A location belonging to a [B2B](/docs/apps/build/b2b) company.
+   * - `'company'`: A [B2B](https://shopify.dev/docs/apps/build/b2b) company associated with the order.
+   * - `'companyLocation'`: A location belonging to a [B2B](https://shopify.dev/docs/apps/build/b2b) company.
    * - `'cart'`: The cart associated with the checkout.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.
    */
   type:
     | 'customer'
@@ -266,7 +266,7 @@ export interface AppMetafieldEntryTarget {
     | 'cart';
 
   /**
-   * The globally-unique identifier of the Shopify resource, in [GID](/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the [Storefront API](/docs/api/storefront).
+   * The globally-unique identifier of the Shopify resource, in [GID](https://shopify.dev/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the [Storefront API](https://shopify.dev/docs/api/storefront).
    *
    * @example 'gid://shopify/Product/123'
    */
@@ -274,13 +274,13 @@ export interface AppMetafieldEntryTarget {
 }
 
 /**
- * An entry that pairs a Shopify resource with one of its [metafields](/docs/apps/build/custom-data/metafields). Each entry contains a `target` identifying which resource the metafield belongs to and a `metafield` object with the actual data.
+ * An entry that pairs a Shopify resource with one of its [metafields](https://shopify.dev/docs/apps/build/custom-data/metafields). Each entry contains a `target` identifying which resource the metafield belongs to and a `metafield` object with the actual data.
  */
 export interface AppMetafieldEntry {
   /**
    * The Shopify resource that this metafield is attached to, including the resource type (such as `'product'` or `'customer'`) and its globally-unique ID.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.
    */
   target: AppMetafieldEntryTarget;
 
@@ -375,7 +375,7 @@ export interface Currency {
 }
 
 /**
- * A [Shopify Market](/docs/apps/build/markets) that represents a group of one or more regions for international selling.
+ * A [Shopify Market](https://shopify.dev/docs/apps/build/markets) that represents a group of one or more regions for international selling.
  */
 export interface Market {
   /**
@@ -384,7 +384,7 @@ export interface Market {
   id: string;
 
   /**
-   * The human-readable, shop-scoped identifier for the market, such as `'us'` or `'eu'`. Merchants define these handles when configuring [Shopify Markets](/docs/apps/build/markets).
+   * The human-readable, shop-scoped identifier for the market, such as `'us'` or `'eu'`. Merchants define these handles when configuring [Shopify Markets](https://shopify.dev/docs/apps/build/markets).
    */
   handle: string;
 }
@@ -416,7 +416,7 @@ export interface Localization {
   country: SubscribableSignalLike<Country | undefined>;
 
   /**
-   * The [market](/docs/apps/build/markets) context of the checkout, carried over from the cart context. Markets group countries and regions with shared pricing, languages, and domains. It updates when the buyer changes the country of their shipping address. The value is `undefined` if the market is unknown.
+   * The [market](https://shopify.dev/docs/apps/build/markets) context of the checkout, carried over from the cart context. Markets group countries and regions with shared pricing, languages, and domains. It updates when the buyer changes the country of their shipping address. The value is `undefined` if the market is unknown.
    *
    * > Caution: Deprecated as of version `2025-04`. Merchants now manage which extensions load for each market, so extensions no longer need to check this value.
    *
@@ -456,13 +456,13 @@ export interface BuyerJourney {
    * This returns a promise that resolves to a teardown function. Calling the
    * teardown function removes the interceptor.
    *
-   * To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/configuration#block-progress)
+   * To block checkout progress, you must set the [block_progress](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#block-progress)
    * capability in your extension's configuration.
    *
    * If you do, then you're expected to inform the buyer why navigation was blocked,
    * either by passing validation errors to the checkout UI or rendering the errors in your extension.
    *
-   * If the merchant hasn't allowed your extension to block checkout progress, show a warning in the [checkout editor](/docs/apps/build/checkout/test-checkout-ui-extensions#test-the-extension-in-the-checkout-editor).
+   * If the merchant hasn't allowed your extension to block checkout progress, show a warning in the [checkout editor](https://shopify.dev/docs/apps/build/checkout/test-checkout-ui-extensions#test-the-extension-in-the-checkout-editor).
    */
   intercept(interceptor: Interceptor): Promise<() => void>;
 
@@ -540,7 +540,7 @@ export interface BuyerJourneyStep {
 /** @publicDocs */
 export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
-   * The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event.
+   * The methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
    */
   analytics: Analytics;
 
@@ -560,20 +560,20 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.
    *
    * > Caution: As of version `2024-07`, UI extension code must check for instructions before calling select APIs in case those APIs aren't available.
-   *  See the [update guide](/docs/api/checkout-ui-extensions/apis/cart-instructions#examples) for more information.
+   *  See the [update guide](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples) for more information.
    *
    */
   instructions: SubscribableSignalLike<CartInstructions>;
 
   /**
    * The metafields requested in the
-   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration)
+   * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration)
    * file. These metafields are updated when there's a change in the merchandise items
    * being purchased by the customer.
    *
-   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` isn't supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.
+   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` isn't supported. See [app owned metafields](https://shopify.dev/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   appMetafields: SubscribableSignalLike<AppMetafieldEntry[]>;
 
@@ -590,14 +590,14 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * Information about the buyer that's interacting with the checkout. The property is available only if the extension has access to protected customer data.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   buyerIdentity?: BuyerIdentity;
 
   /**
    * Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.
    *
-   * Refer to [buyer journey](/docs/api/checkout-ui-extensions/apis/buyer-journey#examples)
+   * Refer to [buyer journey](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/buyer-journey#examples)
    * examples for more information.
    */
   buyerJourney: BuyerJourney;
@@ -614,8 +614,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * Use this to correlate checkout sessions across your extension, web pixels, and backend systems.
    *
-   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)
-   * and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).
+   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](https://shopify.dev/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)
+   * and the `checkout_token` field in the [REST Admin API `Order` resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
    */
   checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;
 
@@ -635,7 +635,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   discountCodes: SubscribableSignalLike<CartDiscountCode[]>;
 
   /**
-   * The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from [Shopify Functions](/docs/apps/build/functions). Each allocation indicates how much was discounted and how the discount was triggered.
+   * The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from [Shopify Functions](https://shopify.dev/docs/apps/build/functions). Each allocation indicates how much was discounted and how the discount was triggered.
    */
   discountAllocations: SubscribableSignalLike<CartDiscountAllocation[]>;
 
@@ -650,8 +650,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * extension's configuration file.
    *
    * @example 'purchase.checkout.block.render'
-   * @see /docs/api/checkout-ui-extensions/latest/extension-targets-overview
-   * @see /docs/apps/app-extensions/configuration#targets
+   * @see https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/extension-targets-overview
+   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
    *
    * @deprecated Deprecated as of version `2023-07`, use `extension.target` instead.
    */
@@ -659,10 +659,10 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * Utilities for translating content and formatting values according to the current
-   * [`localization`](/docs/api/checkout-ui-extensions/apis/localization)
+   * [`localization`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization)
    * of the checkout.
    *
-   * Refer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples)
+   * Refer to [`localization` examples](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization#examples)
    * for more information.
    */
   i18n: I18n;
@@ -675,7 +675,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The details about the location, language, and currency of the customer. For utilities to easily
    * format and translate content based on these details, you can use the
-   * [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
+   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization#standardapi-propertydetail-i18n)
    * object instead.
    */
   localization: Localization;
@@ -690,7 +690,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The method used to query the Storefront GraphQL API with a prefetched token.
    *
-   * Refer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.
+   * Refer to [Storefront API access examples](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/storefront-api) for more information.
    */
   query: <Data = unknown, Variables = Record<string, unknown>>(
     query: string,
@@ -709,15 +709,15 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * If the previous token expires, this value reflects a new session token with a new signature and expiry.
    *
-   * Refer to [session token examples](/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/session-token) for more information.
    */
   sessionToken: SessionToken;
 
   /**
    * The settings matching the settings definition written in the
-   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.
+   * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file.
    *
-   *  Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.
+   *  Refer to [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/settings#examples) for more information.
    *
    * > Note: When an extension is being installed in the editor, the settings are empty until
    * a merchant sets a value. In that case, this object updates in real time as a merchant fills in the settings.
@@ -730,7 +730,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * The property is available only if the extension has access to protected customer
    * data. When available, the subscribable value is `undefined` if delivery isn't required.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   shippingAddress?: SubscribableSignalLike<ShippingAddress | undefined>;
 
@@ -740,7 +740,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * if the extension has access to protected customer data. The subscribable value is
    * `undefined` if the billing address hasn't been provided yet.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   billingAddress?: SubscribableSignalLike<MailingAddress | undefined>;
 
@@ -774,9 +774,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * Enables setting and updating customer privacy consent settings and tracking consent metafields.
    *
-   * > Note: Requires the [`customer_privacy` capability](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be set to `true`.
+   * > Note: Requires the [`customer_privacy` capability](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#collect-buyer-consent) to be set to `true`.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   applyTrackingConsentChange: ApplyTrackingConsentChangeType;
 
@@ -799,53 +799,53 @@ export interface SessionToken {
 /**
  * Information about the buyer who is completing the checkout.
  *
- * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data). The `customer` and `purchasingCompany` properties require level 1 access. The `email` and `phone` properties require level 2 access.
+ * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data). The `customer` and `purchasingCompany` properties require level 1 access. The `email` and `phone` properties require level 2 access.
  */
 export interface BuyerIdentity {
   /**
    * The buyer's customer account, including their ID and whether they've accepted marketing. The value is `undefined` if the buyer isn't a
    * known customer for this shop or if they haven't logged in yet.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   customer: SubscribableSignalLike<Customer | undefined>;
 
   /**
    * The email address the buyer provided during checkout. The value is `undefined` if the app doesn't have access to customer data.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   email: SubscribableSignalLike<string | undefined>;
 
   /**
    * The phone number the buyer provided during checkout. The value is `undefined` if no phone number was provided or the app doesn't have access to customer data.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   phone: SubscribableSignalLike<string | undefined>;
 
   /**
    * The company and company location that a B2B (business-to-business) customer is purchasing on behalf of. Use this to identify the business context of the order. The value is `undefined` if the buyer isn't a B2B customer.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   purchasingCompany: SubscribableSignalLike<PurchasingCompany | undefined>;
 }
 
 /**
- * The company and location that the [B2B](/docs/apps/build/b2b) customer is purchasing on behalf of. This is present only when the buyer is logged in as a business customer.
+ * The company and location that the [B2B](https://shopify.dev/docs/apps/build/b2b) customer is purchasing on behalf of. This is present only when the buyer is logged in as a business customer.
  */
 export interface PurchasingCompany {
   /**
    * The company the B2B customer belongs to.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   company: Company;
   /**
    * The specific company location associated with this B2B purchase.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   location: CompanyLocation;
 }
@@ -854,7 +854,7 @@ export interface Company {
   /**
    * A globally-unique identifier for the company in the format `gid://shopify/Company/<id>`.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'gid://shopify/Company/123'
    */
@@ -862,13 +862,13 @@ export interface Company {
   /**
    * The company's display name.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   name: string;
   /**
    * A merchant-defined external identifier for the company. The value is `undefined` if the merchant hasn't set one.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   externalId?: string;
 }
@@ -877,7 +877,7 @@ export interface CompanyLocation {
   /**
    * A globally-unique identifier for the company location in the format `gid://shopify/CompanyLocation/<id>`.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'gid://shopify/CompanyLocation/123'
    */
@@ -885,13 +885,13 @@ export interface CompanyLocation {
   /**
    * The display name of the company location.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   name: string;
   /**
    * A merchant-defined external identifier for the company location. The value is `undefined` if the merchant hasn't set one.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   externalId?: string;
 }
@@ -993,7 +993,7 @@ export interface CartLine {
   discountAllocations: CartDiscountAllocation[];
 
   /**
-   * The individual components of a [bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component represents a separate product within the bundle. Returns an empty array if the line item isn't a bundle.
+   * The individual components of a [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles) line item. Each component represents a separate product within the bundle. Returns an empty array if the line item isn't a bundle.
    */
   lineComponents: CartLineComponentType[];
 
@@ -1137,7 +1137,7 @@ export interface ProductVariant extends BaseMerchandise {
   requiresShipping: boolean;
 
   /**
-   * The [selling plan](/docs/apps/build/purchase-options/subscriptions) associated with this variant, such as a subscription or pre-order plan. The value is `undefined` if the item isn't being purchased through a selling plan.
+   * The [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions) associated with this variant, such as a subscription or pre-order plan. The value is `undefined` if the item isn't being purchased through a selling plan.
    */
   sellingPlan?: SellingPlan;
 
@@ -1250,7 +1250,7 @@ export interface CartDiscountCode {
  *
  * - `CartCodeDiscountAllocation` (`type: 'code'`): Triggered by a discount code the buyer entered.
  * - `CartAutomaticDiscountAllocation` (`type: 'automatic'`): Applied automatically based on merchant-configured rules.
- * - `CartCustomDiscountAllocation` (`type: 'custom'`): Applied by a [Shopify Function](/docs/apps/build/discounts).
+ * - `CartCustomDiscountAllocation` (`type: 'custom'`): Applied by a [Shopify Function](https://shopify.dev/docs/api/functions/latest/discount).
  */
 export type CartDiscountAllocation =
   | CartCodeDiscountAllocation
@@ -1292,12 +1292,12 @@ export interface CartAutomaticDiscountAllocation
 export interface CartCustomDiscountAllocation
   extends CartDiscountAllocationBase {
   /**
-   * The title of the custom discount, typically applied by a [Shopify Function](/docs/apps/build/discounts).
+   * The title of the custom discount, typically applied by a [Shopify Function](https://shopify.dev/docs/api/functions/latest/discount).
    */
   title: string;
 
   /**
-   * Identifies this as a custom discount applied by a [Shopify Function](/docs/apps/build/discounts).
+   * Identifies this as a custom discount applied by a [Shopify Function](https://shopify.dev/docs/api/functions/latest/discount).
    */
   type: 'custom';
 }
@@ -1387,13 +1387,13 @@ export type Interceptor = (
 /**
  * Information about a customer who has previously purchased from this shop.
  *
- * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+ * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
  */
 export interface Customer {
   /**
    * A globally-unique identifier for the customer in the format `gid://shopify/Customer/<id>`.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'gid://shopify/Customer/123'
    */
@@ -1401,43 +1401,43 @@ export interface Customer {
   /**
    * The email address associated with the customer's account. The value is `undefined` if the app doesn't have the required access level.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   email?: string;
   /**
    * The phone number associated with the customer's account. The value is `undefined` if no phone number is on file or the app doesn't have the required access level.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   phone?: string;
   /**
    * The customer's full name, typically a combination of first and last name. The value is `undefined` if the app doesn't have the required access level.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   fullName?: string;
   /**
    * The customer's first name. The value is `undefined` if the app doesn't have the required access level.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   firstName?: string;
   /**
    * The customer's last name. The value is `undefined` if the app doesn't have the required access level.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   lastName?: string;
   /**
    * The customer's profile image, such as a Gravatar avatar. Use this to personalize the extension UI for the logged-in buyer.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   image: ImageDetails;
   /**
    * Whether the customer has opted in to receiving marketing communications from the merchant, such as email campaigns and promotional offers.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * > Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
    *
@@ -1447,19 +1447,19 @@ export interface Customer {
   /**
    * Whether the customer has opted in to email marketing.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   acceptsEmailMarketing: boolean;
   /**
    * Whether the customer has opted in to SMS marketing.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   acceptsSmsMarketing: boolean;
   /**
    * The store credit accounts owned by this customer that can be used as payment during checkout. Each account has a balance representing available store credit.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @private
    */
@@ -1467,7 +1467,7 @@ export interface Customer {
   /**
    * The number of orders the customer has previously placed with this shop.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   ordersCount: number;
 }
@@ -1553,7 +1553,7 @@ export type ExtensionSettings = Record<
 
 export interface Analytics {
   /**
-   * Publish method to emit analytics events to [Web Pixels](/docs/apps/marketing).
+   * Publish method to emit analytics events to [Web Pixels](https://shopify.dev/docs/apps/marketing).
    */
   publish(name: string, data: Record<string, unknown>): Promise<boolean>;
 
@@ -1634,7 +1634,7 @@ export interface DeliveryGroup {
  * The possible types of a delivery group.
  *
  * - `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.
- * - `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.
+ * - `'subscription'`: Items bought through a [selling plan](https://shopify.dev/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.
  */
 export type DeliveryGroupType = 'oneTimePurchase' | 'subscription';
 
@@ -1697,7 +1697,7 @@ export interface DeliveryOptionBase {
   code: string;
 
   /**
-   * Custom [metafields](/docs/apps/build/custom-data/metafields) attached to this delivery option by the carrier or a [Shopify Function](/docs/apps/build/functions). Use these to display additional information about the option.
+   * Custom [metafields](https://shopify.dev/docs/apps/build/custom-data/metafields) attached to this delivery option by the carrier or a [Shopify Function](https://shopify.dev/docs/apps/build/functions). Use these to display additional information about the option.
    */
   metafields: Metafield[];
 }
@@ -1960,7 +1960,7 @@ export interface CustomerPrivacyRegion {
   /**
    * The buyer's country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if geolocation failed.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'CA' for Canada, 'US' for United States, 'GB' for Great Britain
    */
@@ -1968,7 +1968,7 @@ export interface CustomerPrivacyRegion {
   /**
    * The buyer's province, state, or region code in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format. The value is `undefined` if geolocation failed or only the country was detected.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *
    * @example 'ON' for Ontario, 'ENG' for England, 'CA' for California
    */
@@ -2005,7 +2005,7 @@ export interface CustomerPrivacy {
    *
    * @example `{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.
    *
-   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
+   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    */
   region?: CustomerPrivacyRegion;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -68,19 +68,19 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * The allowed capabilities of the extension, defined
-   * in your [shopify.extension.toml](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   * in your [shopify.extension.toml](/docs/api/checkout-ui-extensions/configuration) file.
    *
-   * * [`api_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.
+   * * [`api_access`](/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.
    *
-   * * [`network_access`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
+   * * [`network_access`](/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.
    *
-   * * [`block_progress`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.
+   * * [`block_progress`](/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.
    *
-   * * [`collect_buyer_consent.sms_marketing`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.
+   * * [`collect_buyer_consent.sms_marketing`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.
    *
-   * * [`collect_buyer_consent.customer_privacy`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that are honored on Shopify-managed services.
+   * * [`collect_buyer_consent.customer_privacy`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that are honored on Shopify-managed services.
    *
-   * * [`iframe.sources`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe.
+   * * [`iframe.sources`](/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe.
    */
   capabilities: SubscribableSignalLike<Capability[]>;
 
@@ -115,8 +115,8 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
    * extension's configuration file.
    *
    * @example 'purchase.checkout.block.render'
-   * @see https://shopify.dev/docs/api/checkout-ui-extensions/latest/extension-targets-overview
-   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
+   * @see /docs/api/checkout-ui-extensions/latest/extension-targets-overview
+   * @see /docs/apps/app-extensions/configuration#targets
    */
   target: Target;
 
@@ -142,8 +142,7 @@ export interface Editor {
  */
 export interface Metafield {
   /**
-   * The name of the metafield. It must be between three and 30 characters in
-   * length (inclusive).
+   * The name of the metafield.
    *
    * @example 'delivery_instructions'
    */
@@ -152,7 +151,7 @@ export interface Metafield {
   /**
    * A container for a set of metafields. You need to define a custom
    * namespace for your metafields to distinguish them from the metafields
-   * used by other apps. This must be between two and 20 characters in length (inclusive).
+   * used by other apps.
    *
    * @example 'my_app'
    */
@@ -239,7 +238,7 @@ export interface CartMetafield {
 }
 
 /**
- * The Shopify resource that a metafield is attached to. Each entry identifies a specific resource by its type and globally-unique ID, so your extension can determine where the metafield data originates.
+ * The Shopify resource that a metafield is attached to. Each entry identifies a specific resource by its type and globally-unique ID, so you can trace where the data comes from.
  */
 export interface AppMetafieldEntryTarget {
   /**
@@ -267,7 +266,7 @@ export interface AppMetafieldEntryTarget {
     | 'cart';
 
   /**
-   * The globally-unique identifier of the Shopify resource, in [GID](https://shopify.dev/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the GraphQL API.
+   * The globally-unique identifier of the Shopify resource, in [GID](/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the [Storefront API](/docs/api/storefront).
    *
    * @example 'gid://shopify/Product/123'
    */
@@ -338,12 +337,9 @@ export interface I18n {
   /**
    * Returns a localized date value.
    *
-   * This function behaves like the standard `Intl.DateTimeFormatOptions()` and uses
-   * the buyer's locale by default. Formatting options can be passed in as
+   * This function behaves like the standard [`Intl.DateTimeFormat()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) and uses
+   * the buyer's locale by default. Formatting [options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options) can be passed in as
    * options.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat0
-   * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options
    *
    * @param options.inExtensionLocale - If true, uses the extension's locale.
    */
@@ -415,14 +411,14 @@ export interface Localization {
   extensionLanguage: SubscribableSignalLike<Language>;
 
   /**
-   * The country context of the checkout, carried over from the cart context where it was used to contextualize the storefront experience. It updates when the buyer changes the country of their shipping address. Use this value to display region-specific content such as local support information or regional policies. The value is `undefined` if the buyer's country is unknown.
+   * The country context of the checkout, carried over from the cart. It updates when the buyer changes their shipping address country. Use this value to display region-specific content such as local support information or regional policies. The value is `undefined` if the buyer's country is unknown.
    */
   country: SubscribableSignalLike<Country | undefined>;
 
   /**
    * The [market](/docs/apps/build/markets) context of the checkout, carried over from the cart context. Markets group countries and regions with shared pricing, languages, and domains. It updates when the buyer changes the country of their shipping address. The value is `undefined` if the market is unknown.
    *
-   * > Caution: This field is deprecated and is removed in a future version.
+   * > Caution: Deprecated as of version `2025-04`. Merchants now manage which extensions load for each market, so extensions no longer need to check this value.
    *
    * @deprecated Deprecated as of version `2025-04`
    */
@@ -460,14 +456,13 @@ export interface BuyerJourney {
    * This returns a promise that resolves to a teardown function. Calling the
    * teardown function removes the interceptor.
    *
-   * To block checkout progress, you must set the [block_progress](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#block-progress)
+   * To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/configuration#block-progress)
    * capability in your extension's configuration.
    *
    * If you do, then you're expected to inform the buyer why navigation was blocked,
    * either by passing validation errors to the checkout UI or rendering the errors in your extension.
    *
-   * It's good practice to show a warning in the checkout editor when the merchant hasn't given permission for your extension
-   * to block checkout progress.
+   * If the merchant hasn't allowed your extension to block checkout progress, show a warning in the [checkout editor](/docs/apps/build/checkout/test-checkout-ui-extensions#test-the-extension-in-the-checkout-editor).
    */
   intercept(interceptor: Interceptor): Promise<() => void>;
 
@@ -545,7 +540,7 @@ export interface BuyerJourneyStep {
 /** @publicDocs */
 export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
-   * The methods for interacting with [Web Pixels](https://shopify.dev/docs/apps/marketing), such as emitting an event.
+   * The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event.
    */
   analytics: Analytics;
 
@@ -572,7 +567,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * The metafields requested in the
-   * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration)
+   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration)
    * file. These metafields are updated when there's a change in the merchandise items
    * being purchased by the customer.
    *
@@ -593,7 +588,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   availablePaymentOptions: SubscribableSignalLike<PaymentOption[]>;
 
   /**
-   * Information about the buyer that's interacting with the checkout.
+   * Information about the buyer that's interacting with the checkout. The property is available only if the extension has access to protected customer data.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -602,7 +597,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.
    *
-   * Refer to [buyer journey](https://shopify.dev/docs/api/checkout-ui-extensions/apis/buyer-journey#examples)
+   * Refer to [buyer journey](/docs/api/checkout-ui-extensions/apis/buyer-journey#examples)
    * examples for more information.
    */
   buyerJourney: BuyerJourney;
@@ -619,13 +614,13 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * Use this to correlate checkout sessions across your extension, web pixels, and backend systems.
    *
-   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](https://shopify.dev/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)
-   * and the `checkout_token` field in the [REST Admin API `Order` resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
+   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)
+   * and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).
    */
   checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;
 
   /**
-   * The cost breakdown for the current checkout, including subtotal, shipping, tax, and total amounts. These values update as the buyer progresses through checkout and new costs are negotiated.
+   * The cost breakdown for the current checkout, including subtotal, shipping, tax, and total amounts. These values update as the buyer progresses through checkout and costs like shipping and tax are calculated.
    */
   cost: CartCost;
 
@@ -640,7 +635,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   discountCodes: SubscribableSignalLike<CartDiscountCode[]>;
 
   /**
-   * The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from Shopify Functions. Each allocation indicates how much was discounted and how the discount was triggered.
+   * The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from [Shopify Functions](/docs/apps/build/functions). Each allocation indicates how much was discounted and how the discount was triggered.
    */
   discountAllocations: SubscribableSignalLike<CartDiscountAllocation[]>;
 
@@ -655,8 +650,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * extension's configuration file.
    *
    * @example 'purchase.checkout.block.render'
-   * @see https://shopify.dev/docs/api/checkout-ui-extensions/latest/extension-targets-overview
-   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
+   * @see /docs/api/checkout-ui-extensions/latest/extension-targets-overview
+   * @see /docs/apps/app-extensions/configuration#targets
    *
    * @deprecated Deprecated as of version `2023-07`, use `extension.target` instead.
    */
@@ -664,10 +659,10 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * Utilities for translating content and formatting values according to the current
-   * [`localization`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization)
+   * [`localization`](/docs/api/checkout-ui-extensions/apis/localization)
    * of the checkout.
    *
-   * Refer to [`localization` examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#examples)
+   * Refer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples)
    * for more information.
    */
   i18n: I18n;
@@ -680,7 +675,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The details about the location, language, and currency of the customer. For utilities to easily
    * format and translate content based on these details, you can use the
-   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
+   * [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
    * object instead.
    */
   localization: Localization;
@@ -695,7 +690,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The method used to query the Storefront GraphQL API with a prefetched token.
    *
-   * Refer to [Storefront API access examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.
+   * Refer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.
    */
   query: <Data = unknown, Variables = Record<string, unknown>>(
     query: string,
@@ -714,15 +709,15 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * If the previous token expires, this value reflects a new session token with a new signature and expiry.
    *
-   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   * Refer to [session token examples](/docs/api/checkout-ui-extensions/apis/session-token) for more information.
    */
   sessionToken: SessionToken;
 
   /**
    * The settings matching the settings definition written in the
-   * [`shopify.extension.toml`](https://shopify.dev/docs/api/checkout-ui-extensions/configuration) file.
+   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.
    *
-   *  Refer to [settings examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.
+   *  Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.
    *
    * > Note: When an extension is being installed in the editor, the settings are empty until
    * a merchant sets a value. In that case, this object updates in real time as a merchant fills in the settings.
@@ -732,8 +727,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The proposed customer shipping address. During the information step, the address
    * updates when the field is committed (on change) rather than every keystroke.
-   * An address value is present only if delivery is required. Otherwise, the
-   * subscribable value is undefined.
+   * The property is available only if the extension has access to protected customer
+   * data. When available, the subscribable value is `undefined` if delivery isn't required.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -741,7 +736,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * The proposed customer billing address. The address updates when the field is
-   * committed (on change) rather than every keystroke.
+   * committed (on change) rather than every keystroke. The property is available only
+   * if the extension has access to protected customer data. The subscribable value is
+   * `undefined` if the billing address hasn't been provided yet.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -777,14 +774,14 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * Enables setting and updating customer privacy consent settings and tracking consent metafields.
    *
-   * > Note: Requires the [`customer_privacy` capability](https://shopify.dev/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be set to `true`.
+   * > Note: Requires the [`customer_privacy` capability](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be set to `true`.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
   applyTrackingConsentChange: ApplyTrackingConsentChangeType;
 
   /**
-   * Additional region-specific fields required during checkout, such as tax identification numbers (Brazil's CPF/CNPJ) or customs credentials. The value is `undefined` if the current checkout doesn't require any localized fields.
+   * Additional region-specific fields required during checkout, such as tax identification numbers (Brazil's CPF/CNPJ) or customs credentials. The property is available only if the extension has access to protected customer data. The array is empty if the current checkout doesn't require any localized fields.
    */
   localizedFields?: SubscribableSignalLike<LocalizedField[]>;
 }
@@ -814,7 +811,7 @@ export interface BuyerIdentity {
   customer: SubscribableSignalLike<Customer | undefined>;
 
   /**
-   * The email address associated with the checkout. This is the email the buyer provided during checkout for order confirmation and communication. The value is `undefined` if the app doesn't have access to customer data.
+   * The email address the buyer provided during checkout. The value is `undefined` if the app doesn't have access to customer data.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */
@@ -947,7 +944,7 @@ export interface CartCost {
   subtotalAmount: SubscribableSignalLike<Money>;
 
   /**
-   * The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been negotiated yet, such as when the buyer is still on the information step.
+   * The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been calculated yet, such as when the buyer is still on the information step.
    */
   totalShippingAmount: SubscribableSignalLike<Money | undefined>;
 
@@ -957,7 +954,7 @@ export interface CartCost {
   totalTaxAmount: SubscribableSignalLike<Money | undefined>;
 
   /**
-   * The minimum total the buyer can expect to pay at the current step of checkout. This excludes amounts that haven't been negotiated yet. For example, on the information step this won't include delivery costs because the buyer hasn't selected a shipping method. Gift cards and store credits are excluded from this total.
+   * The minimum total at the current step of checkout. Costs not yet calculated, such as shipping on the information step, aren't included. Gift cards and store credits are excluded from this total.
    */
   totalAmount: SubscribableSignalLike<Money>;
 }
@@ -1251,9 +1248,9 @@ export interface CartDiscountCode {
 /**
  * A discount allocation applied to the cart. Use the `type` property to determine how the discount was triggered:
  *
- * - `CartCodeDiscountAllocation` (`type: 'code'`) - Triggered by a discount code the buyer entered.
- * - `CartAutomaticDiscountAllocation` (`type: 'automatic'`) - Applied automatically based on merchant-configured rules.
- * - `CartCustomDiscountAllocation` (`type: 'custom'`) - Applied by a [Shopify Function](/docs/apps/build/discounts).
+ * - `CartCodeDiscountAllocation` (`type: 'code'`): Triggered by a discount code the buyer entered.
+ * - `CartAutomaticDiscountAllocation` (`type: 'automatic'`): Applied automatically based on merchant-configured rules.
+ * - `CartCustomDiscountAllocation` (`type: 'custom'`): Applied by a [Shopify Function](/docs/apps/build/discounts).
  */
 export type CartDiscountAllocation =
   | CartCodeDiscountAllocation
@@ -1379,9 +1376,9 @@ export interface InterceptorProps {
 /**
  * A function for intercepting and preventing navigation on checkout. You can block
  * navigation by returning an object with
- * `{behavior: 'block', reason: InvalidResultReason.InvalidExtensionState, errors?: ValidationErrors[]}`.
+ * `{behavior: 'block', reason: 'your reason here', errors?: ValidationError[]}`.
  * If you do, then you're expected to also update some part of your UI to reflect the reason why navigation
- * was blocked, either by targeting checkout UI fields, passing errors to the page level or rendering the errors in your extension.
+ * was blocked, either by targeting checkout UI fields, passing errors to the page level, or rendering the errors in your extension.
  */
 export type Interceptor = (
   interceptorProps: InterceptorProps,
@@ -1442,7 +1439,7 @@ export interface Customer {
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    *
-   * > Caution: This field is deprecated and is removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
+   * > Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
    *
    * @deprecated Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.
    */
@@ -1556,7 +1553,7 @@ export type ExtensionSettings = Record<
 
 export interface Analytics {
   /**
-   * Publish method to emit analytics events to [Web Pixels](https://shopify.dev/docs/apps/marketing).
+   * Publish method to emit analytics events to [Web Pixels](/docs/apps/marketing).
    */
   publish(name: string, data: Record<string, unknown>): Promise<boolean>;
 
@@ -1602,7 +1599,7 @@ export interface VisitorError {
  */
 export interface DeliveryGroup {
   /**
-   * A unique identifier for the delivery group. The value is `undefined` on the Thank You page because delivery groups aren't available after order completion.
+   * A unique identifier for the delivery group. The value is `undefined` if the underlying delivery line doesn't have an ID assigned.
    */
   id?: string;
   /**
@@ -1664,9 +1661,9 @@ export interface DeliveryOptionReference {
 /**
  * A delivery option available to the buyer. Use the `type` property to determine which kind of option it is:
  *
- * - `ShippingOption` (`type: 'shipping' | 'local'`) - Items shipped by a carrier or delivered locally by the merchant.
- * - `PickupPointOption` (`type: 'pickupPoint'`) - Items shipped to a third-party collection point for the buyer to pick up.
- * - `PickupLocationOption` (`type: 'pickup'`) - Items picked up directly from a merchant's store or warehouse.
+ * - `ShippingOption` (`type: 'shipping' | 'local'`): Items shipped by a carrier or delivered locally by the merchant.
+ * - `PickupPointOption` (`type: 'pickupPoint'`): Items shipped to a third-party collection point for the buyer to pick up.
+ * - `PickupLocationOption` (`type: 'pickup'`): Items picked up directly from a merchant's store or warehouse.
  */
 export type DeliveryOption =
   | ShippingOption
@@ -1700,7 +1697,7 @@ export interface DeliveryOptionBase {
   code: string;
 
   /**
-   * Custom [metafields](/docs/apps/build/custom-data/metafields) attached to this delivery option by the carrier or a Shopify Function. Use these to display additional information about the option.
+   * Custom [metafields](/docs/apps/build/custom-data/metafields) attached to this delivery option by the carrier or a [Shopify Function](/docs/apps/build/functions). Use these to display additional information about the option.
    */
   metafields: Metafield[];
 }
@@ -2089,9 +2086,9 @@ export interface AttributesCartInstructions {
 export interface DeliveryCartInstructions {
   /**
    * Whether the shipping address can be modified using
-   * `applyShippingAddressChange()`. When `true`, the buyer is using a
-   * standard checkout flow where the shipping address can be changed
-   * programmatically.
+   * `applyShippingAddressChange()`. When `false`, the buyer is using an
+   * accelerated checkout flow (Apple Pay, Google Pay) where the address
+   * can't be changed.
    */
   canSelectCustomAddress: boolean;
 }


### PR DESCRIPTION
Partially closes https://github.com/shop/issues-learn/issues/1047

## Summary

- Ports enriched JSDoc descriptions from checkout-web ([shop/world#548830](https://github.com/Shopify/world/pull/548830)) to ui-extensions `2026-04-rc`
- Covers all 16 Checkout APIs across 10 files: shared types, StandardApi, CheckoutApi, OrderConfirmationApi, CartLineItemApi, ShippingOptionItemApi, ShippingOptionListApi, PickupLocationItemApi, PickupLocationListApi, PickupPointListApi
- Every description verified against the 2026-04-rc TypeScript types
- Follows Shopify style guide: contractions, no Latinisms, present tense, colon bullet format for enums

## Test plan

- [x] `yarn tsc --noEmit` passes
- [x] `yarn docs:checkout 2026-04-rc` generates successfully
- [x] Verify enriched descriptions appear correctly in shopify-dev docs preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)