### PR TITLE
fix: post-process generated_docs_data_v2.json in checkout build 2026-01

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs.sh
@@ -90,6 +90,7 @@ fi
 # Make sure https://shopify.dev URLs are relative.
 # See https://github.com/Shopify/generate-docs/issues/181
 run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data.json
+run_sed 's/https:\/\/shopify.dev//gi' ./$DOCS_PATH/generated/generated_docs_data_v2.json
 sed_exit=$?
 if [ $sed_exit -ne 0 ]; then
   fail_and_exit $sed_exit
@@ -111,7 +112,7 @@ if [ -d $SHOPIFY_DEV_PATH ]; then
   cp ./$DOCS_PATH/generated/* $SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION
 
   # Replace 'latest' with the exact API version in relative doc links
-  for file in generated_docs_data.json generated_static_pages.json; do
+  for file in generated_docs_data.json generated_docs_data_v2.json generated_static_pages.json; do
     run_sed \
       "s/\/docs\/api\/checkout-ui-extensions\/latest/\/docs\/api\/checkout-ui-extensions\/$API_VERSION/gi" \
       "$SHOPIFY_DEV_PATH/areas/platforms/shopify-dev/db/data/docs/templated_apis/checkout_extensions/$API_VERSION/$file"


### PR DESCRIPTION
## Summary

- Adds `generated_docs_data_v2.json` to the URL-stripping `run_sed` call (strips `https://shopify.dev` to make URLs relative)
- Adds `generated_docs_data_v2.json` to the version-replacement `for` loop (replaces `/latest` with actual API version)

The v2 file was being generated but skipped by both post-processing steps, leaving absolute URLs that caused staging links to point to production shopify.dev.

## Test plan

- [x] Temporarily bumped generate-docs from 0.19.8 to 1.1.0 (not committed) to produce v2 output
- [x] Ran `yarn docs:checkout 2026-01`
- [x] Verified `grep -c 'https://shopify.dev' generated_docs_data_v2.json` returns 0 (v2 URLs now relative)
- [x] Verified `grep -c 'https://shopify.dev' generated_docs_data.json` returns 0 (v1 still correct)

Also opened against `2026-04-rc` (#4242) and `2025-10` (#4244).