### PR TITLE
[Customer account UI extensions 2025-07]: Improved descriptions for "Feedback and status indicators" components

### DIFF
--- a/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge/Badge.ts
@@ -20,8 +20,8 @@ interface BadgeBaseProps extends AccessibilityLabelProps {
   /**
    * The size of the badge.
    *
-   * - `small-100`: A smaller badge, useful for compact layouts.
    * - `base`: The standard badge size.
+   * - `small-100`: A smaller badge, useful for compact layouts.
    *
    * @defaultValue 'base'
    */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
@@ -3,37 +3,49 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {Size, VisibilityProps} from '../shared';
 import type {IconSource} from '../Icon/Icon';
 
+/**
+ * The available tone values for the badge.
+ *
+ * - `default`: General information without specific intent.
+ * - `subdued`: Reduced visual emphasis for less prominent badges.
+ * - `critical`: Urgent problems or destructive actions requiring immediate attention.
+ */
 type Tone = 'default' | 'critical' | 'subdued';
 
 /**
- * Use badges to highlight contextual information, like a label or a status, about an object. An object can be anything that has a status or label attributed to it, like an order or subscription.
  * @publicDocs
  */
 export interface BadgeProps extends VisibilityProps {
   /**
-   * The tone of the badge being rendered. Indicates its level of importance,
-   * where subdued provides the least emphasis, while critical indicates the highest level of urgency.
+   * The semantic meaning and color treatment of the badge.
    *
    * @default 'default'
    */
   tone?: Tone;
   /**
-   * The size of the badge being rendered.
+   * The size of the badge.
+   *
+   * - `base`: The default size, suitable for most use cases.
+   * - `small`: A smaller badge for compact layouts.
    *
    * @default 'base'
    */
   size?: Extract<Size, 'base' | 'small'>;
   /**
-   * A label that describes the purpose or contents of the element. When set,
-   * it will announced to buyers using assistive technologies.
+   * A label that describes the purpose or contents of the element. When set, it will be announced
+   * to users using assistive technologies and will provide them with more context. When set, any
+   * children or `label` supplied won't be announced to screen readers.
    */
   accessibilityLabel?: string;
   /**
-   * The name of the icon to be displayed in the badge.
+   * An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning.
    */
   icon?: IconSource;
   /**
-   * The position of the icon in relation to the text.
+   * The position of the icon relative to the badge text.
+   *
+   * - `start`: Places the icon before the text.
+   * - `end`: Places the icon after the text.
    *
    * @default 'start'
    */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.ts
@@ -3,39 +3,33 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {IdProps, Status} from '../shared';
 
 /**
- * Use banners to communicate important messages to customers in a prominent way.
  * @publicDocs
  */
 export interface BannerProps extends IdProps {
   /**
-   * Banners have an optional title. Use a title to grab the buyer’s attention
-   * with a short, concise message. Banners with no title should have child elements
-   * to convey the banner’s purpose to the buyer.
+   * The title text displayed at the top of the banner to summarize the message or alert.
    */
   title?: string;
   /**
-   * Sets the status of the banner.
+   * The semantic meaning and color treatment of the banner.
    *
    * @defaultValue 'info'
    */
   status?: Status;
   /**
-   * Makes the content collapsible. A collapsible banner will conceal child
-   * elements initially, but allow the user to expand the banner to see them.
+   * Whether the banner content can be collapsed and expanded by the user.
+   * A collapsible banner conceals child elements initially, allowing the user to expand the banner to reveal them.
    *
    * @defaultValue false
    */
   collapsible?: boolean;
   /**
-   * Callback when banner is dismissed. This component is
-   * [controlled](https://reactjs.org/docs/forms.html#controlled-components),
+   * A callback that fires when the banner is dismissed by the user.
+   * This component is [controlled](https://reactjs.org/docs/forms.html#controlled-components),
    * so you must manage the visibility of the banner in state by using
-   * the onDismiss callback.
+   * the `onDismiss` callback.
    */
   onDismiss?(): void;
 }
 
-/**
- * Use banners to communicate important messages to customers in a prominent way.
- */
 export const Banner = createRemoteComponent<'Banner', BannerProps>('Banner');

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.ts
@@ -2,43 +2,40 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-type Tone = 'auto' | 'critical';
-
 /**
- * Use to visually represent the completion of a task or process.
  * @publicDocs
  */
 export interface ProgressProps extends IdProps {
   /**
-   * Specify how much of the task that has been completed.
-   * It must be a valid floating point number between 0 and max, or between 0 and 1 if max is omitted.
-   * When undefined, the progress bar is indeterminate;
-   * this indicates that an activity is ongoing with no indication of how long it is expected to take.
+   * How much of the task has been completed. Must be a valid floating point number between 0 and `max`, or between 0 and 1 if `max` is omitted. When no value is set, the progress bar is indeterminate, indicating an ongoing activity with no estimated completion time.
    *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#value
+   * Learn more about the [value attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#value).
    */
   value?: number;
 
   /**
-   * Define the maximum limit of the progress element.
-   * It must have a value greater than 0 and be a valid floating point number.
+   * The total amount of work the task requires. Must be a value greater than 0 and a valid floating point number.
+   *
+   * Learn more about the [max attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#max).
    *
    * @defaultValue 1
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress#max
    */
   max?: number;
 
   /**
-   * Set the color of the progress bar.
+   * The semantic meaning and color treatment of the progress indicator.
+   *
+   * - `auto`: Automatically determined based on context.
+   * - `critical`: Indicates an urgent or error state requiring immediate attention.
    *
    * @defaultValue 'auto'
    */
-  tone?: Tone;
+  tone?: 'auto' | 'critical';
 
   /**
-   * A label to use for the Progress that will be used for buyers using assistive technologies like screen readers.
-   * It will also be used to replace the animated loading indicator when buyers prefer reduced motion.
-   *
+   * A label that describes the purpose or contents of the element. When set, it will be announced
+   * to users using assistive technologies and will provide them with more context. When set, any
+   * children or `label` supplied won't be announced to screen readers.
    */
   accessibilityLabel?: string;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.ts
@@ -3,29 +3,36 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {Appearance, IdProps, Size} from '../shared';
 
 /**
- * Spinner is used to notify buyers that their action is being processed. The Spinner is usually used when sending or receiving data from a server.
  * @publicDocs
  */
 export interface SpinnerProps extends IdProps {
   /**
-   * Adjusts the size of the icon.
+   * The size of the spinner icon.
+   *
+   * - `extraSmall`: The smallest size for tight spaces or inline indicators.
+   * - `small`: A compact size for secondary loading states.
+   * - `base`: The default size, suitable for most use cases.
+   * - `large`: A larger size for more prominent loading states.
+   * - `fill`: Expands to fill the available space.
    *
    * @defaultValue 'base'
    */
   size?: Extract<Size, 'extraSmall' | 'small' | 'base' | 'large' | 'fill'>;
 
   /**
-   * Sets the appearance (color) of the icon.
+   * The visual appearance of the spinner icon.
+   *
+   * - `accent`: Uses the accent color to convey emphasis and draw attention.
+   * - `monochrome`: Inherits the color of its parent element.
    *
    * @defaultValue 'accent'
    */
   appearance?: Extract<Appearance, 'accent' | 'monochrome'>;
 
   /**
-   * A label to use for the Spinner that will be used for buyers using
-   * assistive technologies like screen readers. If will also be used to replace
-   * the animated loading indicator when buyers prefers reduced motion. If not included,
-   * it will use the loading indicator for all buyers.
+   * A label that describes the purpose or contents of the element. When set, it will be announced
+   * to users using assistive technologies and will provide them with more context. When set, any
+   * children or `label` supplied won't be announced to screen readers.
    */
   accessibilityLabel?: string;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
@@ -809,22 +809,25 @@ export type MultiPick<Base, AcceptedCombinations extends (keyof Base)[]> = {
   };
 }[number];
 
+/**
+ * The available visibility states for an element.
+ *
+ * - `hidden`: Visually hides the element while keeping it accessible to assistive technologies like screen readers. Hidden elements don't occupy any visual space.
+ */
 export type Visibility = 'hidden';
+/**
+ * The available accessibility visibility states for an element.
+ *
+ * - `hidden`: Hides the element from assistive technologies like screen readers while keeping it visually visible.
+ */
 export type AccessibilityVisibility = 'hidden';
 export interface VisibilityProps {
   /**
-   * Changes the visibility of the element.
-   *
-   * `hidden` visually hides the component while keeping it accessible
-   * to assistive technology, such as screen readers.
-   * Hidden elements don't take any visual space contrary to CSS visibility: hidden;
+   * Controls the visual visibility of the element.
    */
   visibility?: Visibility;
   /**
-   * Changes the visibility of the element to assistive technologies.
-   *
-   * `hidden` hides the component from assistive technology (for example,
-   * a screen reader) but remains visually visible.
+   * Controls the visibility of the element to assistive technologies.
    */
   accessibilityVisibility?: AccessibilityVisibility;
 }
@@ -853,7 +856,7 @@ export type TextSize =
 
 export interface IdProps {
   /**
-   * A unique identifier for the component.
+   * A unique identifier for the component. Use this to target the component in scripts or stylesheets, or to distinguish it from other instances of the same component.
    */
   id?: string;
 }


### PR DESCRIPTION
## This PR:
- Improves JSDoc descriptions for checkout Feedback and Status Indicator components (Badge, Banner, Progress, Spinner) to align with admin UI extensions documentation style — clearer opening sentences, consistent `accessibilityLabel` descriptions across surfaces, and bulleted value descriptions for enum props like `tone`, `status`, `size`, and `appearance`.
- Adds type-level JSDoc to `Tone`, `Visibility`, and `AccessibilityVisibility` so value descriptions render inside the nested type boxes in the docs, with differentiated high-level descriptions at the prop level to avoid duplication.
- Inlines the Progress `tone` type to prevent the docs generator from resolving to Badge's `Tone` definition, which was displaying incorrect values (`'default' | 'critical' | 'subdued'` instead of `'auto' | 'critical'`).
- Updates shared props in `shared.ts` — improved `IdProps`, `VisibilityProps`, and `AccessibilityVisibility` descriptions — benefiting all components that inherit from them.
- Relates to https://github.com/shop/world/pull/577654
- Partially closes https://github.com/shop/issues-learn/issues/1494