### PR TITLE
[Customer account UI extensions 2026-04-rc]: Remove duplicate descriptions being pulled into docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
@@ -37,10 +37,7 @@ declare const CHECKOUT_AVAILABLE_ICONS: readonly ["alert-circle", "alert-triangl
 export type ReducedIconTypes = (typeof CHECKOUT_AVAILABLE_ICONS)[number];
 
 declare const tagName = "s-icon";
-/**
- * The element props interface for the Icon component.
- * @publicDocs
- */
+
 export interface IconElementProps extends Pick<IconProps$1, 'id' | 'size' | 'tone' | 'type'> {
     /**
      * The semantic meaning and color treatment of the icon.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
@@ -37,7 +37,7 @@ declare const CHECKOUT_AVAILABLE_ICONS: readonly ["alert-circle", "alert-triangl
 export type ReducedIconTypes = (typeof CHECKOUT_AVAILABLE_ICONS)[number];
 
 declare const tagName = "s-icon";
-
+/** @publicDocs */
 export interface IconElementProps extends Pick<IconProps$1, 'id' | 'size' | 'tone' | 'type'> {
     /**
      * The semantic meaning and color treatment of the icon.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
@@ -49,7 +49,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-image";
-
+/** @publicDocs */
 export interface ImageElementProps extends Pick<ImageProps$1, 'accessibilityRole' | 'alt' | 'aspectRatio' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'id' | 'inlineSize' | 'loading' | 'objectFit' | 'sizes' | 'src' | 'srcSet'> {
     /**
      * A shorthand for setting the border around the image. Accepts a size keyword alone (for example, `'base'`), a size and color (for example, `'base base'`), or a size, color, and style (for example, `'base base solid'`). Use `'none'` to remove the border.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
@@ -49,10 +49,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-image";
-/**
- * The element props interface for the Image component.
- * @publicDocs
- */
+
 export interface ImageElementProps extends Pick<ImageProps$1, 'accessibilityRole' | 'alt' | 'aspectRatio' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'id' | 'inlineSize' | 'loading' | 'objectFit' | 'sizes' | 'src' | 'srcSet'> {
     /**
      * A shorthand for setting the border around the image. Accepts a size keyword alone (for example, `'base'`), a size and color (for example, `'base base'`), or a size, color, and style (for example, `'base base solid'`). Use `'none'` to remove the border.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
@@ -50,7 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map";
-
+/** @publicDocs */
 export interface MapElementProps extends Pick<MapProps$1, 'accessibilityLabel' | 'apiKey' | 'blockSize' | 'id' | 'inlineSize' | 'latitude' | 'longitude' | 'maxBlockSize' | 'maxInlineSize' | 'maxZoom' | 'minBlockSize' | 'minInlineSize' | 'minZoom' | 'zoom'> {
 }
 /**
@@ -107,7 +107,7 @@ export interface MapViewChangeEvent extends MapLocationEvent {
      */
     zoom?: number;
 }
-
+/** @publicDocs */
 export interface MapElementEvents {
     /**
      * A callback fired when the visible map boundaries change, such as after a pan or zoom completes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
@@ -50,10 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map";
-/**
- * The element props interface for the Map component.
- * @publicDocs
- */
+
 export interface MapElementProps extends Pick<MapProps$1, 'accessibilityLabel' | 'apiKey' | 'blockSize' | 'id' | 'inlineSize' | 'latitude' | 'longitude' | 'maxBlockSize' | 'maxInlineSize' | 'maxZoom' | 'minBlockSize' | 'minInlineSize' | 'minZoom' | 'zoom'> {
 }
 /**
@@ -110,10 +107,7 @@ export interface MapViewChangeEvent extends MapLocationEvent {
      */
     zoom?: number;
 }
-/**
- * The events interface for the Map component.
- * @publicDocs
- */
+
 export interface MapElementEvents {
     /**
      * A callback fired when the visible map boundaries change, such as after a pan or zoom completes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
@@ -38,10 +38,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map-marker";
-/**
- * The element props interface for the MapMarker component.
- * @publicDocs
- */
+
 export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibilityLabel' | 'blockSize' | 'command' | 'commandFor' | 'clusterable' | 'inlineSize' | 'latitude' | 'longitude'> {
     /**
      * Sets the action the `commandFor` target should take when this marker is activated. See the documentation of particular components for the actions they support. Learn more about the [`command` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
@@ -64,10 +61,7 @@ export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibi
  */
 export interface MapMarkerEvents extends Pick<MapMarkerProps$1, 'onClick'> {
 }
-/**
- * The events interface for the MapMarker component.
- * @publicDocs
- */
+
 export interface MapMarkerElementEvents {
     /**
      * A callback fired when the user clicks on the marker. This event does not propagate to the parent map — only the marker receives the click.

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
@@ -38,7 +38,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map-marker";
-
+/** @publicDocs */
 export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibilityLabel' | 'blockSize' | 'command' | 'commandFor' | 'clusterable' | 'inlineSize' | 'latitude' | 'longitude'> {
     /**
      * Sets the action the `commandFor` target should take when this marker is activated. See the documentation of particular components for the actions they support. Learn more about the [`command` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
@@ -61,7 +61,7 @@ export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibi
  */
 export interface MapMarkerEvents extends Pick<MapMarkerProps$1, 'onClick'> {
 }
-
+/** @publicDocs */
 export interface MapMarkerElementEvents {
     /**
      * A callback fired when the user clicks on the marker. This event does not propagate to the parent map — only the marker receives the click.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
@@ -50,10 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-modal";
-/**
- * The element props interface for the Modal component.
- * @publicDocs
- */
+
 export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding' | 'size'> {
     /**
      * The size of the modal.
@@ -69,10 +66,7 @@ export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabe
      */
     size?: Extract<ModalProps$1['size'], 'small-100' | 'small' | 'base' | 'large-100' | 'large' | 'max'>;
 }
-/**
- * The slots interface for the Modal component.
- * @publicDocs
- */
+
 export interface ModalElementSlots {
     /**
      * The main action button displayed in the modal footer, representing the primary action users should take. Only accepts a single button component.
@@ -88,16 +82,10 @@ export interface ModalElementSlots {
  */
 export interface ModalEvents extends Pick<ModalProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
-/**
- * The methods interface for the Modal component.
- * @publicDocs
- */
+
 export interface ModalElementMethods extends Pick<ModalProps$1, 'hideOverlay'> {
 }
-/**
- * The events interface for the Modal component.
- * @publicDocs
- */
+
 export interface ModalElementEvents {
     /**
      * A callback fired when the modal is hidden, after any hide animations have completed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
@@ -50,7 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-modal";
-
+/** @publicDocs */
 export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding' | 'size'> {
     /**
      * The size of the modal.
@@ -66,7 +66,7 @@ export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabe
      */
     size?: Extract<ModalProps$1['size'], 'small-100' | 'small' | 'base' | 'large-100' | 'large' | 'max'>;
 }
-
+/** @publicDocs */
 export interface ModalElementSlots {
     /**
      * The main action button displayed in the modal footer, representing the primary action users should take. Only accepts a single button component.
@@ -83,9 +83,10 @@ export interface ModalElementSlots {
 export interface ModalEvents extends Pick<ModalProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
 
+/** @publicDocs */
 export interface ModalElementMethods extends Pick<ModalProps$1, 'hideOverlay'> {
 }
-
+/** @publicDocs */
 export interface ModalElementEvents {
     /**
      * A callback fired when the modal is hidden, after any hide animations have completed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
@@ -29,7 +29,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-payment-icon";
-
+/** @publicDocs */
 export interface PaymentIconElementProps extends PaymentIconProps$1 {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
@@ -29,10 +29,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-payment-icon";
-/**
- * The element props interface for the PaymentIcon component.
- * @publicDocs
- */
+
 export interface PaymentIconElementProps extends PaymentIconProps$1 {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
@@ -50,7 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-popover";
-
+/** @publicDocs */
 export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
     /**
      * The block size of the popover (height in horizontal writing modes). Learn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
@@ -94,7 +94,7 @@ export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
  */
 export interface PopoverEvents extends Pick<PopoverProps$1, 'onHide' | 'onShow'> {
 }
-
+/** @publicDocs */
 export interface PopoverElementEvents {
     /**
      * A callback fired immediately after the popover is hidden.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
@@ -50,10 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-popover";
-/**
- * The element props interface for the Popover component.
- * @publicDocs
- */
+
 export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
     /**
      * The block size of the popover (height in horizontal writing modes). Learn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
@@ -97,10 +94,7 @@ export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
  */
 export interface PopoverEvents extends Pick<PopoverProps$1, 'onHide' | 'onShow'> {
 }
-/**
- * The events interface for the Popover component.
- * @publicDocs
- */
+
 export interface PopoverElementEvents {
     /**
      * A callback fired immediately after the popover is hidden.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
@@ -29,10 +29,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-product-thumbnail";
-/**
- * The element props interface for the ProductThumbnail component.
- * @publicDocs
- */
+
 export interface ProductThumbnailElementProps extends Pick<ProductThumbnailProps$1, 'alt' | 'size' | 'sizes' | 'src' | 'srcSet' | 'totalItems'> {
     /**
      * The size of the product thumbnail image.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
@@ -29,7 +29,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-product-thumbnail";
-
+/** @publicDocs */
 export interface ProductThumbnailElementProps extends Pick<ProductThumbnailProps$1, 'alt' | 'size' | 'sizes' | 'src' | 'srcSet' | 'totalItems'> {
     /**
      * The size of the product thumbnail image.

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
@@ -41,10 +41,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-qr-code";
-/**
- * The element props interface for the QRCode component.
- * @publicDocs
- */
+
 export interface QRCodeElementProps extends QRCodeProps$1 {
 }
 /**
@@ -52,10 +49,7 @@ export interface QRCodeElementProps extends QRCodeProps$1 {
  */
 export interface QRCodeEvents extends Pick<QRCodeProps$1, 'onError'> {
 }
-/**
- * The events interface for the QRCode component.
- * @publicDocs
- */
+
 export interface QRCodeElementEvents {
     /**
      * A callback that's fired when the conversion of `content` to a QR code fails.

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
@@ -41,7 +41,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-qr-code";
-
+/** @publicDocs */
 export interface QRCodeElementProps extends QRCodeProps$1 {
 }
 /**
@@ -49,7 +49,7 @@ export interface QRCodeElementProps extends QRCodeProps$1 {
  */
 export interface QRCodeEvents extends Pick<QRCodeProps$1, 'onError'> {
 }
-
+/** @publicDocs */
 export interface QRCodeElementEvents {
     /**
      * A callback that's fired when the conversion of `content` to a QR code fails.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
@@ -50,10 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-sheet";
-/**
- * The element props interface for the Sheet component.
- * @publicDocs
- */
+
 export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'heading' | 'id'> {
     /**
      * A label that describes the purpose of the sheet, announced by assistive technologies. When set, screen readers will use this label instead of the `heading` to describe the sheet.
@@ -65,10 +62,7 @@ export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'h
  */
 export interface SheetEvents extends Pick<SheetProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
-/**
- * The events interface for the Sheet component.
- * @publicDocs
- */
+
 export interface SheetElementEvents {
     /**
      * A callback fired when the sheet is hidden, after any hide animations have completed.
@@ -87,10 +81,7 @@ export interface SheetElementEvents {
      */
     show?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The slots interface for the Sheet component.
- * @publicDocs
- */
+
 export interface SheetElementSlots {
     /**
      * The main action button displayed in the sheet footer, representing the primary action users should take. Only accepts a single button component.
@@ -101,10 +92,7 @@ export interface SheetElementSlots {
      */
     'secondary-actions'?: HTMLElement;
 }
-/**
- * The methods interface for the Sheet component.
- * @publicDocs
- */
+
 export interface SheetElementMethods extends Pick<SheetProps$1, 'hideOverlay'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
@@ -50,7 +50,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-sheet";
-
+/** @publicDocs */
 export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'heading' | 'id'> {
     /**
      * A label that describes the purpose of the sheet, announced by assistive technologies. When set, screen readers will use this label instead of the `heading` to describe the sheet.
@@ -62,7 +62,7 @@ export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'h
  */
 export interface SheetEvents extends Pick<SheetProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
-
+/** @publicDocs */
 export interface SheetElementEvents {
     /**
      * A callback fired when the sheet is hidden, after any hide animations have completed.
@@ -81,7 +81,7 @@ export interface SheetElementEvents {
      */
     show?: CallbackEventListener<typeof tagName>;
 }
-
+/** @publicDocs */
 export interface SheetElementSlots {
     /**
      * The main action button displayed in the sheet footer, representing the primary action users should take. Only accepts a single button component.
@@ -92,7 +92,7 @@ export interface SheetElementSlots {
      */
     'secondary-actions'?: HTMLElement;
 }
-
+/** @publicDocs */
 export interface SheetElementMethods extends Pick<SheetProps$1, 'hideOverlay'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
@@ -38,7 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-tooltip";
-
+/** @publicDocs */
 export interface TooltipElementProps extends Pick<TooltipProps$1, 'id'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
@@ -38,10 +38,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-tooltip";
-/**
- * The element props interface for the Tooltip component.
- * @publicDocs
- */
+
 export interface TooltipElementProps extends Pick<TooltipProps$1, 'id'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -64,10 +64,6 @@ declare module 'preact' {
   }
 }
 
-/**
- * Display up to 4 images in a grid or stacked layout. For example, images of products in a wishlist or subscription.
- * @publicDocs
- */
 export type ImageGroupPropsDocs = ImageGroupProps;
 
 /**
@@ -131,10 +127,6 @@ declare module 'preact' {
   }
 }
 
-/**
- * The element props interface for the Avatar component.
- * @publicDocs
- */
 export type AvatarElementPropsDocs = AvatarElementProps;
 
 /**
@@ -149,10 +141,6 @@ export type AvatarPropsDocs = AvatarProps;
  */
 export type AvatarElementDocs = AvatarElement;
 
-/**
- * The events interface for the Avatar component.
- * @publicDocs
- */
 export type AvatarEventsDocs = AvatarEvents;
 
 declare global {

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -63,7 +63,7 @@ declare module 'preact' {
     }
   }
 }
-
+/** @publicDocs */
 export type ImageGroupPropsDocs = ImageGroupProps;
 
 /**
@@ -126,7 +126,7 @@ declare module 'preact' {
     }
   }
 }
-
+/** @publicDocs */
 export type AvatarElementPropsDocs = AvatarElementProps;
 
 /**
@@ -141,6 +141,7 @@ export type AvatarPropsDocs = AvatarProps;
  */
 export type AvatarElementDocs = AvatarElement;
 
+/** @publicDocs */
 export type AvatarEventsDocs = AvatarEvents;
 
 declare global {


### PR DESCRIPTION
## This PR: 

- Removes duplicate JSDoc descriptions from checkout and customer-account component type definitions that were being redundantly pulled into generated docs.

- Cleans up customer-account components.d.ts by removing extraneous doc comments on re-exported type aliases that duplicated the source descriptions 