### PR TITLE
Revert "Update POS cart api docs to reflect discount per unit allocation"

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -158,12 +158,12 @@ export interface CartApiContent {
   removeLineItemProperties(uuid: string, keys: string[]): Promise<void>;
 
   /**
-   * Apply a discount to a specific line item using its `UUID`. Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value with improved discount allocation tracking. For `FixedAmount` discounts, this is the per-unit amount. For example, passing `'5.00'` on a line item with quantity 2 results in $10.00 total discount.
+   * Apply a discount to a specific line item using its `UUID`. Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value with improved discount allocation tracking.
    *
    * @param uuid the uuid of the line item that should receive a discount
    * @param type the type of discount applied (example: 'Percentage')
    * @param title the title attributed with the discount
-   * @param amount the percentage or fixed monetary amount deducted with the discount
+   * @param amount the percentage or fixed monetary amount deducted with the discout
    */
   setLineItemDiscount(
     uuid: string,
@@ -173,9 +173,9 @@ export interface CartApiContent {
   ): Promise<void>;
 
   /**
-   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations with enhanced validation and allocation tracking. For `FixedAmount` discounts, the amount is applied per unit.
+   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations with enhanced validation and allocation tracking.
    *
-   * @param lineItemDiscounts a map of discounts to add. The key is the uuid of the line item you want to add the discount to. The value is the discount input.
+   * @param lineItemDiscounts a map of discounts to add. They key is the uuid of the line item you want to add the discount to. The value is the discount input.
    */
   bulkSetLineItemDiscounts(
     lineItemDiscounts: SetLineItemDiscountInput[],


### PR DESCRIPTION
Part of https://github.com/shop/issues-retail/issues/26513

### Background

Reverting https://github.com/Shopify/ui-extensions/pull/4231 PR to defer this change to 2026-07. Will update docs then. No update needed on the `shopify-dev` dev side since the doc update PR was never merged (https://github.com/shop/world/pull/553810).

### Solution

n/a

### 🎩

- Ran `yarn docs:point-of-sale 2026-04` in this repo.
- Provide absolute path for the `shopify-dev` repo location (should be something like `/Users/janezhu/world/trees/root/src/areas/platforms/shopify-dev/`)

- In `shopify-dev` repo (now in the monorepo), run `dev server`
- Go to your local https://shopify-dev.shop.dev/docs/api/pos-ui-extensions/2026-04-rc/target-apis/contextual-apis/cart-api to see the reverted docs:

![Screenshot 2026-03-30 at 12.00.22 PM.png](https://app.graphite.com/user-attachments/assets/6025f2bd-a199-47d5-b8ae-be00bae78b55.png)

![Screenshot 2026-03-30 at 12.00.59 PM.png](https://app.graphite.com/user-attachments/assets/b3cd2c55-fc0b-4ed4-8fc9-d8d5a504a918.png)



### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation