### PR TITLE
[Customer account UI extensions 2025-07]: Remove duplicate descriptions being pulled into docs

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
@@ -81,6 +81,7 @@ export type IconSource =
   | 'warning'
   | 'warningFill';
 
+/** @publicDocs */
 export interface IconProps extends IdProps {
   /**
    * A label that describes the purpose or contents of the icon. When set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon/Icon.ts
@@ -81,10 +81,6 @@ export type IconSource =
   | 'warning'
   | 'warningFill';
 
-/**
- * Icons are pictograms or graphic symbols. They can act as wayfinding tools or as a means of communicating functionality.
- * @publicDocs
- */
 export interface IconProps extends IdProps {
   /**
    * A label that describes the purpose or contents of the icon. When set,
@@ -120,8 +116,4 @@ export interface IconProps extends IdProps {
   source: IconSource;
 }
 
-/**
- * Icons are pictograms or graphic symbols.
- * They can act as wayfinding tools or as a means of communicating functionality.
- */
 export const Icon = createRemoteComponent<'Icon', IconProps>('Icon');

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
@@ -15,10 +15,6 @@ import type {
   IdProps,
 } from '../shared';
 
-/**
- * Image is used for large format, responsive images.
- * @publicDocs
- */
 export interface ImageProps extends BorderProps, CornerProps, IdProps {
   /**
    * The URL of the image to display. Supports remote URLs and local file
@@ -89,7 +85,4 @@ type Loading =
    */
   | 'lazy';
 
-/**
- * Image is used for large format, responsive images.
- */
 export const Image = createRemoteComponent<'Image', ImageProps>('Image');

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image/Image.ts
@@ -15,6 +15,7 @@ import type {
   IdProps,
 } from '../shared';
 
+/** @publicDocs */
 export interface ImageProps extends BorderProps, CornerProps, IdProps {
   /**
    * The URL of the image to display. Supports remote URLs and local file

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map/Map.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map/Map.ts
@@ -138,8 +138,4 @@ export interface MapProps
   onZoomChange?: (zoom: MapZoom) => void;
 }
 
-/**
- * Use the Map component to provide visual representation of geographic data such as verifying address, package or pickup locations.
- * Please note that the merchant or partner has to provide an API key and a set of allowed domains where the map would render.
- */
 export const Map = createRemoteComponent<'Map', MapProps>('Map');

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.ts
@@ -2,10 +2,6 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {OverlayActivatorProps} from '../shared';
 
-/**
- * MapMarker represents a specific location or point of interest on a map.
- * @publicDocs
- */
 export interface MapMarkerProps extends OverlayActivatorProps {
   /**
    * The latitude of the marker, in degrees. Valid values range from
@@ -53,9 +49,6 @@ export interface MapMarkerProps extends OverlayActivatorProps {
   inlineSize?: number;
 }
 
-/**
- * Use the `MapMarker` component to provide visual representation of single geographic location such as a shipping address or package pickup location.
- */
 export const MapMarker = createRemoteComponent<'MapMarker', MapMarkerProps>(
   'MapMarker',
 );

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker/MapMarker.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {OverlayActivatorProps} from '../shared';
 
+/** @publicDocs */
 export interface MapMarkerProps extends OverlayActivatorProps {
   /**
    * The latitude of the marker, in degrees. Valid values range from

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface MapPopoverProps extends IdProps {
   /**
    * A callback that fires when the popover is closed. Use this to

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapPopover/MapPopover.ts
@@ -2,10 +2,6 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * MapPopover provides additional information or context about a specific location or point of interest on a map.
- * @publicDocs
- */
 export interface MapPopoverProps extends IdProps {
   /**
    * A callback that fires when the popover is closed. Use this to

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
@@ -1,6 +1,7 @@
 import type {RemoteFragment} from '@remote-ui/core';
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ModalProps {
   /**
    * A unique identifier for the modal. When no `id` is set, a globally unique value will be used instead.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal/Modal.ts
@@ -1,12 +1,6 @@
 import type {RemoteFragment} from '@remote-ui/core';
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * Modals are a special type of overlay that shift focus towards a specific action/set of information before the main flow can proceed. They must be specified inside the `overlay` prop of an activator component (`Button`, `Link` or `Pressable`).
-
-The library automatically applies the [WAI-ARIA Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) to both the activator and the modal content.
- * @publicDocs
- */
 export interface ModalProps {
   /**
    * A unique identifier for the modal. When no `id` is set, a globally unique value will be used instead.
@@ -53,9 +47,4 @@ export interface ModalProps {
   secondaryActions?: RemoteFragment;
 }
 
-/**
- * Modals are a special type of overlay that shift focus towards a specific action or set of information before the main flow can proceed. They must be specified inside the `overlay` prop of an activator component (`Button`, `Link`, or `Pressable`).
- *
- * The library automatically applies the [WAI-ARIA Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) to both the activator and the modal content.
- */
 export const Modal = createRemoteComponent<'Modal', ModalProps>('Modal');

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.ts
@@ -452,6 +452,7 @@ export type PaymentMethod =
   | 'zip'
   | 'zoodpay';
 
+/** @publicDocs */
 export interface PaymentIconProps {
   /**
    * The name of the payment method whose icon should be displayed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon/PaymentIcon.ts
@@ -452,10 +452,6 @@ export type PaymentMethod =
   | 'zip'
   | 'zoodpay';
 
-/**
- * Payment icons can be used for displaying payment-related information or features such as a user’s saved or available payment methods.
- * @publicDocs
- */
 export interface PaymentIconProps {
   /**
    * The name of the payment method whose icon should be displayed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.ts
@@ -16,12 +16,6 @@ export type PopoverPosition =
   | 'blockStart'
   | 'blockEnd';
 
-/**
- * Popovers are similar to tooltips. They are small overlays that open on demand after a user interaction. The difference is that the popover can contain more content, without cluttering the page. They must be specified inside the `overlay` prop of an activator component (`Button`, `Link` or `Pressable`).
-
-The library automatically applies the WAI-ARIA Popover Widget pattern to both the activator and the popover content.
- * @publicDocs
- */
 export interface PopoverProps
   extends IdProps,
     Pick<SizingProps, 'maxInlineSize' | 'minInlineSize'>,
@@ -46,11 +40,6 @@ export interface PopoverProps
   onClose?: () => void;
 }
 
-/**
- * Popovers are similar to tooltips. They are small overlays that open on demand after a user interaction. The difference is that the popover can contain more content, without cluttering the page. They must be specified inside the `overlay` prop of an activator component (`Button`, `Link`, or `Pressable`).
- *
- * The library automatically applies the WAI-ARIA Popover Widget pattern to both the activator and the popover content.
- */
 export const Popover = createRemoteComponent<'Popover', PopoverProps>(
   'Popover',
 );

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover/Popover.ts
@@ -16,6 +16,7 @@ export type PopoverPosition =
   | 'blockStart'
   | 'blockEnd';
 
+/** @publicDocs */
 export interface PopoverProps
   extends IdProps,
     Pick<SizingProps, 'maxInlineSize' | 'minInlineSize'>,

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
@@ -6,10 +6,6 @@ import type {
 } from '../../style/types';
 import type {Size} from '../shared';
 
-/**
- * Product thumbnail is a representation of a product image. It provides a visual preview of the item, so buyers can quickly identify products.
- * @publicDocs
- */
 export interface ProductThumbnailProps {
   /**
    * The alternative text that describes the product thumbnail for assistive

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail/ProductThumbnail.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../style/types';
 import type {Size} from '../shared';
 
+/** @publicDocs */
 export interface ProductThumbnailProps {
   /**
    * The alternative text that describes the product thumbnail for assistive

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, BorderStyle} from '../shared';
 
+/** @publicDocs */
 export interface QRCodeProps extends IdProps {
   /**
    * The data to encode in the QR code. Accepts any string, such as a URL,

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode/QRCode.ts
@@ -2,10 +2,6 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, BorderStyle} from '../shared';
 
-/**
- * Used to quickly access scannable data.
- * @publicDocs
- */
 export interface QRCodeProps extends IdProps {
   /**
    * The data to encode in the QR code. Accepts any string, such as a URL,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface SheetProps extends IdProps {
   /**
    * A label that describes the purpose of the sheet, announced by screen readers. If not set, it will use the value of `heading`.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet/Sheet.ts
@@ -3,12 +3,6 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * The Sheet component displays essential information for customers at the bottom of the screen, appearing above other elements. Use it sparingly to avoid distracting customers during checkout. This component requires access to [Customer Privacy API](/docs/api/checkout-ui-extensions/unstable/configuration#collect-buyer-consent) to be rendered. 
-
-The library automatically applies the [WAI-ARIA Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) to both the activator and the sheet content.
- * @publicDocs
- */
 export interface SheetProps extends IdProps {
   /**
    * A label that describes the purpose of the sheet, announced by screen readers. If not set, it will use the value of `heading`.
@@ -46,9 +40,4 @@ export interface SheetProps extends IdProps {
   secondaryAction?: RemoteFragment;
 }
 
-/**
- * A sheet is designed to be used on top of other elements in a user interface and is typically bound to the bottom of a page. It can contain and display various types of content such as forms or informational messages. Unlike a modal, which interrupts user flow, a sheet offers a less intrusive, fluid experience.
- *
- * The library automatically applies the [WAI-ARIA Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) to both the activator and the sheet content.
- */
 export const Sheet = createRemoteComponent<'Sheet', SheetProps>('Sheet');

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
@@ -3,10 +3,6 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps} from '../shared';
 
-/**
- * SkeletonImage is used to provide a low fidelity representation of an image before it appears on the page.
- * @publicDocs
- */
 export interface SkeletonImageProps extends IdProps {
   /**
    * The block size (height in horizontal writing modes) of the skeleton placeholder.
@@ -36,9 +32,7 @@ export interface SkeletonImageProps extends IdProps {
    */
   aspectRatio?: number;
 }
-/**
- * SkeletonImage is used to provide a low fidelity representation of an image before it appears on the page.
- */
+
 export const SkeletonImage = createRemoteComponent<
   'SkeletonImage',
   SkeletonImageProps

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonImage/SkeletonImage.ts
@@ -3,6 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface SkeletonImageProps extends IdProps {
   /**
    * The block size (height in horizontal writing modes) of the skeleton placeholder.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface TooltipProps extends IdProps {}
 
 export const Tooltip = createRemoteComponent<'Tooltip', TooltipProps>(

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip/Tooltip.ts
@@ -2,19 +2,8 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * Tooltips are floating labels that briefly explain the function of a user interface element. They must be specified inside the `overlay` prop of an activator component. Currently, activator components are `Button`, `Link`, and `Pressable`.
-
-The library automatically applies the [WAI-ARIA Tooltip Widget pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/) to both the activator and the tooltip content. Expect screen readers to read the tooltip content when the user focuses the activator.
- * @publicDocs
- */
 export interface TooltipProps extends IdProps {}
 
-/**
- * Tooltips are floating labels that briefly explain the function of a user interface element. They must be specified inside the `overlay` prop of an activator component. Currently, activator components are `Button`, `Link`, and `Pressable`.
- *
- * The library automatically applies the [WAI-ARIA Tooltip Widget pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/) to both the activator and the tooltip content. Screen readers will read the tooltip content when the user focuses the activator.
- */
 export const Tooltip = createRemoteComponent<'Tooltip', TooltipProps>(
   'Tooltip',
 );

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.ts
@@ -2,6 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import {Size} from '../../../checkout';
 import type {IdProps} from '../shared';
 
+/** @publicDocs */
 export interface AvatarProps extends IdProps {
   /**
    * The initials to display in the avatar. Used as a text fallback when no

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.ts
@@ -2,10 +2,6 @@ import {createRemoteComponent} from '@remote-ui/core';
 import {Size} from '../../../checkout';
 import type {IdProps} from '../shared';
 
-/**
- * Display a user avatar with initials or an image.
- * @publicDocs
- */
 export interface AvatarProps extends IdProps {
   /**
    * The initials to display in the avatar. Used as a text fallback when no

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.ts
@@ -1,5 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
+/** @publicDocs */
 export interface ImageGroupProps {
   /**
    * The layout arrangement for the images within the group.

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.ts
@@ -1,9 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * Display a group of images.
- * @publicDocs
- */
 export interface ImageGroupProps {
   /**
    * The layout arrangement for the images within the group.


### PR DESCRIPTION
## This PR: 

- Removes duplicate JSDoc descriptions from checkout and customer-account component type definitions that were being redundantly pulled into generated docs.

- Cleans up customer-account components.d.ts by removing extraneous doc comments on re-exported type aliases that duplicated the source descriptions 