### PR TITLE
[Customer account UI extensions 2025-10]: Improved descriptions for "Feedback and status indicators" components

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Announcement.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Announcement.d.ts
@@ -40,11 +40,24 @@ export type CallbackEvent<TTagName extends keyof HTMLElementTagNameMap, TEvent e
 export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, TData = object> = (EventListener & {
     (event: CallbackEvent<TTagName, Event> & TData): void;
 }) | null;
-/** @publicDocs */
+/**
+ * The visibility state of a toggleable element.
+ *
+ * - `open`: The element is visible and showing its content.
+ * - `closed`: The element is hidden and its content is not visible.
+ */
 export type ToggleState = 'open' | 'closed';
-/** @publicDocs */
+/**
+ * The event data provided to toggle-related callbacks. Contains the previous and next visibility states of the element.
+ */
 export interface ToggleArgumentsEvent {
+    /**
+     * The visibility state of the element before the toggle occurred.
+     */
     oldState?: ToggleState;
+    /**
+     * The visibility state of the element after the toggle occurred.
+     */
     newState?: ToggleState;
 }
 
@@ -53,38 +66,33 @@ declare const tagName = "s-announcement";
 export interface AnnouncementEvents extends Pick<AnnouncementProps$1, 'onAfterToggle' | 'onDismiss' | 'onToggle'> {
 }
 /**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
  * @publicDocs
  */
 export interface AnnouncementElementEvents {
     /**
-     * Callback fired when the element state changes **after** any animations have finished.
+     * A callback that fires when the element state changes, after any toggle animations have finished.
      *
      * - If the element transitioned from hidden to showing, the `oldState` property will be set to `closed` and the
      *   `newState` property will be set to `open`.
      * - If the element transitioned from showing to hidden, the `oldState` property will be set to `open` and the
      *   `newState` will be `closed`.
      *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState
+     * Learn more about [ToggleEvent.newState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState) and [ToggleEvent.oldState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
      */
     aftertoggle?: CallbackEventListener<typeof tagName, ToggleArgumentsEvent>;
     /**
-     * Callback fired when the announcement is dismissed by the user
-     * (either via the built-in dismiss button or programmatically).
+     * A callback that fires when the announcement is dismissed by the user clicking the close button or by calling the `dismiss()` method programmatically.
      */
     dismiss?: CallbackEventListener<typeof tagName>;
     /**
-     * Callback straight after the element state changes.
+     * A callback that fires immediately when the element state changes, before any animations.
      *
      * - If the element is transitioning from hidden to showing, the `oldState` property will be set to `closed` and the
      *   `newState` property will be set to `open`.
      * - If the element is transitioning from showing to hidden, then `oldState` property will be set to `open` and the
      *   `newState` will be `closed`.
      *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState
+     * Learn more about the [toggle event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event), [ToggleEvent.newState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState), and [ToggleEvent.oldState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
      */
     toggle?: CallbackEventListener<typeof tagName, ToggleArgumentsEvent>;
 }
@@ -99,13 +107,18 @@ export interface AnnouncementProps extends AnnouncementEvents {
 }
 /** @publicDocs */
 export interface AnnouncementMethods {
+    /**
+     * Programmatically dismisses the announcement. This triggers the `dismiss` event callback.
+     */
     dismiss: () => void;
 }
 /**
- * Learn more about [component methods](/docs/api/checkout-ui-extensions/latest/using-polaris-components#methods).
  * @publicDocs
  */
 export interface AnnouncementElementMethods {
+    /**
+     * Programmatically dismisses the announcement. This triggers the `dismiss` event callback.
+     */
     dismiss: AnnouncementMethods['dismiss'];
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge.d.ts
@@ -27,26 +27,62 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
     children?: preact.ComponentChildren;
 }
 /**
- * Used as the single source of truth for checkout icon types.
- *
- * @see https://github.com/Shopify/ui-api-design/blob/main/packages/ui-api-design/src/components/Icon/Icon.ts#L10
+ * The available icon types for checkout components. This is the single source of truth for checkout icon names.
  */
 declare const CHECKOUT_AVAILABLE_ICONS: readonly ["alert-circle", "alert-triangle-filled", "alert-triangle", "arrow-down", "arrow-left", "arrow-right", "arrow-up-right", "arrow-up", "bag", "bullet", "calendar", "camera", "caret-down", "cart", "cash-dollar", "categories", "check-circle", "check", "chevron-down", "chevron-left", "chevron-right", "chevron-up", "circle", "clipboard", "clock", "credit-card", "delete", "delivered", "delivery", "disabled", "discount", "edit", "email", "empty", "external", "filter", "geolocation", "gift-card", "globe", "grid", "image", "info-filled", "info", "list-bulleted", "location", "lock", "map", "menu-horizontal", "menu-vertical", "menu", "minus", "mobile", "note", "order", "organization", "plus", "profile", "question-circle-filled", "question-circle", "reorder", "reset", "return", "savings", "search", "settings", "star-filled", "star-half", "star", "store", "truck", "upload", "x-circle-filled", "x-circle", "x"];
-/** @publicDocs */
+/**
+ * The subset of icon types available in checkout and customer account surfaces. This is a narrowed set from the full Shopify icon library, containing only the icons supported in these contexts.
+ * @publicDocs
+ */
 export type ReducedIconTypes = (typeof CHECKOUT_AVAILABLE_ICONS)[number];
 
 declare const tagName = "s-badge";
 /**
- * The badge component displays status information or indicates completed actions through compact visual indicators. Use badge to communicate object states, order statuses, or system-generated classifications that help users quickly understand item conditions.
- *
- * Badges support multiple tones and sizes, with optional icons to reinforce status meaning and improve scannability in lists and tables. For user-created labels, categories, or tags, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip) instead.
  * @publicDocs
  */
 export interface BadgeProps extends Pick<BadgeProps$1, 'color' | 'icon' | 'iconPosition' | 'id' | 'size' | 'tone'> {
+    /**
+     * The size of the badge.
+     *
+     * - `base`: The default size, suitable for most use cases.
+     * - `small`: A smaller badge for compact layouts.
+     * - `small-100`: The smallest badge for tight spaces or dense lists.
+     *
+     * @default 'base'
+     */
     size?: Extract<BadgeProps$1['size'], 'small' | 'small-100' | 'base'>;
+    /**
+     * The semantic meaning and color treatment of the badge.
+     *
+     * - `auto`: Automatically determined based on context.
+     * - `neutral`: General information without specific intent.
+     * - `critical`: Urgent problems or destructive actions.
+     *
+     * @default 'auto'
+     */
     tone?: Extract<BadgeProps$1['tone'], 'auto' | 'neutral' | 'critical'>;
+    /**
+     * Controls the visual weight and emphasis of the badge.
+     *
+     * - `base`: Standard weight with moderate emphasis, suitable for most use cases.
+     * - `subdued`: Reduced visual weight for less prominent or secondary badges.
+     *
+     * @default 'base'
+     */
     color?: Extract<BadgeProps$1['color'], 'base' | 'subdued'>;
+    /**
+     * An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Set to an empty string to display no icon.
+     *
+     * @default ''
+     */
     icon?: '' | ReducedIconTypes;
+    /**
+     * The position of the icon relative to the badge text.
+     *
+     * - `start`: Places the icon before the text.
+     * - `end`: Places the icon after the text.
+     */
+    iconPosition?: BadgeProps$1['iconPosition'];
 }
 /** @publicDocs */
 export interface BadgeElement extends BadgeProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner.d.ts
@@ -43,38 +43,77 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 
 declare const tagName = "s-banner";
 /**
- * The banner component highlights important information or required actions prominently within the interface. Use banner to communicate statuses, provide feedback, draw attention to critical updates, or guide users toward necessary actions.
- *
- * Banners support multiple tones to convey urgency levels, optional actions for next steps, and can be positioned contextually within sections or page-wide at the top. For inline status indicators on individual items, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge).
  * @publicDocs
  */
 export interface BannerElementProps extends Pick<BannerProps$1, 'collapsible' | 'dismissible' | 'heading' | 'hidden' | 'id' | 'tone'> {
+    /**
+     * Whether the banner content can be collapsed and expanded by the user. A collapsible banner conceals child elements initially, allowing the user to expand the banner to reveal them.
+     *
+     * @default false
+     */
+    collapsible?: BannerProps$1['collapsible'];
+    /**
+     * Whether the banner displays a close button that allows users to dismiss it.
+     *
+     * When the close button is pressed, the `dismiss` event will fire,
+     * then `hidden` will be set to `true`,
+     * any animation will complete,
+     * and the `afterhide` event will fire.
+     *
+     * @default false
+     */
+    dismissible?: BannerProps$1['dismissible'];
+    /**
+     * The heading text displayed at the top of the banner to summarize the message or alert.
+     *
+     * @default ''
+     */
+    heading?: BannerProps$1['heading'];
+    /**
+     * Controls whether the banner is visible or hidden.
+     *
+     * When using a controlled component pattern and the banner is `dismissible`,
+     * update this property to `true` when the `dismiss` event fires.
+     *
+     * You can hide the banner programmatically by setting this to `true` even if it's not `dismissible`.
+     *
+     * @default false
+     */
+    hidden?: BannerProps$1['hidden'];
+    /**
+     * The semantic meaning and color treatment of the component. The banner is a live region and the type of status is dictated by the tone selected.
+     *
+     * - `info`: Informational content or helpful tips.
+     * - `auto`: Automatically determined based on context.
+     * - `success`: Positive outcomes or successful states.
+     * - `warning`: Important warnings about potential issues.
+     * - `critical`: Urgent problems or destructive actions.
+     *
+     * The `critical` tone creates an [assertive live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) that is announced by screen readers immediately. The `info`, `success`, and `warning` tones create an [informative live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) that is announced by screen readers after the current message.
+     *
+     * @default 'auto'
+     */
     tone?: Extract<BannerProps$1['tone'], 'auto' | 'info' | 'success' | 'warning' | 'critical'>;
 }
 /** @publicDocs */
 export interface BannerEvents extends Pick<BannerProps$1, 'onAfterHide' | 'onDismiss'> {
 }
 /**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
  * @publicDocs
  */
 export interface BannerElementEvents {
     /**
-     * Event handler when the banner has fully hidden.
+     * A callback that fires when the banner has fully hidden, including after any hide animations have completed.
      *
-     * The `hidden` property will be `true` when this event fires.
-     *
-     * @implementation If implementations animate the hiding of the banner,
-     * this event must fire after the banner has fully hidden.
-     * We can add an `onHide` event in future if we want to provide a hook for the start of the animation.
+     * The `hidden` property is `true` when this event fires.
      */
     afterhide?: CallbackEventListener<typeof tagName>;
     /**
-     * Event handler when the banner is dismissed by the user.
+     * A callback that fires when the banner is dismissed by the user clicking the close button.
      *
-     * This does not fire when setting `hidden` manually.
+     * This doesn't fire when setting `hidden` manually.
      *
-     * The `hidden` property will be `false` when this event fires.
+     * The `hidden` property is `false` when this event fires.
      */
     dismiss?: CallbackEventListener<typeof tagName>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress.d.ts
@@ -22,11 +22,36 @@ export interface BaseElementProps<TClass = HTMLElement> {
 
 declare const tagName = "s-progress";
 /**
- * Displays an indicator showing the completion status of a task. Use to visually communicate progress in either determinate (known percentage) or indeterminate (unknown duration) states.
  * @publicDocs
  */
 export interface ProgressProps extends Pick<ProgressProps$1, 'accessibilityLabel' | 'id' | 'max' | 'tone' | 'value'> {
+    /**
+     * A label announced by assistive technologies that describes what is progressing. Use this to provide context about the ongoing task, such as "Loading order details" or "Uploading file".
+     */
+    accessibilityLabel?: ProgressProps$1['accessibilityLabel'];
+    /**
+     * The total amount of work the task requires. Must be a value greater than 0 and a valid floating point number.
+     *
+     * Learn more about the [max attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#max).
+     *
+     * @default 1
+     */
+    max?: ProgressProps$1['max'];
+    /**
+     * The semantic meaning and color treatment of the progress indicator.
+     *
+     * - `auto`: Automatically determined based on context.
+     * - `critical`: Indicates an urgent or error state requiring immediate attention.
+     *
+     * @default 'auto'
+     */
     tone?: Extract<ProgressProps$1['tone'], 'auto' | 'critical'>;
+    /**
+     * How much of the task has been completed. Must be a valid floating point number between 0 and `max`, or between 0 and 1 if `max` is omitted. When no value is set, the progress bar is indeterminate, indicating an ongoing activity with no estimated completion time.
+     *
+     * Learn more about the [value attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#value).
+     */
+    value?: ProgressProps$1['value'];
 }
 /** @publicDocs */
 export interface ProgressElement extends ProgressProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner.d.ts
@@ -22,12 +22,24 @@ export interface BaseElementProps<TClass = HTMLElement> {
 
 declare const tagName = "s-spinner";
 /**
- * The spinner component displays an animated indicator showing users that content or actions are loading. Use spinner to communicate ongoing processes like fetching data, processing requests, or waiting for operations to complete.
- *
- * Spinners support multiple sizes and should be used for page or section loading states. For button loading states, use the `loading` property on the [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) component instead.
  * @publicDocs
  */
 export interface SpinnerProps extends SpinnerProps$1 {
+    /**
+     * A label that describes the purpose of the spinner for assistive technologies like screen readers. Provide an `accessibilityLabel` when there is no visible text that conveys a loading state.
+     */
+    accessibilityLabel?: SpinnerProps$1['accessibilityLabel'];
+    /**
+     * The size of the spinner icon.
+     *
+     * - `base`: The default size, suitable for most use cases.
+     * - `small`: A compact size for secondary loading states.
+     * - `small-100`: The smallest size for tight spaces or inline indicators.
+     * - `large`: A larger size for more prominent loading states.
+     * - `large-100`: The largest size for full-page or section-level loading indicators.
+     *
+     * @default 'base'
+     */
     size?: Extract<SpinnerProps$1['size'], 'small-100' | 'small' | 'base' | 'large' | 'large-100'>;
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -114,7 +114,7 @@ export interface FocusEventProps {
 /** @publicDocs */
 export interface ToggleEventProps {
 	/**
-	 * A callback fired when the element state changes, after any toggle animations have finished.
+	 * A callback that fires when the element state changes, after any toggle animations have finished.
 	 *
 	 * - If the element transitioned from hidden to showing, the `oldState` property will be set to `closed` and the
 	 *   `newState` property will be set to `open`.
@@ -125,7 +125,7 @@ export interface ToggleEventProps {
 	 */
 	onAfterToggle?: (event: ToggleEvent$1) => void;
 	/**
-	 * A callback fired immediately when the element state changes, before any animations.
+	 * A callback that fires immediately when the element state changes, before any animations.
 	 *
 	 * - If the element is transitioning from hidden to showing, the `oldState` property will be set to `closed` and the
 	 *   `newState` property will be set to `open`.
@@ -136,10 +136,24 @@ export interface ToggleEventProps {
 	 */
 	onToggle?: (event: ToggleEvent$1) => void;
 }
-/** @publicDocs */
+/**
+ * The visibility state of a toggleable element.
+ *
+ * - `open`: The element is visible and showing its content.
+ * - `closed`: The element is hidden and its content is not visible.
+ */
 export type ToggleState = "open" | "closed";
+/**
+ * The event data provided to toggle-related callbacks. Contains the previous and next visibility states of the element.
+ */
 interface ToggleEvent$1 extends Event {
+	/**
+	 * The visibility state of the element after the toggle occurred.
+	 */
 	readonly newState: ToggleState;
+	/**
+	 * The visibility state of the element before the toggle occurred.
+	 */
 	readonly oldState: ToggleState;
 }
 /** @publicDocs */
@@ -160,8 +174,7 @@ interface AnnouncementProps$1 extends GlobalProps, ToggleEventProps {
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Callback fired when the announcement is dismissed by the user
-	 * (either via the built-in dismiss button or programmatically).
+	 * A callback that fires when the announcement is dismissed by the user clicking the close button or by calling the `dismiss()` method programmatically.
 	 */
 	onDismiss?: (event: Event) => void;
 	/**
@@ -812,29 +825,32 @@ interface BadgeProps$1 extends GlobalProps {
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Sets the tone of the Badge, based on the intention of the information being conveyed.
+	 * The semantic meaning and color treatment of the badge.
 	 *
 	 * @default 'auto'
 	 */
 	tone?: ToneKeyword;
 	/**
-	 * Modify the color to be more or less intense.
+	 * Controls the visual weight and emphasis of the badge.
 	 *
 	 * @default 'base'
 	 */
 	color?: ColorKeyword;
 	/**
-	 * The type of icon to be displayed in the badge.
+	 * An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Set to an empty string to display no icon.
 	 *
 	 * @default ''
 	 */
 	icon?: IconType | AnyString;
 	/**
-	 * The position of the icon in relation to the text.
+	 * The position of the icon relative to the badge text.
+	 *
+	 * - `start`: Places the icon before the text.
+	 * - `end`: Places the icon after the text.
 	 */
 	iconPosition?: "start" | "end";
 	/**
-	 * Adjusts the size.
+	 * The size of the badge.
 	 *
 	 * @default 'base'
 	 */
@@ -842,42 +858,34 @@ interface BadgeProps$1 extends GlobalProps {
 }
 interface BannerProps$1 extends GlobalProps, ActionSlots {
 	/**
-	 * The title of the banner.
+	 * The heading text displayed at the top of the banner to summarize the message or alert.
 	 *
 	 * @default ''
 	 */
 	heading?: string;
 	/**
-	 * The content of the Banner.
+	 * The main content displayed within the banner component, typically descriptive text or other elements providing details about the message or alert.
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Sets the tone of the Banner, based on the intention of the information being conveyed.
+	 * The semantic meaning and color treatment of the component. The banner is a live region and the type of status is dictated by the tone selected.
 	 *
-	 * The banner is a live region and the type of status will be dictated by the Tone selected.
-	 *
-	 * - `critical` creates an [assertive live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) that is announced by screen readers immediately.
-	 * - `neutral`, `info`, `success`, `warning` and `caution` creates an [informative live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) that is announced by screen readers after the current message.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
-	 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
-	 * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role
+	 * The `critical` tone creates an [assertive live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role) that is announced by screen readers immediately. The `neutral`, `info`, `success`, `warning`, and `caution` tones create an [informative live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/status_role) that is announced by screen readers after the current message.
 	 *
 	 * @default 'auto'
 	 */
 	tone?: ToneKeyword;
 	/**
-	 * Makes the content collapsible.
-	 * A collapsible banner will conceal child elements initially, but allow the user to expand the banner to see them.
+	 * Whether the banner content can be collapsed and expanded by the user. A collapsible banner conceals child elements initially, allowing the user to expand the banner to reveal them.
 	 *
 	 * @default false
 	 */
 	collapsible?: boolean;
 	/**
-	 * Determines whether the close button of the banner is present.
+	 * Whether the banner displays a close button that allows users to dismiss it.
 	 *
 	 * When the close button is pressed, the `dismiss` event will fire,
-	 * then `hidden` will be true,
+	 * then `hidden` will be set to `true`,
 	 * any animation will complete,
 	 * and the `afterhide` event will fire.
 	 *
@@ -885,31 +893,26 @@ interface BannerProps$1 extends GlobalProps, ActionSlots {
 	 */
 	dismissible?: boolean;
 	/**
-	 * Event handler when the banner is dismissed by the user.
+	 * A callback that fires when the banner is dismissed by the user clicking the close button.
 	 *
-	 * This does not fire when setting `hidden` manually.
+	 * This doesn't fire when setting `hidden` manually.
 	 *
-	 * The `hidden` property will be `false` when this event fires.
+	 * The `hidden` property is `false` when this event fires.
 	 */
 	onDismiss?: (event: Event) => void;
 	/**
-	 * Event handler when the banner has fully hidden.
+	 * A callback that fires when the banner has fully hidden, including after any hide animations have completed.
 	 *
-	 * The `hidden` property will be `true` when this event fires.
-	 *
-	 * @implementation If implementations animate the hiding of the banner,
-	 * this event must fire after the banner has fully hidden.
-	 * We can add an `onHide` event in future if we want to provide a hook for the start of the animation.
+	 * The `hidden` property is `true` when this event fires.
 	 */
 	onAfterHide?: (event: Event) => void;
 	/**
-	 * Determines whether the banner is hidden.
+	 * Controls whether the banner is visible or hidden.
 	 *
-	 * If this property is being set on each framework render (as in 'controlled' usage),
-	 * and the banner is `dismissible`,
-	 * ensure you update app state for this property when the `dismiss` event fires.
+	 * When using a controlled component pattern and the banner is `dismissible`,
+	 * update this property to `true` when the `dismiss` event fires.
 	 *
-	 * If the banner is not `dismissible`, it can still be hidden by setting this property.
+	 * You can hide the banner programmatically by setting this to `true` even if it's not `dismissible`.
 	 *
 	 * @default false
 	 */
@@ -3164,41 +3167,27 @@ interface ProductThumbnailProps$1 extends GlobalProps, BaseImageProps {
 }
 interface ProgressProps$1 extends GlobalProps {
 	/**
-	 * A label that describes the purpose of the progress. When set,
-	 * it will be announced to users using assistive technologies and will
-	 * provide them with more context.
-	 *
-	 * Use it to provide context of what is progressing.
+	 * A label announced by assistive technologies that describes what is progressing. Use this to provide context about the ongoing task, such as "Loading order details" or "Uploading file".
 	 */
 	accessibilityLabel?: string;
 	/**
-	 * Sets the tone of the progress, based on the intention of the information being conveyed.
+	 * The semantic meaning and color treatment of the progress indicator.
 	 *
 	 * @default 'auto'
 	 */
 	tone?: ToneKeyword;
 	/**
-	 * Specifies how much of the task has been completed.
+	 * How much of the task has been completed. Must be a valid floating point number between 0 and `max`, or between 0 and 1 if `max` is omitted. When no value is set, the progress bar is indeterminate, indicating an ongoing activity with no estimated completion time.
 	 *
-	 * It must be a valid floating point number between 0 and `max`, or between 0 and 1 if `max` is omitted.
-	 * If there is no value attribute, the progress bar is indeterminate;
-	 * this indicates that an activity is ongoing with no indication of how long it is expected to take.
-	 *
-	 * @implementation Surfaces should apply styling to cover that indeterminate state.
-	 * @implementation In a HTML host, you can customize the progress animation via the :indeterminate pseudo-class.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#value
-	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate#progress_bar
+	 * Learn more about the [value attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#value).
 	 */
 	value?: number;
 	/**
-	 * This attribute describes how much work the task indicated by the progress element requires.
+	 * The total amount of work the task requires. Must be a value greater than 0 and a valid floating point number.
 	 *
-	 * The `max` attribute, if present, must have a value greater than 0 and be a valid floating point number.
+	 * Learn more about the [max attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#max).
 	 *
 	 * @default 1
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#max
 	 */
 	max?: number;
 }
@@ -3365,17 +3354,13 @@ interface SkeletonParagraphProps$1 extends GlobalProps {
 }
 interface SpinnerProps$1 extends GlobalProps {
 	/**
-	 * Adjusts the size of the spinner icon.
+	 * The size of the spinner icon.
 	 *
 	 * @default 'base'
 	 */
 	size?: SizeKeyword;
 	/**
-	 * A label that describes the purpose of the progress. When set,
-	 * it will be announced to users using assistive technologies and will
-	 * provide them with more context. Providing an `accessibilityLabel` is
-	 * recommended if there is no accompanying text describing that something
-	 * is loading.
+	 * A label that describes the purpose of the spinner for assistive technologies like screen readers. Provide an `accessibilityLabel` when there is no visible text that conveys a loading state.
 	 */
 	accessibilityLabel?: string;
 }


### PR DESCRIPTION
## This PR:
- Improves JSDoc descriptions for checkout Feedback and Status Indicator components (Announcement, Badge, Banner, Progress, Spinner) to align with admin UI extensions documentation style — clearer opening sentences, bulleted value descriptions for enum props, and inline "Learn more about" links replacing `@see` tags.
- Adds missing descriptions for `ToggleState`, `ToggleArgumentsEvent`, `ReducedIconTypes`, and the `dismiss()` method on Announcement, ensuring all public types and methods are documented.
- Updated `components-shared.d.ts` to keep upstream descriptions consistent with the component-level overrides, removing internal `@implementation` annotations and vague phrasing like "Adjusts the size" or "Modify the color."
- Relates to https://github.com/shop/world/pull/577654
- Partially closes https://github.com/shop/issues-learn/issues/1494