### PR TITLE
[Customer account UI extensions 2026-01]: Remove duplicate descriptions being pulled into docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
@@ -39,8 +39,7 @@ declare const CHECKOUT_AVAILABLE_ICONS: readonly ["alert-circle", "alert-triangl
 export type ReducedIconTypes = (typeof CHECKOUT_AVAILABLE_ICONS)[number];
 
 declare const tagName = "s-icon";
-
-
+/** @publicDocs */
 export interface IconElementProps extends Pick<IconProps$1, 'id' | 'size' | 'tone' | 'type'> {
     /**
      * The semantic meaning and color treatment of the icon.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
@@ -39,9 +39,8 @@ declare const CHECKOUT_AVAILABLE_ICONS: readonly ["alert-circle", "alert-triangl
 export type ReducedIconTypes = (typeof CHECKOUT_AVAILABLE_ICONS)[number];
 
 declare const tagName = "s-icon";
-/**
- * @publicDocs
- */
+
+
 export interface IconElementProps extends Pick<IconProps$1, 'id' | 'size' | 'tone' | 'type'> {
     /**
      * The semantic meaning and color treatment of the icon.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
@@ -53,12 +53,8 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-image";
-/**
- * The image component embeds images within the interface with control over presentation and loading behavior. Use image to visually illustrate concepts, showcase products, display user content, or support tasks and interactions with visual context.
- *
- * Images support responsive sizing, alt text for accessibility, aspect ratio control, and loading states for progressive enhancement. For small preview images in lists or tables, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/thumbnail). For profile images, use [avatar](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/media-and-visuals/avatar).
- * @publicDocs
- */
+
+
 export interface ImageElementProps extends Pick<ImageProps$1, 'accessibilityRole' | 'alt' | 'aspectRatio' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'id' | 'inlineSize' | 'loading' | 'objectFit' | 'sizes' | 'src' | 'srcSet'> {
     /**
      * A shorthand for setting the border around the image. Accepts a size keyword alone (for example, `'base'`), a size and color (for example, `'base base'`), or a size, color, and style (for example, `'base base solid'`). Use `'none'` to remove the border.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
@@ -53,8 +53,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-image";
-
-
+/** @publicDocs */
 export interface ImageElementProps extends Pick<ImageProps$1, 'accessibilityRole' | 'alt' | 'aspectRatio' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'id' | 'inlineSize' | 'loading' | 'objectFit' | 'sizes' | 'src' | 'srcSet'> {
     /**
      * A shorthand for setting the border around the image. Accepts a size keyword alone (for example, `'base'`), a size and color (for example, `'base base'`), or a size, color, and style (for example, `'base base solid'`). Use `'none'` to remove the border.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
@@ -54,10 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map";
-/**
- * Use Map to display a map on a page. This component is useful for displaying a map of a location, such as a store or a customer’s address.
- * @publicDocs
- */
+
 export interface MapElementProps extends Pick<MapProps$1, 'accessibilityLabel' | 'apiKey' | 'blockSize' | 'id' | 'inlineSize' | 'latitude' | 'longitude' | 'maxBlockSize' | 'maxInlineSize' | 'maxZoom' | 'minBlockSize' | 'minInlineSize' | 'minZoom' | 'zoom'> {
 }
 /**
@@ -119,10 +116,8 @@ export interface MapViewChangeEvent extends MapLocationEvent {
      */
     zoom?: number;
 }
-/**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
- * @publicDocs
- */
+
+
 export interface MapElementEvents {
     /**
      * A callback fired when the visible map boundaries change, such as after a pan or zoom completes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
@@ -54,7 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map";
-
+/** @publicDocs */
 export interface MapElementProps extends Pick<MapProps$1, 'accessibilityLabel' | 'apiKey' | 'blockSize' | 'id' | 'inlineSize' | 'latitude' | 'longitude' | 'maxBlockSize' | 'maxInlineSize' | 'maxZoom' | 'minBlockSize' | 'minInlineSize' | 'minZoom' | 'zoom'> {
 }
 /**
@@ -116,8 +116,7 @@ export interface MapViewChangeEvent extends MapLocationEvent {
      */
     zoom?: number;
 }
-
-
+/** @publicDocs */
 export interface MapElementEvents {
     /**
      * A callback fired when the visible map boundaries change, such as after a pan or zoom completes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
@@ -42,7 +42,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map-marker";
-
+/** @publicDocs */
 export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibilityLabel' | 'blockSize' | 'command' | 'commandFor' | 'clusterable' | 'inlineSize' | 'latitude' | 'longitude'> {
     /**
      * Sets the action the `commandFor` target should take when this marker is activated. See the documentation of particular components for the actions they support. Learn more about the [`command` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
@@ -66,7 +66,7 @@ export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibi
  */
 export interface MapMarkerEvents extends Pick<MapMarkerProps$1, 'onClick'> {
 }
-
+/** @publicDocs */
 export interface MapMarkerElementEvents {
     /**
      * A callback fired when the user clicks on the marker. This event does not propagate to the parent map — only the marker receives the click.

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
@@ -42,7 +42,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-map-marker";
-/** @publicDocs */
+
 export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibilityLabel' | 'blockSize' | 'command' | 'commandFor' | 'clusterable' | 'inlineSize' | 'latitude' | 'longitude'> {
     /**
      * Sets the action the `commandFor` target should take when this marker is activated. See the documentation of particular components for the actions they support. Learn more about the [`command` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
@@ -66,7 +66,7 @@ export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibi
  */
 export interface MapMarkerEvents extends Pick<MapMarkerProps$1, 'onClick'> {
 }
-/** @publicDocs */
+
 export interface MapMarkerElementEvents {
     /**
      * A callback fired when the user clicks on the marker. This event does not propagate to the parent map — only the marker receives the click.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
@@ -54,12 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-modal";
-/**
- * The modal component displays content in an overlay. Use to create a distraction-free experience such as a confirmation dialog or a settings panel.
- *
- * A button triggers the modal using the `commandFor` attribute. Content within the modal scrolls if it exceeds available height.
- * @publicDocs
- */
+
 export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding' | 'size'> {
     /**
      * The size of the modal.
@@ -75,10 +70,7 @@ export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabe
      */
     size?: Extract<ModalProps$1['size'], 'small-100' | 'small' | 'base' | 'large-100' | 'large' | 'max'>;
 }
-/**
- * Learn more about [component slots](/docs/api/checkout-ui-extensions/latest/using-polaris-components#slots).
- * @publicDocs
- */
+
 export interface ModalElementSlots {
     /**
      * The main action button displayed in the modal footer, representing the primary action users should take. Only accepts a single button component.
@@ -95,16 +87,10 @@ export interface ModalElementSlots {
  */
 export interface ModalEvents extends Pick<ModalProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
-/**
- * Learn more about [component methods](/docs/api/checkout-ui-extensions/latest/using-polaris-components#methods).
- * @publicDocs
- */
+
 export interface ModalElementMethods extends Pick<ModalProps$1, 'hideOverlay'> {
 }
-/**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
- * @publicDocs
- */
+
 export interface ModalElementEvents {
     /**
      * A callback fired when the modal is hidden, after any hide animations have completed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
@@ -54,7 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-modal";
-
+/** @publicDocs */
 export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding' | 'size'> {
     /**
      * The size of the modal.
@@ -70,7 +70,7 @@ export interface ModalElementProps extends Pick<ModalProps$1, 'accessibilityLabe
      */
     size?: Extract<ModalProps$1['size'], 'small-100' | 'small' | 'base' | 'large-100' | 'large' | 'max'>;
 }
-
+/** @publicDocs */
 export interface ModalElementSlots {
     /**
      * The main action button displayed in the modal footer, representing the primary action users should take. Only accepts a single button component.
@@ -87,10 +87,10 @@ export interface ModalElementSlots {
  */
 export interface ModalEvents extends Pick<ModalProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
-
+/** @publicDocs */
 export interface ModalElementMethods extends Pick<ModalProps$1, 'hideOverlay'> {
 }
-
+/** @publicDocs */
 export interface ModalElementEvents {
     /**
      * A callback fired when the modal is hidden, after any hide animations have completed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
@@ -30,10 +30,8 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-payment-icon";
-/**
- * Displays icons representing payment methods. Use to visually communicate available or saved payment options clearly
- * @publicDocs
- */
+
+
 export interface PaymentIconElementProps extends PaymentIconProps$1 {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
@@ -30,8 +30,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-payment-icon";
-
-
+/** @publicDocs */
 export interface PaymentIconElementProps extends PaymentIconProps$1 {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
@@ -54,7 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-popover";
-
+/** @publicDocs */
 export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
     /**
      * The block size of the popover (height in horizontal writing modes). Learn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
@@ -99,7 +99,7 @@ export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
  */
 export interface PopoverEvents extends Pick<PopoverProps$1, 'onHide' | 'onShow'> {
 }
-
+/** @publicDocs */
 export interface PopoverElementEvents {
     /**
      * A callback fired immediately after the popover is hidden.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
@@ -54,12 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-popover";
-/**
- * The popover component displays contextual content in an overlay triggered by a button using the [`commandFor`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#commandfor) attribute. Use for secondary actions, settings, or information that doesn't require a full modal.
- *
- * For interactions that need more space or user focus, such as confirmations or complex forms, use [modal](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/overlays/modal) instead.
- * @publicDocs
- */
+
 export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
     /**
      * The block size of the popover (height in horizontal writing modes). Learn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).
@@ -104,10 +99,7 @@ export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
  */
 export interface PopoverEvents extends Pick<PopoverProps$1, 'onHide' | 'onShow'> {
 }
-/**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
- * @publicDocs
- */
+
 export interface PopoverElementEvents {
     /**
      * A callback fired immediately after the popover is hidden.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
@@ -30,10 +30,8 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-product-thumbnail";
-/**
- * Use ProductThumbnail to display a product thumbnail
- * @publicDocs
- */
+
+
 export interface ProductThumbnailElementProps extends Pick<ProductThumbnailProps$1, 'alt' | 'size' | 'sizes' | 'src' | 'srcSet' | 'totalItems'> {
     /**
      * The size of the product thumbnail image.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
@@ -30,8 +30,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-product-thumbnail";
-
-
+/** @publicDocs */
 export interface ProductThumbnailElementProps extends Pick<ProductThumbnailProps$1, 'alt' | 'size' | 'sizes' | 'src' | 'srcSet' | 'totalItems'> {
     /**
      * The size of the product thumbnail image.

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
@@ -44,7 +44,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-qr-code";
-
+/** @publicDocs */
 export interface QRCodeElementProps extends QRCodeProps$1 {
 }
 /**
@@ -53,7 +53,7 @@ export interface QRCodeElementProps extends QRCodeProps$1 {
  */
 export interface QRCodeEvents extends Pick<QRCodeProps$1, 'onError'> {
 }
-
+/** @publicDocs */
 export interface QRCodeElementEvents {
     /**
      * A callback that's fired when the conversion of `content` to a QR code fails.

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
@@ -44,10 +44,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-qr-code";
-/**
- * Displays a scannable QR code representing data such as URLs or text. Use to let users quickly access information by scanning with a smartphone or other device.
- * @publicDocs
- */
+
 export interface QRCodeElementProps extends QRCodeProps$1 {
 }
 /**
@@ -56,10 +53,7 @@ export interface QRCodeElementProps extends QRCodeProps$1 {
  */
 export interface QRCodeEvents extends Pick<QRCodeProps$1, 'onError'> {
 }
-/**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
- * @publicDocs
- */
+
 export interface QRCodeElementEvents {
     /**
      * A callback that's fired when the conversion of `content` to a QR code fails.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
@@ -54,7 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-sheet";
-
+/** @publicDocs */
 export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'heading' | 'id'> {
     /**
      * A label that describes the purpose of the sheet, announced by assistive technologies. When set, screen readers will use this label instead of the `heading` to describe the sheet.
@@ -67,7 +67,7 @@ export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'h
  */
 export interface SheetEvents extends Pick<SheetProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
-
+/** @publicDocs */
 export interface SheetElementEvents {
     /**
      * A callback fired when the sheet is hidden, after any hide animations have completed.
@@ -86,7 +86,7 @@ export interface SheetElementEvents {
      */
     show?: CallbackEventListener<typeof tagName>;
 }
-
+/** @publicDocs */
 export interface SheetElementSlots {
     /**
      * The main action button displayed in the sheet footer, representing the primary action users should take. Only accepts a single button component.
@@ -97,7 +97,7 @@ export interface SheetElementSlots {
      */
     'secondary-actions'?: HTMLElement;
 }
-
+/** @publicDocs */
 export interface SheetElementMethods extends Pick<SheetProps$1, 'hideOverlay'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
@@ -54,12 +54,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-sheet";
-/**
- * The Sheet component displays essential information for customers at the bottom of the screen, appearing above other elements. Use it sparingly to avoid distracting customers during checkout. This component requires access to [Customer Privacy API](/docs/api/checkout-ui-extensions/latest/configuration#collect-buyer-consent) to be rendered.
- *
- * The library automatically applies the [WAI-ARIA Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) to both the activator and the sheet content.
- * @publicDocs
- */
+
 export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'heading' | 'id'> {
     /**
      * A label that describes the purpose of the sheet, announced by assistive technologies. When set, screen readers will use this label instead of the `heading` to describe the sheet.
@@ -72,10 +67,7 @@ export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'h
  */
 export interface SheetEvents extends Pick<SheetProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
-/**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
- * @publicDocs
- */
+
 export interface SheetElementEvents {
     /**
      * A callback fired when the sheet is hidden, after any hide animations have completed.
@@ -94,10 +86,7 @@ export interface SheetElementEvents {
      */
     show?: CallbackEventListener<typeof tagName>;
 }
-/**
- * Learn more about [component slots](/docs/api/checkout-ui-extensions/latest/using-polaris-components#slots).
- * @publicDocs
- */
+
 export interface SheetElementSlots {
     /**
      * The main action button displayed in the sheet footer, representing the primary action users should take. Only accepts a single button component.
@@ -108,10 +97,7 @@ export interface SheetElementSlots {
      */
     'secondary-actions'?: HTMLElement;
 }
-/**
- * Learn more about [component methods](/docs/api/checkout-ui-extensions/latest/using-polaris-components#methods).
- * @publicDocs
- */
+
 export interface SheetElementMethods extends Pick<SheetProps$1, 'hideOverlay'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
@@ -40,8 +40,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-tooltip";
-
-
+/** @publicDocs */
 export interface TooltipElementProps extends Pick<TooltipProps$1, 'id'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
@@ -40,10 +40,8 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-tooltip";
-/**
- * Properties for the Tooltip component element.
- * @publicDocs
- */
+
+
 export interface TooltipElementProps extends Pick<TooltipProps$1, 'id'> {
 }
 /**

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -74,9 +74,6 @@ declare module 'preact' {
   }
 }
 
-/**
- * @publicDocs
- */
 export type ImageGroupPropsDocs = ImageGroupProps;
 /**
  * @publicDocs
@@ -133,9 +130,6 @@ declare module 'preact' {
   }
 }
 
-/**
- * @publicDocs
- */
 export type AvatarElementPropsDocs = AvatarElementProps;
 /**
  * @publicDocs
@@ -145,10 +139,7 @@ export type AvatarPropsDocs = AvatarProps;
  * @publicDocs
  */
 export type AvatarElementDocs = AvatarElement;
-/**
- * Learn more about [registering events](/docs/api/app-home/using-polaris-components#event-handling).
- * @publicDocs
- */
+
 export type AvatarEventsDocs = AvatarEvents;
 
 declare global {

--- a/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components.d.ts
@@ -28,13 +28,13 @@ import {
   SectionElement,
   SectionElementSlots,
 } from './components/Section';
-
+/** @publicDocs */
 export type AvatarElementPropsDocs = AvatarElementProps;
 /**
  * @publicDocs
  */
 export type AvatarElementEventsDocs = AvatarEvents;
-
+/** @publicDocs */
 export type AvatarElementPropsDocs = AvatarElementProps;
 /**
  * @publicDocs
@@ -73,7 +73,7 @@ declare module 'preact' {
     }
   }
 }
-
+/** @publicDocs */
 export type ImageGroupPropsDocs = ImageGroupProps;
 /**
  * @publicDocs
@@ -129,7 +129,7 @@ declare module 'preact' {
     }
   }
 }
-
+/** @publicDocs */
 export type AvatarElementPropsDocs = AvatarElementProps;
 /**
  * @publicDocs
@@ -139,7 +139,7 @@ export type AvatarPropsDocs = AvatarProps;
  * @publicDocs
  */
 export type AvatarElementDocs = AvatarElement;
-
+/** @publicDocs */
 export type AvatarEventsDocs = AvatarEvents;
 
 declare global {


### PR DESCRIPTION
## This PR: 

- Removes duplicate JSDoc descriptions from checkout and customer-account component type definitions that were being redundantly pulled into generated docs.

- Cleans up customer-account components.d.ts by removing extraneous doc comments on re-exported type aliases that duplicated the source descriptions 