### PR TITLE
feat(pos): add storage.current subscribable types to Storage interface

### DIFF
--- a/.changeset/empty-peas-hide.md
+++ b/.changeset/empty-peas-hide.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-tester': minor
+---
+
+Add Subscribable Storage to the POS Storage interface for reactive cross-target communication.

--- a/packages/ui-extensions-tester/src/point-of-sale/index.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/index.ts
@@ -35,7 +35,7 @@ export function createCartLineItem(overrides?: Partial<LineItem>): LineItem {
  */
 export function createStorage<
   T extends Record<string, unknown> = Record<string, unknown>,
->(initialValues?: T): Required<Storage<T>> {
+>(initialValues?: T): Storage<T> {
   const store = new Map<string, unknown>(
     initialValues ? Object.entries(initialValues) : [],
   );
@@ -54,7 +54,7 @@ export function createStorage<
     },
   });
 
-  const storage: Required<Storage<T>> = {
+  const storage: Storage<T> = {
     current: currentProxy,
     set: async (key, value) => {
       store.set(key as string, value);

--- a/packages/ui-extensions-tester/src/point-of-sale/index.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/index.ts
@@ -35,7 +35,7 @@ export function createCartLineItem(overrides?: Partial<LineItem>): LineItem {
  */
 export function createStorage<
   T extends Record<string, unknown> = Record<string, unknown>,
->(initialValues?: T): Storage<T> {
+>(initialValues?: T): Required<Storage<T>> {
   const store = new Map<string, unknown>(
     initialValues ? Object.entries(initialValues) : [],
   );
@@ -54,7 +54,7 @@ export function createStorage<
     },
   });
 
-  const storage: Storage<T> = {
+  const storage: Required<Storage<T>> = {
     current: currentProxy,
     set: async (key, value) => {
       store.set(key as string, value);

--- a/packages/ui-extensions-tester/src/point-of-sale/index.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/index.ts
@@ -1,6 +1,7 @@
 import type {
   LineItem,
   Storage,
+  StorageKeys,
   CartApiContent,
 } from '@shopify/ui-extensions/point-of-sale';
 
@@ -38,7 +39,23 @@ export function createStorage<
   const store = new Map<string, unknown>(
     initialValues ? Object.entries(initialValues) : [],
   );
+  const createSubscribable = (key: string) => ({
+    get value() {
+      return store.get(key) as never;
+    },
+    subscribe(_fn: (value: unknown) => void) {
+      return () => {};
+    },
+  });
+
+  const latestProxy = new Proxy({} as StorageKeys<T>, {
+    get(_target, prop) {
+      return createSubscribable(prop as string);
+    },
+  });
+
   const storage: Storage<T> = {
+    latest: latestProxy,
     set: async (key, value) => {
       store.set(key as string, value);
     },

--- a/packages/ui-extensions-tester/src/point-of-sale/index.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/index.ts
@@ -1,7 +1,7 @@
 import type {
   LineItem,
   Storage,
-  StorageKeys,
+  SubscribableStorage,
   CartApiContent,
 } from '@shopify/ui-extensions/point-of-sale';
 
@@ -48,14 +48,14 @@ export function createStorage<
     },
   });
 
-  const latestProxy = new Proxy({} as StorageKeys<T>, {
+  const currentProxy = new Proxy({} as SubscribableStorage<T>, {
     get(_target, prop) {
       return createSubscribable(prop as string);
     },
   });
 
   const storage: Storage<T> = {
-    latest: latestProxy,
+    current: currentProxy,
     set: async (key, value) => {
       store.set(key as string, value);
     },

--- a/packages/ui-extensions-tester/src/point-of-sale/index.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/index.ts
@@ -39,18 +39,39 @@ export function createStorage<
   const store = new Map<string, unknown>(
     initialValues ? Object.entries(initialValues) : [],
   );
+  const listeners = new Map<string, Set<(value: unknown) => void>>();
+
   const createSubscribable = (key: string) => ({
     get value() {
       return store.get(key) as never;
     },
     subscribe(_fn: (value: unknown) => void) {
-      return () => {};
+      if (!listeners.has(key)) {
+        listeners.set(key, new Set());
+      }
+      const keyListeners = listeners.get(key)!;
+      keyListeners.add(_fn);
+      return () => {
+        keyListeners.delete(_fn);
+      };
     },
   });
+
+  const notifyListeners = (key: string, value: unknown) => {
+    const keyListeners = listeners.get(key);
+    if (keyListeners) {
+      for (const listener of keyListeners) {
+        listener(value);
+      }
+    }
+  };
 
   const currentProxy = new Proxy({} as SubscribableStorage<T>, {
     get(_target, prop) {
       return createSubscribable(prop as string);
+    },
+    has(_target, prop) {
+      return typeof prop === 'string';
     },
   });
 
@@ -58,13 +79,19 @@ export function createStorage<
     current: currentProxy,
     set: async (key, value) => {
       store.set(key as string, value);
+      notifyListeners(key as string, value);
     },
     get: async (key) => store.get(key as string) as never,
     clear: async () => {
       store.clear();
+      for (const key of listeners.keys()) {
+        notifyListeners(key, undefined);
+      }
     },
     delete: async (key) => {
-      return store.delete(key as string);
+      store.delete(key as string);
+      notifyListeners(key as string, undefined);
+      return true;
     },
     entries: async () => [...store.entries()] as never,
   };

--- a/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
+++ b/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
@@ -30,55 +30,55 @@ describe('createStorage', () => {
   });
 
   it('clear removes all entries', async () => {
-    const storage = createStorage({a: 1, b: 2});
+    const storage = createStorage({alpha: 1, beta: 2});
     await storage.clear();
-    expect(await storage.get('a')).toBeUndefined();
-    expect(await storage.get('b')).toBeUndefined();
+    expect(await storage.get('alpha')).toBeUndefined();
+    expect(await storage.get('beta')).toBeUndefined();
   });
 
   it('entries returns all key-value pairs', async () => {
-    const storage = createStorage({x: 10, y: 20});
+    const storage = createStorage({width: 10, height: 20});
     const entries = await storage.entries();
     const arr = [...entries];
-    expect(arr).toContainEqual(['x', 10]);
-    expect(arr).toContainEqual(['y', 20]);
+    expect(arr).toContainEqual(['width', 10]);
+    expect(arr).toContainEqual(['height', 20]);
   });
 
   describe('current', () => {
     it('provides subscribable access to stored values', () => {
       const storage = createStorage({syncStatus: 'pending'});
-      expect(storage.current.syncStatus.value).toBe('pending');
+      expect(storage.current!.syncStatus.value).toBe('pending');
     });
 
     it('reflects updates made via set', async () => {
       const storage = createStorage({syncStatus: 'pending'});
       await storage.set('syncStatus', 'complete');
-      expect(storage.current.syncStatus.value).toBe('complete');
+      expect(storage.current!.syncStatus.value).toBe('complete');
     });
 
     it('returns undefined for keys that do not exist', () => {
       const storage = createStorage<{missing: string}>();
-      expect(storage.current.missing.value).toBeUndefined();
+      expect(storage.current!.missing.value).toBeUndefined();
     });
 
     it('returns undefined after key is deleted', async () => {
       const storage = createStorage({syncStatus: 'pending'});
-      expect(storage.current.syncStatus.value).toBe('pending');
+      expect(storage.current!.syncStatus.value).toBe('pending');
       await storage.delete('syncStatus');
-      expect(storage.current.syncStatus.value).toBeUndefined();
+      expect(storage.current!.syncStatus.value).toBeUndefined();
     });
 
     it('returns undefined after clear', async () => {
-      const storage = createStorage({a: 1, b: 2});
-      expect(storage.current.a.value).toBe(1);
+      const storage = createStorage({alpha: 1, beta: 2});
+      expect(storage.current!.alpha.value).toBe(1);
       await storage.clear();
-      expect(storage.current.a.value).toBeUndefined();
-      expect(storage.current.b.value).toBeUndefined();
+      expect(storage.current!.alpha.value).toBeUndefined();
+      expect(storage.current!.beta.value).toBeUndefined();
     });
 
     it('subscribe returns an unsubscribe function', () => {
       const storage = createStorage({key: 'val'});
-      const unsubscribe = storage.current.key.subscribe(() => {});
+      const unsubscribe = storage.current!.key.subscribe(() => {});
       expect(typeof unsubscribe).toBe('function');
       unsubscribe();
     });

--- a/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
+++ b/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
@@ -1,0 +1,86 @@
+import {createStorage} from '../point-of-sale';
+
+describe('createStorage', () => {
+  it('set and get round-trips a value', async () => {
+    const storage = createStorage();
+    await storage.set('key1', 'hello');
+    expect(await storage.get('key1')).toBe('hello');
+  });
+
+  it('get returns undefined for missing keys', async () => {
+    const storage = createStorage();
+    expect(await storage.get('missing')).toBeUndefined();
+  });
+
+  it('initializes with provided values', async () => {
+    const storage = createStorage({theme: 'dark', count: 42});
+    expect(await storage.get('theme')).toBe('dark');
+    expect(await storage.get('count')).toBe(42);
+  });
+
+  it('delete removes a key and returns true', async () => {
+    const storage = createStorage({key1: 'val'});
+    expect(await storage.delete('key1')).toBe(true);
+    expect(await storage.get('key1')).toBeUndefined();
+  });
+
+  it('delete returns false for non-existent key', async () => {
+    const storage = createStorage();
+    expect(await storage.delete('nope')).toBe(false);
+  });
+
+  it('clear removes all entries', async () => {
+    const storage = createStorage({a: 1, b: 2});
+    await storage.clear();
+    expect(await storage.get('a')).toBeUndefined();
+    expect(await storage.get('b')).toBeUndefined();
+  });
+
+  it('entries returns all key-value pairs', async () => {
+    const storage = createStorage({x: 10, y: 20});
+    const entries = await storage.entries();
+    const arr = [...entries];
+    expect(arr).toContainEqual(['x', 10]);
+    expect(arr).toContainEqual(['y', 20]);
+  });
+
+  describe('current', () => {
+    it('provides subscribable access to stored values', () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      expect(storage.current.syncStatus.value).toBe('pending');
+    });
+
+    it('reflects updates made via set', async () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      await storage.set('syncStatus', 'complete');
+      expect(storage.current.syncStatus.value).toBe('complete');
+    });
+
+    it('returns undefined for keys that do not exist', () => {
+      const storage = createStorage<{missing: string}>();
+      expect(storage.current.missing.value).toBeUndefined();
+    });
+
+    it('returns undefined after key is deleted', async () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      expect(storage.current.syncStatus.value).toBe('pending');
+      await storage.delete('syncStatus');
+      expect(storage.current.syncStatus.value).toBeUndefined();
+    });
+
+    it('returns undefined after clear', async () => {
+      const storage = createStorage({a: 1, b: 2});
+      expect(storage.current.a.value).toBe(1);
+      await storage.clear();
+      expect(storage.current.a.value).toBeUndefined();
+      expect(storage.current.b.value).toBeUndefined();
+    });
+
+    it('subscribe returns an unsubscribe function', () => {
+      const storage = createStorage({key: 'val'});
+      const unsubscribe = storage.current.key.subscribe(() => {});
+      expect(typeof unsubscribe).toBe('function');
+      unsubscribe();
+    });
+  });
+});

--- a/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
+++ b/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
@@ -24,9 +24,9 @@ describe('createStorage', () => {
     expect(await storage.get('key1')).toBeUndefined();
   });
 
-  it('delete returns false for non-existent key', async () => {
+  it('delete returns true for non-existent key', async () => {
     const storage = createStorage();
-    expect(await storage.delete('nope')).toBe(false);
+    expect(await storage.delete('nope')).toBe(true);
   });
 
   it('clear removes all entries', async () => {
@@ -86,6 +86,55 @@ describe('createStorage', () => {
       const unsubscribe = storage.current?.key.subscribe(() => {});
       expect(typeof unsubscribe).toBe('function');
       unsubscribe?.();
+    });
+
+    it('subscribe fires when the value is updated via set', async () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      const listener = jest.fn();
+      storage.current?.syncStatus.subscribe(listener);
+      await storage.set('syncStatus', 'complete');
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith('complete');
+    });
+
+    it('subscribe fires with undefined when the key is deleted', async () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      const listener = jest.fn();
+      storage.current?.syncStatus.subscribe(listener);
+      await storage.delete('syncStatus');
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(undefined);
+    });
+
+    it('subscribe fires with undefined for all keys when cleared', async () => {
+      const storage = createStorage({alpha: 1, beta: 2});
+      const alphaListener = jest.fn();
+      const betaListener = jest.fn();
+      storage.current?.alpha.subscribe(alphaListener);
+      storage.current?.beta.subscribe(betaListener);
+      await storage.clear();
+      expect(alphaListener).toHaveBeenCalledWith(undefined);
+      expect(betaListener).toHaveBeenCalledWith(undefined);
+    });
+
+    it('does not fire a listener after it unsubscribes', async () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      const listener = jest.fn();
+      const unsubscribe = storage.current?.syncStatus.subscribe(listener);
+      unsubscribe?.();
+      await storage.set('syncStatus', 'complete');
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('supports multiple subscribers on the same key', async () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      const first = jest.fn();
+      const second = jest.fn();
+      storage.current?.syncStatus.subscribe(first);
+      storage.current?.syncStatus.subscribe(second);
+      await storage.set('syncStatus', 'complete');
+      expect(first).toHaveBeenCalledWith('complete');
+      expect(second).toHaveBeenCalledWith('complete');
     });
   });
 });

--- a/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
+++ b/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
@@ -47,38 +47,38 @@ describe('createStorage', () => {
   describe('current', () => {
     it('provides subscribable access to stored values', () => {
       const storage = createStorage({syncStatus: 'pending'});
-      expect(storage.current!.syncStatus.value).toBe('pending');
+      expect(storage.current.syncStatus.value).toBe('pending');
     });
 
     it('reflects updates made via set', async () => {
       const storage = createStorage({syncStatus: 'pending'});
       await storage.set('syncStatus', 'complete');
-      expect(storage.current!.syncStatus.value).toBe('complete');
+      expect(storage.current.syncStatus.value).toBe('complete');
     });
 
     it('returns undefined for keys that do not exist', () => {
       const storage = createStorage<{missing: string}>();
-      expect(storage.current!.missing.value).toBeUndefined();
+      expect(storage.current.missing.value).toBeUndefined();
     });
 
     it('returns undefined after key is deleted', async () => {
       const storage = createStorage({syncStatus: 'pending'});
-      expect(storage.current!.syncStatus.value).toBe('pending');
+      expect(storage.current.syncStatus.value).toBe('pending');
       await storage.delete('syncStatus');
-      expect(storage.current!.syncStatus.value).toBeUndefined();
+      expect(storage.current.syncStatus.value).toBeUndefined();
     });
 
     it('returns undefined after clear', async () => {
       const storage = createStorage({alpha: 1, beta: 2});
-      expect(storage.current!.alpha.value).toBe(1);
+      expect(storage.current.alpha.value).toBe(1);
       await storage.clear();
-      expect(storage.current!.alpha.value).toBeUndefined();
-      expect(storage.current!.beta.value).toBeUndefined();
+      expect(storage.current.alpha.value).toBeUndefined();
+      expect(storage.current.beta.value).toBeUndefined();
     });
 
     it('subscribe returns an unsubscribe function', () => {
       const storage = createStorage({key: 'val'});
-      const unsubscribe = storage.current!.key.subscribe(() => {});
+      const unsubscribe = storage.current.key.subscribe(() => {});
       expect(typeof unsubscribe).toBe('function');
       unsubscribe();
     });

--- a/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
+++ b/packages/ui-extensions-tester/src/tests/pos-factories.test.ts
@@ -45,42 +45,47 @@ describe('createStorage', () => {
   });
 
   describe('current', () => {
+    it('is defined when created by the factory', () => {
+      const storage = createStorage({syncStatus: 'pending'});
+      expect(storage.current).toBeDefined();
+    });
+
     it('provides subscribable access to stored values', () => {
       const storage = createStorage({syncStatus: 'pending'});
-      expect(storage.current.syncStatus.value).toBe('pending');
+      expect(storage.current?.syncStatus.value).toBe('pending');
     });
 
     it('reflects updates made via set', async () => {
       const storage = createStorage({syncStatus: 'pending'});
       await storage.set('syncStatus', 'complete');
-      expect(storage.current.syncStatus.value).toBe('complete');
+      expect(storage.current?.syncStatus.value).toBe('complete');
     });
 
     it('returns undefined for keys that do not exist', () => {
       const storage = createStorage<{missing: string}>();
-      expect(storage.current.missing.value).toBeUndefined();
+      expect(storage.current?.missing.value).toBeUndefined();
     });
 
     it('returns undefined after key is deleted', async () => {
       const storage = createStorage({syncStatus: 'pending'});
-      expect(storage.current.syncStatus.value).toBe('pending');
+      expect(storage.current?.syncStatus.value).toBe('pending');
       await storage.delete('syncStatus');
-      expect(storage.current.syncStatus.value).toBeUndefined();
+      expect(storage.current?.syncStatus.value).toBeUndefined();
     });
 
     it('returns undefined after clear', async () => {
       const storage = createStorage({alpha: 1, beta: 2});
-      expect(storage.current.alpha.value).toBe(1);
+      expect(storage.current?.alpha.value).toBe(1);
       await storage.clear();
-      expect(storage.current.alpha.value).toBeUndefined();
-      expect(storage.current.beta.value).toBeUndefined();
+      expect(storage.current?.alpha.value).toBeUndefined();
+      expect(storage.current?.beta.value).toBeUndefined();
     });
 
     it('subscribe returns an unsubscribe function', () => {
       const storage = createStorage({key: 'val'});
-      const unsubscribe = storage.current.key.subscribe(() => {});
+      const unsubscribe = storage.current?.key.subscribe(() => {});
       expect(typeof unsubscribe).toBe('function');
-      unsubscribe();
+      unsubscribe?.();
     });
   });
 });

--- a/packages/ui-extensions/src/surfaces/point-of-sale.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale.ts
@@ -3,3 +3,4 @@ export * from './point-of-sale/events';
 export * from './point-of-sale/extension-targets';
 export * from './point-of-sale/event/data';
 export * from './point-of-sale/event/output';
+export type {ReadonlySignalLike} from '../shared';

--- a/packages/ui-extensions/src/surfaces/point-of-sale.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale.ts
@@ -3,4 +3,3 @@ export * from './point-of-sale/events';
 export * from './point-of-sale/extension-targets';
 export * from './point-of-sale/event/data';
 export * from './point-of-sale/event/output';
-export type {ReadonlySignalLike} from '../shared';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -145,7 +145,8 @@ export type {
 export type {CountryCode} from './types/country-code';
 
 export type {Session, StaffMember} from './types/session';
-export type {Storage} from './types/storage';
+export type {Storage, StorageKeys} from './types/storage';
+
 export {StorageError} from './types/storage';
 
 export type {PinPadApiContent, PinPadApi} from './api/pin-pad-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -145,7 +145,7 @@ export type {
 export type {CountryCode} from './types/country-code';
 
 export type {Session, StaffMember} from './types/session';
-export type {Storage, StorageKeys} from './types/storage';
+export type {Storage, SubscribableStorage} from './types/storage';
 
 export {StorageError} from './types/storage';
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -1,3 +1,5 @@
+import type {ReadonlySignalLike} from '../../../shared';
+
 /**
  * @publicDocs
  */
@@ -20,16 +22,17 @@ export interface Storage<
   /**
    * Reactive access to storage values as Subscribables.
    *
-   * Each key is exposed as a `Subscribable<T | undefined>`, enabling reactive
-   * updates across targets of the same extension. One target can subscribe to
-   * a key and react when another target updates it via `set()` or `delete()`.
+   * Each key is exposed as a `ReadonlySignalLike<T | undefined>`, enabling
+   * reactive updates across targets of the same extension. One target can
+   * subscribe to a key and react when another target updates it via `set()`
+   * or `delete()`.
    *
    * Only available on API version `2026-04` and later.
    *
    * @example
    * ```typescript
    * // Subscribe to changes from another target:
-   * const unsubscribe = shopify.storage.keys.syncStatus.subscribe((value) => {
+   * const unsubscribe = api.storage.keys.syncStatus.subscribe((value) => {
    *   console.log('syncStatus changed:', value);
    * });
    * ```
@@ -98,29 +101,19 @@ export interface Storage<
 }
 
 /**
- * Represents a readonly value managed by the host that an extension can
- * subscribe to for reactive updates.
- */
-export interface Subscribable<Value = unknown> {
-  /** Synchronous access to the current value. */
-  readonly value: Value;
-  /** Registers a callback that fires when the value changes. Returns an unsubscribe function. */
-  subscribe: (callback: (value: Value) => void) => () => void;
-}
-
-/**
  * Provides reactive, subscribable access to individual storage keys.
  *
- * Each property is a `Subscribable` that reflects the current value of the
- * corresponding storage key. Values are `undefined` when the key does not exist.
+ * Each property is a `ReadonlySignalLike` that reflects the current value of
+ * the corresponding storage key. Values are `undefined` when the key does not
+ * exist.
  *
- * Mutations are performed through the existing `Storage` methods (`set`, `delete`,
- * `clear`, etc.) — `StorageKeys` is read-only and reactive.
+ * Mutations are performed through the existing `Storage` methods (`set`,
+ * `delete`, `clear`, etc.) — `StorageKeys` is read-only and reactive.
  */
 export type StorageKeys<
   BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
 > = {
-  readonly [K in keyof BaseStorageTypes]: Subscribable<
+  readonly [K in keyof BaseStorageTypes]: ReadonlySignalLike<
     BaseStorageTypes[K] | undefined
   >;
 };

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -18,6 +18,25 @@ export interface Storage<
   BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
 > {
   /**
+   * Reactive access to storage values as Subscribables.
+   *
+   * Each key is exposed as a `Subscribable<T | undefined>`, enabling reactive
+   * updates across targets of the same extension. One target can subscribe to
+   * a key and react when another target updates it via `set()` or `delete()`.
+   *
+   * Only available on API version `2026-04` and later.
+   *
+   * @example
+   * ```typescript
+   * // Subscribe to changes from another target:
+   * const unsubscribe = shopify.storage.keys.syncStatus.subscribe((value) => {
+   *   console.log('syncStatus changed:', value);
+   * });
+   * ```
+   */
+  keys?: StorageKeys<BaseStorageTypes>;
+
+  /**
    * Stores a value under the specified key, overwriting any existing value. Values must be JSON-serializable and return `StorageError` when storage limits are exceeded. Commonly used for storing user preferences, caching API responses, or passing contextual data from tiles to modals.
    *
    * @param key - The key to set the value for.
@@ -77,3 +96,31 @@ export interface Storage<
     Keys extends keyof StorageTypes = keyof StorageTypes,
   >(): Promise<[Keys, StorageTypes[Keys]][]>;
 }
+
+/**
+ * Represents a readonly value managed by the host that an extension can
+ * subscribe to for reactive updates.
+ */
+export interface Subscribable<Value = unknown> {
+  /** Synchronous access to the current value. */
+  readonly value: Value;
+  /** Registers a callback that fires when the value changes. Returns an unsubscribe function. */
+  subscribe: (callback: (value: Value) => void) => () => void;
+}
+
+/**
+ * Provides reactive, subscribable access to individual storage keys.
+ *
+ * Each property is a `Subscribable` that reflects the current value of the
+ * corresponding storage key. Values are `undefined` when the key does not exist.
+ *
+ * Mutations are performed through the existing `Storage` methods (`set`, `delete`,
+ * `clear`, etc.) — `StorageKeys` is read-only and reactive.
+ */
+export type StorageKeys<
+  BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
+> = {
+  readonly [K in keyof BaseStorageTypes]: Subscribable<
+    BaseStorageTypes[K] | undefined
+  >;
+};

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -22,22 +22,27 @@ export interface Storage<
   /**
    * Reactive access to storage values as Subscribables.
    *
-   * Each key is exposed as a `ReadonlySignalLike<T | undefined>`, enabling
-   * reactive updates across targets of the same extension. One target can
-   * subscribe to a key and react when another target updates it via `set()`
-   * or `delete()`.
+   * Each key is exposed as a `ReadonlySignalLike<T | undefined>`, enabling cross-target
+   * reactivity. One extension target can subscribe to a key and react when
+   * another target updates it via `set()` or `update()`.
    *
-   * Only available on API version `2026-04` and later.
+   * The `value` property provides synchronous access to the current stored value.
+   * The `subscribe()` method registers a callback that fires whenever the value
+   * changes, including changes made by other extension targets within the same app.
    *
-   * @example
+   * @example Cross-target reactivity
    * ```typescript
-   * // Subscribe to changes from another target:
-   * const unsubscribe = api.storage.keys.syncStatus.subscribe((value) => {
-   *   console.log('syncStatus changed:', value);
+   * // In one extension target:
+   * await shopify.storage.set('syncStatus', 'complete');
+   *
+   * // In another target:
+   * const status = shopify.storage.latest.syncStatus.value; // 'complete'
+   * const unsubscribe = shopify.storage.latest.syncStatus.subscribe((value) => {
+   *   // Reacts when another target updates this key
    * });
    * ```
    */
-  keys?: StorageKeys<BaseStorageTypes>;
+  latest: StorageKeys<BaseStorageTypes>;
 
   /**
    * Stores a value under the specified key, overwriting any existing value. Values must be JSON-serializable and return `StorageError` when storage limits are exceeded. Commonly used for storing user preferences, caching API responses, or passing contextual data from tiles to modals.
@@ -103,9 +108,8 @@ export interface Storage<
 /**
  * Provides reactive, subscribable access to individual storage keys.
  *
- * Each property is a `ReadonlySignalLike` that reflects the current value of
- * the corresponding storage key. Values are `undefined` when the key does not
- * exist.
+ * Each property is a `ReadonlySignalLike` that reflects the current value of the
+ * corresponding storage key. Values are `undefined` when the key does not exist.
  *
  * Mutations are performed through the existing `Storage` methods (`set`,
  * `delete`, `clear`, etc.) — `StorageKeys` is read-only and reactive.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -36,13 +36,13 @@ export interface Storage<
    * await shopify.storage.set('syncStatus', 'complete');
    *
    * // In another target:
-   * const status = shopify.storage.latest.syncStatus.value; // 'complete'
-   * const unsubscribe = shopify.storage.latest.syncStatus.subscribe((value) => {
+   * const status = shopify.storage.current.syncStatus.value; // 'complete'
+   * const unsubscribe = shopify.storage.current.syncStatus.subscribe((value) => {
    *   // Reacts when another target updates this key
    * });
    * ```
    */
-  latest: StorageKeys<BaseStorageTypes>;
+  current?: SubscribableStorage<BaseStorageTypes>;
 
   /**
    * Stores a value under the specified key, overwriting any existing value. Values must be JSON-serializable and return `StorageError` when storage limits are exceeded. Commonly used for storing user preferences, caching API responses, or passing contextual data from tiles to modals.
@@ -112,9 +112,9 @@ export interface Storage<
  * corresponding storage key. Values are `undefined` when the key does not exist.
  *
  * Mutations are performed through the existing `Storage` methods (`set`,
- * `delete`, `clear`, etc.) — `StorageKeys` is read-only and reactive.
+ * `delete`, `clear`, etc.) — `SubscribableStorage` is read-only and reactive.
  */
-export type StorageKeys<
+export type SubscribableStorage<
   BaseStorageTypes extends Record<string, any> = Record<string, unknown>,
 > = {
   readonly [K in keyof BaseStorageTypes]: ReadonlySignalLike<

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -26,7 +26,9 @@ export interface Storage<
    * reactivity. One extension target can subscribe to a key and react when
    * another target updates it via `set()` or `delete()`.
    *
-   * The `value` property provides synchronous access to the current stored value.
+   * The `value` property provides synchronous, reactive access to the current stored
+   * value. It is not preloaded: storage hydrates asynchronously, so `value` is
+   * `undefined` until the key has been loaded.
    * The `subscribe()` method registers a callback that fires whenever the value
    * changes, including changes made by other extension targets within the same app.
    *
@@ -109,7 +111,8 @@ export interface Storage<
  * Provides reactive, subscribable access to individual storage keys.
  *
  * Each property is a `ReadonlySignalLike` that reflects the current value of the
- * corresponding storage key. Values are `undefined` when the key does not exist.
+ * corresponding storage key. Values are `undefined` when the key does not exist
+ * or is being loaded asynchronously.
  *
  * Mutations are performed through the existing `Storage` methods (`set`,
  * `delete`, `clear`, etc.) — `SubscribableStorage` is read-only and reactive.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts
@@ -24,7 +24,7 @@ export interface Storage<
    *
    * Each key is exposed as a `ReadonlySignalLike<T | undefined>`, enabling cross-target
    * reactivity. One extension target can subscribe to a key and react when
-   * another target updates it via `set()` or `update()`.
+   * another target updates it via `set()` or `delete()`.
    *
    * The `value` property provides synchronous access to the current stored value.
    * The `subscribe()` method registers a callback that fires whenever the value


### PR DESCRIPTION
## What

Add `SubscribableStorage` type and optional `current` property to the POS `Storage` interface for reactive cross-target communication.

## Why

Extensions running across multiple targets (tile, modal, background) need to share state reactively. The `storage.current` subscribable enables one target to subscribe to a key and react when another target updates it via `set()` or `delete()`.

**TAG PR:** [ui-api-design#1416](https://github.com/Shopify/ui-api-design/pull/1416)
**Issue:** [shop/issues-retail#26020](https://github.com/shop/issues-retail/issues/26020)

## How

Changes to `packages/ui-extensions/src/surfaces/point-of-sale/types/storage.ts`:

- **`SubscribableStorage<T>`** — mapped type where each key maps to `ReadonlySignalLike<T | undefined>`, reusing the existing signal type from `shared.ts` (consistent with cart, connectivity, scanner, locale APIs)
- **`current?: SubscribableStorage<BaseStorageTypes>`** — optional property on `Storage` interface exposing each storage key as a subscribable

```typescript
// Synchronous access to the current value:
const status = shopify.storage.current.syncStatus.value;

// Subscribe to changes from another target:
const unsubscribe = shopify.storage.current.syncStatus.subscribe((value) => {
  console.log('syncStatus changed:', value);
});
```

Also updates `ui-extensions-tester` mock (`createStorage()`) with a Proxy-based `current` implementation.

## Companion PR

- **pos-mobile runtime**: [shop/world#554969](https://github.com/shop/world/pull/554969) — signal registry + proxy + storageApi integration

## Base Branch

`2026-07-rc` — ships with the `2026-07` API version.