### PR TITLE
[Customer account UI extensions 2025-07]: Improved descriptions for "Layout and structure" components

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
@@ -5,33 +5,19 @@ import type {Rows} from '../shared';
 import type {GridProps} from '../Grid/Grid';
 
 /**
- * BlockLayout is used to lay out content over multiple rows.
-
-By default, all rows fill the available block space, sharing it equally.
  * @publicDocs
  */
 export interface BlockLayoutProps extends Omit<GridProps, 'columns' | 'rows'> {
   /**
-   * Sizes for each row of the layout.
+   * The sizes for each row of the layout.
    *
+   * - `auto`: The intrinsic size of the element.
+   * - `fill`: Fills the remaining available space. When multiple elements use `fill`, the space is shared equally.
+   * - `` `${number}%` ``: A percentage of the container's block size.
+   * - `` `${number}fr` ``: A fractional unit of the available space.
+   * - `number`: A fixed size in pixels.
    *
-   * `auto`: intrinsic size of the element.
-   *
-   * `fill`: fills the remaining available space. When multiple elements are set to `fill`, the remaining space is shared equally.
-   *
-   * `` `${number}%` ``: size in percentages.
-   *
-   * `` `${number}fr` ``: size in fractions.
-   *
-   * `number`: size in pixels.
-   *
-   *
-   * - When the sum of the defined sizes is larger than the available space, elements will shrink to avoid overflow.
-   *
-   * - When the size of an element is not explicitly set, it will fill the remaining space available.
-   *
-   * - When only one size is set and outside of an array, all elements of the layout will take that size.
-   *
+   * When the sum of defined sizes exceeds the available space, elements shrink to avoid overflow. Elements without an explicit size fill the remaining space. A single value outside an array applies to all rows.
    *
    * @defaultValue 'fill'
    */
@@ -39,9 +25,8 @@ export interface BlockLayoutProps extends Omit<GridProps, 'columns' | 'rows'> {
 }
 
 /**
- * BlockLayout is used to lay out content over multiple rows.
- *
- * By default, all rows fill the available block space, sharing it equally.
+ * BlockLayout arranges content over multiple rows. By default, all rows
+ * fill the available block space, sharing it equally.
  */
 export const BlockLayout = createRemoteComponent<
   'BlockLayout',

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.ts
@@ -4,14 +4,11 @@ import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps, Spacing} from '../shared';
 
 /**
- * BlockSpacer is used to create empty block space, typically when variable spacing is needed between multiple elements.
-
-Note that you should favor BlockStack when spacing between all elements is the same.
  * @publicDocs
  */
 export interface BlockSpacerProps extends IdProps {
   /**
-   * Adjust size of the spacer
+   * The size of the spacer.
    *
    * @defaultValue 'base'
    **/
@@ -19,10 +16,9 @@ export interface BlockSpacerProps extends IdProps {
 }
 
 /**
- * BlockSpacer is used to create empty block space, typically when variable spacing
- * is needed between multiple elements.
- *
- * Note that you should favor BlockStack when spacing between all elements is the same.
+ * BlockSpacer creates empty block-axis space, typically when variable spacing
+ * is needed between elements. Use BlockStack instead when spacing between all
+ * elements is the same.
  */
 export const BlockSpacer = createRemoteComponent<
   'BlockSpacer',

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
@@ -14,7 +14,6 @@ import type {
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 
 /**
- * BlockStack is used to vertically stack elements.
  * @publicDocs
  */
 export interface BlockStackProps
@@ -25,63 +24,43 @@ export interface BlockStackProps
     SizingProps,
     SpacingProps {
   /**
-   * Position children along the main axis
+   * The alignment of children along the inline (main) axis.
    */
   inlineAlignment?: MaybeResponsiveConditionalStyle<InlineAlignment>;
   /**
-   * Adjust spacing between children
+   * The spacing between child elements.
    *
    * @defaultValue 'base'
    */
   spacing?: MaybeResponsiveConditionalStyle<Spacing>;
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help buyers
-   * navigate the page.
-   *
-   *
-   * For example:
-   *
-   * - In an HTML host a `['listItem', 'separator']` tuple will render: `<li role='separator'>`
-   *
-   * - In an HTML host a `listItem` string will render: `<li>`
+   * The semantic meaning of the component's content. When set, assistive technologies use this role to help users navigate the page. Accepts a single role or a tuple of two roles (for example, `['listItem', 'separator']`).
    */
   accessibilityRole?: ViewLikeAccessibilityRole;
   /**
-   * A label that describes the purpose or contents of the element. When set,
-   * it will be announced to buyers using assistive technologies and will
-   * provide them with more context.
+   * A label announced by assistive technologies that describes the purpose or contents of the element. Only set this when the element's visible content doesn't provide enough context on its own.
    */
   accessibilityLabel?: string;
   /**
-   * Sets the overflow behavior of the element.
+   * The overflow behavior of the element.
    *
-   * `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel.
-   *
-   * `visible`: the content that extends beyond the element’s container is visible.
+   * - `visible`: Content that extends beyond the container is visible.
+   * - `hidden`: Content that extends beyond the container is clipped and not scrollable.
    *
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
   /**
-   * Changes the display of the component.
+   * The display mode of the component. Learn more about [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
-   * `auto` the component's initial value. The actual value depends on the component and context.
-   *
-   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   * - `auto`: The initial value; the actual behavior depends on the component and context.
+   * - `none`: Hides the component and removes it from the accessibility tree.
    *
    * @defaultValue 'auto'
    */
   display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
-/**
- * BlockStack is used to vertically stack elements.
- */
 export const BlockStack = createRemoteComponent<'BlockStack', BlockStackProps>(
   'BlockStack',
 );

--- a/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.ts
@@ -3,26 +3,33 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {Alignment, Direction, IdProps, Size} from '../shared';
 
 /**
- * A divider separates content and represents a thematic break between elements.
  * @publicDocs
  */
 export interface DividerProps extends IdProps {
   /**
-   * Use to create dividers with varying widths.
+   * The thickness of the divider line.
+   *
+   * - `small`: A thin, subtle line.
+   * - `base`: The standard divider thickness.
+   * - `large`: A thicker line for stronger visual separation.
+   * - `extraLarge`: The thickest available line.
    *
    * @defaultValue 'small'
    */
   size?: Extract<Size, 'small' | 'base' | 'large' | 'extraLarge'>;
 
   /**
-   * Use to specify direction of divider.
+   * The orientation of the divider, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+   *
+   * - `inline`: A horizontal divider that separates content stacked vertically.
+   * - `block`: A vertical divider that separates content arranged horizontally.
    *
    * @defaultValue 'inline'
    */
   direction?: Direction;
 
   /**
-   * Use to specify alignment of contents of divider.
+   * The alignment of the divider's content within its container.
    *
    * @defaultValue 'center'
    */
@@ -30,7 +37,8 @@ export interface DividerProps extends IdProps {
 }
 
 /**
- * A divider separates content and represents a thematic break between elements.
+ * A visual separator that draws a line between adjacent sections of content,
+ * representing a thematic break.
  */
 export const Divider = createRemoteComponent<'Divider', DividerProps>(
   'Divider',

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
@@ -17,7 +17,6 @@ import type {
 } from '../shared';
 
 /**
- * Grid is used to lay out content in a matrix of rows and columns.
  * @publicDocs
  */
 export interface GridProps
@@ -28,115 +27,73 @@ export interface GridProps
     SizingProps,
     SpacingProps {
   /**
-   * Sizes for each column of the layout.
+   * The sizes for each column of the grid.
    *
+   * - `auto`: The intrinsic size of the content.
+   * - `fill`: Fills the remaining available space. When multiple columns use `fill`, the space is shared equally.
+   * - `` `${number}%` ``: A percentage of the container's inline size.
+   * - `` `${number}fr` ``: A fractional unit of the available space.
+   * - `number`: A fixed size in pixels.
    *
-   * `auto`: intrinsic size of the content.
-   *
-   * `fill`: fills the remaining available space. When multiple columns are set to `fill`, the remaining space is shared equally.
-   *
-   * `` `${number}%` ``: size in percentages.
-   *
-   * `` `${number}fr` ``: size in fractions.
-   *
-   * `number`: size in pixels.
-   *
-   *
-   * - When the sum of the defined sizes is larger than the available space, elements will shrink to avoid overflow.
-   * - Except when in scrollview, where the grid will fill the space with the defined sizes.
-   *
-   * - When only one size is set and outside of an array, the grid will have one column of that size.
+   * When the sum of defined sizes exceeds the available space, elements shrink to avoid overflow (except inside a ScrollView). A single value outside an array creates one column of that size.
    *
    * @defaultValue 'fill'
    */
   columns?: MaybeResponsiveConditionalStyle<Columns>;
   /**
-   * Sizes for each row of the layout.
+   * The sizes for each row of the grid.
    *
+   * - `auto`: The intrinsic size of the content.
+   * - `fill`: Fills the remaining available space. When multiple rows use `fill`, the space is shared equally.
+   * - `` `${number}%` ``: A percentage of the container's block size.
+   * - `` `${number}fr` ``: A fractional unit of the available space.
+   * - `number`: A fixed size in pixels.
    *
-   * `auto`: intrinsic size of the content.
-   *
-   * `fill`: fills the remaining available space. When multiple rows are set to `fill`, the remaining space is shared equally.
-   *
-   * `` `${number}%` ``: size in percentages.
-   *
-   * `` `${number}fr` ``: size in fractions.
-   *
-   * `number`: size in pixels.
-   *
-   *
-   * - When the sum of the defined sizes is larger than the available space, elements will shrink to avoid overflow.
-   *
-   * - When only one size is set and outside of an array, the grid will have one row of that size.
+   * When the sum of defined sizes exceeds the available space, elements shrink to avoid overflow. A single value outside an array creates one row of that size.
    *
    * @defaultValue 'fill'
    */
   rows?: MaybeResponsiveConditionalStyle<Rows>;
   /**
-   * Adjust spacing between children.
-   *
-   * - `base` means the space between rows and columns is `base`.
-   *
-   * - [`base`, `none`] means the space between rows is `base`, space between columns is `none`.
+   * The spacing between child elements. A single value applies to both the row and column axes. A pair of values (for example, `['base', 'none']`) sets the row and column spacing independently.
    *
    * @defaultValue 'none'
    **/
   spacing?: MaybeResponsiveConditionalStyle<Spacing | [Spacing, Spacing]>;
   /**
-   * Position children along the cross axis.
+   * The alignment of children along the block (cross) axis.
    */
   blockAlignment?: MaybeResponsiveConditionalStyle<BlockAlignment>;
   /**
-   * Position children along the main axis.
+   * The alignment of children along the inline (main) axis.
    */
   inlineAlignment?: MaybeResponsiveConditionalStyle<InlineAlignment>;
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help buyers
-   * navigate the page.
-   *
-   *
-   * For example:
-   *
-   * - In an HTML host a `['listItem', 'separator']` tuple will render: `<li role='separator'>`
-   *
-   * - In an HTML host a `listItem` string will render: `<li>`
+   * The semantic meaning of the component's content. When set, assistive technologies use this role to help users navigate the page. Accepts a single role or a tuple of two roles (for example, `['listItem', 'separator']`).
    */
   accessibilityRole?: ViewLikeAccessibilityRole;
   /**
-   * A label that describes the purpose or contents of the element. When set,
-   * it will be announced to buyers using assistive technologies and will
-   * provide them with more context.
+   * A label announced by assistive technologies that describes the purpose or contents of the element. Only set this when the element's visible content doesn't provide enough context on its own.
    */
   accessibilityLabel?: string;
   /**
-   * Sets the overflow behavior of the element.
+   * The overflow behavior of the element.
    *
-   * `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel.
-   *
-   * `visible`: the content that extends beyond the element’s container is visible.
+   * - `visible`: Content that extends beyond the container is visible.
+   * - `hidden`: Content that extends beyond the container is clipped and not scrollable.
    *
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
   /**
-   * Changes the display of the component.
+   * The display mode of the component. Learn more about [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
-   *
-   * `auto` the component's initial value. The actual value depends on the component and context.
-   *
-   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   * - `auto`: The initial value; the actual behavior depends on the component and context.
+   * - `none`: Hides the component and removes it from the accessibility tree.
    *
    * @defaultValue 'auto'
    */
   display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
-/**
- * Grid is used to lay out content in a matrix of rows and columns.
- */
 export const Grid = createRemoteComponent<'Grid', GridProps>('Grid');

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
@@ -12,9 +12,6 @@ import type {
 } from '../shared';
 
 /**
- * GridItem can be used as children of Grid.
-
-It offers a way to span the element across a number of columns and rows.
  * @publicDocs
  */
 export interface GridItemProps
@@ -25,58 +22,37 @@ export interface GridItemProps
     SizingProps,
     SpacingProps {
   /**
-   * Number of columns the item will span across
+   * The number of columns this item spans within the grid.
    */
   columnSpan?: MaybeResponsiveConditionalStyle<number>;
   /**
-   * Number of rows the item will span across
+   * The number of rows this item spans within the grid.
    */
   rowSpan?: MaybeResponsiveConditionalStyle<number>;
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help buyers
-   * navigate the page.
-   *
-   *
-   * For example:
-   *
-   * - In an HTML host a `['listItem', 'separator']` tuple will render: `<li role='separator'>`
-   *
-   * - In an HTML host a `listItem` string will render: `<li>`
+   * The semantic meaning of the component's content. When set, assistive technologies use this role to help users navigate the page. Accepts a single role or a tuple of two roles (for example, `['listItem', 'separator']`).
    */
   accessibilityRole?: ViewLikeAccessibilityRole;
   /**
-   * Sets the overflow behavior of the element.
+   * The overflow behavior of the element.
    *
-   * `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel.
-   *
-   * `visible`: the content that extends beyond the element’s container is visible.
+   * - `visible`: Content that extends beyond the container is visible.
+   * - `hidden`: Content that extends beyond the container is clipped and not scrollable.
    *
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
   /**
-   * Changes the display of the component.
+   * The display mode of the component. Learn more about [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
-   *
-   * `auto` the component's initial value. The actual value depends on the component and context.
-   *
-   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   * - `auto`: The initial value; the actual behavior depends on the component and context.
+   * - `none`: Hides the component and removes it from the accessibility tree.
    *
    * @defaultValue 'auto'
    */
   display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
-/**
- * GridItem can be used as children of Grid.
- *
- * It offers a way to span the element across a number of columns and rows.
- */
 export const GridItem = createRemoteComponent<'GridItem', GridItemProps>(
   'GridItem',
 );

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.ts
@@ -11,9 +11,6 @@ import type {
 import type {GridProps} from '../Grid/Grid';
 
 /**
- * InlineLayout is used to lay out content over multiple columns.
-
-By default, all columns are of equal size and fill the available inline space. Content does not wrap on new rows when not enough columns have been explicitly set, instead they are added as new column and fill the remaining inline space.
  * @publicDocs
  */
 export interface InlineLayoutProps
@@ -23,26 +20,15 @@ export interface InlineLayoutProps
     SizingProps,
     SpacingProps {
   /**
-   * Sizes for each column of the layout.
+   * The sizes for each column of the layout.
    *
+   * - `auto`: The intrinsic size of the element.
+   * - `fill`: Fills the remaining available space. When multiple elements use `fill`, the space is shared equally.
+   * - `` `${number}%` ``: A percentage of the container's inline size.
+   * - `` `${number}fr` ``: A fractional unit of the available space.
+   * - `number`: A fixed size in pixels.
    *
-   * `auto`: intrinsic size of the element.
-   *
-   * `fill`: fills the remaining available space. When multiple elements are set to `fill`, the remaining space is shared equally.
-   *
-   * `` `${number}%` ``: size in percentages.
-   *
-   * `` `${number}fr` ``: size in fractions.
-   *
-   * `number`: size in pixels.
-   *
-   *
-   * - When the sum of the defined sizes is larger than the available space, elements will shrink to avoid overflow.
-   *
-   * - When the size of an element is not explicitly set, it will fill the remaining space available.
-   *
-   * - When only one size is set and outside of an array, all elements of the layout will take that size.
-   *
+   * When the sum of defined sizes exceeds the available space, elements shrink to avoid overflow. Elements without an explicit size fill the remaining space. A single value outside an array applies to all columns.
    *
    * @defaultValue 'fill'
    */
@@ -50,11 +36,9 @@ export interface InlineLayoutProps
 }
 
 /**
- * InlineLayout is used to lay out content over multiple columns.
- *
- * By default, all columns are of equal size and fill the available inline space.
- * Content does not wrap on new rows when not enough columns have been explicitly set,
- * instead they are added as new column and fill the remaining inline space.
+ * InlineLayout arranges content over multiple columns. By default, all
+ * columns are equal-sized and fill the available inline space. Content
+ * does not wrap to new rows; extra children are added as new columns.
  */
 export const InlineLayout = createRemoteComponent<
   'InlineLayout',

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.ts
@@ -4,14 +4,11 @@ import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps, Spacing} from '../shared';
 
 /**
- * InlineSpacer is used to create empty inline space, typically when variable spacing is needed between multiple elements.
-
-Note that you should favor InlineStack when spacing between all elements is the same.
  * @publicDocs
  */
 export interface InlineSpacerProps extends IdProps {
   /**
-   * Adjust size of the spacer
+   * The size of the spacer.
    *
    * @defaultValue 'base'
    **/
@@ -19,10 +16,9 @@ export interface InlineSpacerProps extends IdProps {
 }
 
 /**
- * InlineSpacer is used to create empty inline space, typically when variable spacing
- * is needed between multiple elements.
- *
- * Note that you should favor InlineStack when spacing between all elements is the same.
+ * InlineSpacer creates empty inline-axis space, typically when variable spacing
+ * is needed between elements. Use InlineStack instead when spacing between all
+ * elements is the same.
  */
 export const InlineSpacer = createRemoteComponent<
   'InlineSpacer',

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
@@ -15,7 +15,6 @@ import type {
 } from '../shared';
 
 /**
- * InlineStack is used to lay out a horizontal row of elements. Elements always wrap.
  * @publicDocs
  */
 export interface InlineStackProps
@@ -26,76 +25,51 @@ export interface InlineStackProps
     SizingProps,
     SpacingProps {
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help buyers
-   * navigate the page.
-   *
-   *
-   * For example:
-   *
-   * - In an HTML host a `'listItem'` string will render: `<li>`
-   *
-   * - In an HTML host a `['listItem', 'separator']` tuple will render: `<li role='separator'>`
+   * The semantic meaning of the component's content. When set, assistive technologies use this role to help users navigate the page. Accepts a single role or a tuple of two roles (for example, `['listItem', 'separator']`).
    */
   accessibilityRole?: ViewLikeAccessibilityRole;
   /**
-   * A label that describes the purpose or contents of the element. When set,
-   * it will be announced to buyers using assistive technologies and will
-   * provide them with more context.
+   * A label announced by assistive technologies that describes the purpose or contents of the element. Only set this when the element's visible content doesn't provide enough context on its own.
    */
   accessibilityLabel?: string;
   /**
-   * Position children along the cross axis
+   * The alignment of children along the block (cross) axis.
    *
    * @defaultValue 'start'
    */
   blockAlignment?: MaybeResponsiveConditionalStyle<BlockAlignment>;
   /**
-   * Position children along the main axis
+   * The alignment of children along the inline (main) axis.
    *
    * @defaultValue 'start'
    */
   inlineAlignment?: MaybeResponsiveConditionalStyle<InlineAlignment>;
   /**
-   * Adjust spacing between children
-   *
-   * - `base` means the space between rows and columns is `base`.
-   *
-   * - [`base`, `none`] means the space between rows is `base`, space between columns is `none`.
+   * The spacing between child elements. A single value applies to both the row and column axes. A pair of values (for example, `['base', 'none']`) sets the row and column spacing independently.
    *
    * @defaultValue 'base'
    **/
   spacing?: MaybeResponsiveConditionalStyle<Spacing | [Spacing, Spacing]>;
   /**
-   * Sets the overflow behavior of the element.
+   * The overflow behavior of the element.
    *
-   * `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel.
-   *
-   * `visible`: the content that extends beyond the element’s container is visible.
+   * - `visible`: Content that extends beyond the container is visible.
+   * - `hidden`: Content that extends beyond the container is clipped and not scrollable.
    *
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
   /**
-   * Changes the display of the component.
+   * The display mode of the component. Learn more about [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
-   *
-   * `auto` the component's initial value. The actual value depends on the component and context.
-   *
-   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   * - `auto`: The initial value; the actual behavior depends on the component and context.
+   * - `none`: Hides the component and removes it from the accessibility tree.
    *
    * @defaultValue 'auto'
    */
   display?: MaybeResponsiveConditionalStyle<'auto' | 'none'>;
 }
 
-/**
- * InlineStack is used to lay out a horizontal row of elements. Elements always wrap.
- */
 export const InlineStack = createRemoteComponent<
   'InlineStack',
   InlineStackProps

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
@@ -10,29 +10,31 @@ import type {
 } from '../shared';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 
+/**
+ * The event object passed to `onScroll` and `onScrolledToEdge` callbacks on a ScrollView.
+ */
 export interface ScrollViewEvent {
   /**
-   * The current scroll position, in pixels.
+   * The current scroll position in pixels, broken out by axis.
    */
   position: {
-    /** The current scroll horizontal position, in pixels.*/
+    /** The current horizontal (inline-axis) scroll position in pixels. */
     inline: number;
-    /** The current scroll vertical position, in pixels.*/
+    /** The current vertical (block-axis) scroll position in pixels. */
     block: number;
   };
   /**
-   * A flag to indicate if the scroll is at the start or end of an axis.
+   * Whether the scroll position has reached the start or end of each axis, or `null` if neither edge has been reached.
    */
   scrolledTo: {
-    /** A flag to indicate if the scroll is at the start or end of cross axis. */
+    /** Whether the inline-axis scroll is at the `'start'`, `'end'`, or neither (`null`). */
     inline: 'start' | 'end' | null;
-    /** A flag to indicate if the scroll is at the start or end of main axis. */
+    /** Whether the block-axis scroll is at the `'start'`, `'end'`, or neither (`null`). */
     block: 'start' | 'end' | null;
   };
 }
 
 /**
- * ScrollView is a container for long form content, such as order summary line items, that allows for scrolling so customers can expose more content as they view.
  * @publicDocs
  */
 export interface ScrollViewProps
@@ -43,74 +45,42 @@ export interface ScrollViewProps
     SizingProps,
     SpacingProps {
   /**
-   * A label that describes the purpose or contents of the element. When set,
-   * it will be announced to buyers using assistive technologies and will
-   * provide them with more context.
+   * A label announced by assistive technologies that describes the purpose or contents of the element. Only set this when the element's visible content doesn't provide enough context on its own.
    */
   accessibilityLabel?: string;
   /**
-   * Provides a hint to the user that the area is scrollable.
+   * A visual hint indicating that the area is scrollable.
    *
-   * `pill`: renders a pill with a message at the end of the the scrollable area. It disappear as soon as the user starts scrolling.
-   *
-   * `innerShadow`: renders an inner visual hint to indicate that the content is scrollable.
+   * - `innerShadow`: An inner shadow indicating that content continues beyond the visible area.
+   * - `{type: 'pill', content: string}`: A pill-shaped message displayed at the end of the scrollable area that disappears when the user starts scrolling.
    */
   hint?: 'innerShadow' | {type: 'pill'; content: string};
   /**
-   * The direction on which the content is scrollable.
+   * The axis along which the content is scrollable.
    *
-   * `block`:
-   * Indicates that the content is scrollable on the main axis.
-   *
-   * `inline`:
-   * Indicates that the content is scrollable on the cross axis.
+   * - `block`: Content scrolls along the main (block) axis.
+   * - `inline`: Content scrolls along the cross (inline) axis.
    *
    * @defaultValue block
    */
   direction?: 'block' | 'inline';
   /**
-   * Scroll to a specific position or to an element when the component is first rendered.
-   *
-   * This property allows you to set an initial scroll position or scroll to a specific element
-   * when the `ScrollView` component mounts. Note that this action will only be performed once,
-   * during the initial render of the component.
-   *
-   * @example
-   * // Scroll to 100 pixels from the top on initial render
-   * <ScrollView scrollTo={100} />
-   *
-   * // Scroll to a specific element on initial render
-   * const elementRef = useRef(null);
-   * <ScrollView scrollTo={elementRef.current} />
-   *
-   * @note
-   * This property will only take effect on the first render. Subsequent updates to this property
-   * will not trigger additional scroll actions.
+   * The initial scroll target when the component first renders. Accepts a pixel offset (`number`) to scroll to a specific position, or an `HTMLElement` to scroll that element into view. This only takes effect on the first render; subsequent updates to this prop are ignored.
    */
   scrollTo?: number | HTMLElement;
   /**
-   * Callback function that is called when the scroll position changes.
-   * Allows to listen to events inside the component
-   * returning the position of the scroll.
-   *
-   * Note:
-   * On touch devices, the onScroll event is fired only when the user finishes scrolling
-   * which differs from non touch devices, where the onScroll event is fired when the user scrolls
+   * A callback fired when the scroll position changes. On touch devices, this fires only when the user finishes scrolling, unlike non-touch devices where it fires continuously during scrolling.
    */
   onScroll?: (args: ScrollViewEvent) => void;
   /**
-   * Callback function that is called when the scroll position reaches one of the edges.
+   * A callback fired when the scroll position reaches one of the container's edges.
    */
   onScrolledToEdge?: (args: ScrollViewEvent) => void;
   /**
-   * Changes the display of the component.
+   * The display mode of the component. Learn more about [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
-   *
-   * `auto` the component's initial value. The actual value depends on the component and context.
-   *
-   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   * - `auto`: The initial value; the actual behavior depends on the component and context.
+   * - `none`: Hides the component and removes it from the accessibility tree.
    *
    * @defaultValue 'auto'
    */
@@ -118,8 +88,8 @@ export interface ScrollViewProps
 }
 
 /**
- * ScrollView is a container for long form content, such as order summary line items,
- * that allows for scrolling so customers can expose more content as they view.
+ * A scrollable container for long-form content, such as order summary line items,
+ * that lets customers reveal more content by scrolling.
  */
 export const ScrollView = createRemoteComponent<'ScrollView', ScrollViewProps>(
   'ScrollView',

--- a/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
@@ -21,51 +21,35 @@ export type Coordinate = number | `${number}%`;
 
 interface PositionBlockStart {
   /**
-   * Adjust the block start offset.
-   *
-   * `number`: size in pixels.
-   *
-   * `` `${number}%` ``: size in percentages. It refers to the block size of the parent component.
+   * The block-start offset. Accepts a pixel value (`number`) or a percentage (`` `${number}%` ``) relative to the parent's block size.
    */
   blockStart?: Coordinate;
 }
 
 interface PositionInlineStart {
   /**
-   * Adjust the inline start offset.
-   *
-   * `number`: size in pixels.
-   *
-   * `` `${number}%` ``: size in percentages. It refers to the block size of the parent component.
+   * The inline-start offset. Accepts a pixel value (`number`) or a percentage (`` `${number}%` ``) relative to the parent's inline size.
    */
   inlineStart?: Coordinate;
 }
 
 interface PositionBlockEnd {
   /**
-   * Adjust the block end offset.
-   *
-   * `number`: size in pixels.
-   *
-   * `` `${number}%` ``: size in percentages. It refers to the block size of the parent component.
+   * The block-end offset. Accepts a pixel value (`number`) or a percentage (`` `${number}%` ``) relative to the parent's block size.
    */
   blockEnd?: Coordinate;
 }
 
 interface PositionInlineEnd {
   /**
-   * Adjust the inline end offset.
-   *
-   * `number`: size in pixels.
-   *
-   * `` `${number}%` ``: size in percentages. It refers to the block size of the parent component.
+   * The inline-end offset. Accepts a pixel value (`number`) or a percentage (`` `${number}%` ``) relative to the parent's inline size.
    */
   inlineEnd?: Coordinate;
 }
 
 interface PositionTypeProperty {
   /**
-   * Changes how the `View` is positioned.
+   * The positioning scheme for the `View`.
    *
    * @defaultValue 'relative'
    */
@@ -112,21 +96,16 @@ export type Position =
 
 export interface Translate {
   /**
-   * Adjust the translation on the cross axis.
-   *
-   * A percentage value refers to the block size of the View.
+   * The translation along the block (cross) axis. A percentage value refers to the block size of the View.
    */
   block?: number | `${number}%`;
   /**
-   * Adjust the translation on the main axis.
-   *
-   * A percentage value refers to the inline size of the View.
+   * The translation along the inline (main) axis. A percentage value refers to the inline size of the View.
    */
   inline?: number | `${number}%`;
 }
 
 /**
- * View is a generic container component. Its contents will always be their “natural” size, so this component can be useful in layout components (like `Grid`, `BlockStack`, `InlineStack`) that would otherwise stretch their children to fit.
  * @publicDocs
  */
 export interface ViewProps
@@ -138,45 +117,21 @@ export interface ViewProps
     SpacingProps,
     VisibilityProps {
   /**
-   * Changes the display of the component.
-   *
-   *
-   * `inline` the component starts on the same line as preceding inline content and allows subsequent content to continue on the same line.
-   *
-   * `block` the component starts on its own new line and fills its parent.
-   *
-   * `auto` resets the component to its initial value. The actual value depends on the component and context.
-   *
-   * `none` hides the component and removes it from the accessibility tree, making it invisible to screen readers.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+   * The display mode of the component. Learn more about [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
    *
    * @defaultValue 'auto'
    */
   display?: MaybeResponsiveConditionalStyle<Display>;
   /**
-   * Sets the opacity of the View. The opacity will be applied to the background as well as all
-   * the children of the View. Use carefully as this could decrease the contrast ratio between
-   * the background and foreground elements, resulting in unreadable and inaccessible text.
+   * The opacity of the View, applied to the background and all children. Use carefully as reduced opacity can decrease contrast ratios, resulting in inaccessible text.
    */
   opacity?: Opacity;
   /**
-   * A label that describes the purpose or contents of the element. When set,
-   * it will be announced to buyers using assistive technologies and will
-   * provide them with more context.
+   * A label announced by assistive technologies that describes the purpose or contents of the element. Only set this when the element's visible content doesn't provide enough context on its own.
    */
   accessibilityLabel?: string;
   /**
-   * Sets the semantic meaning of the component’s content. When set,
-   * the role will be used by assistive technologies to help buyers
-   * navigate the page.
-   *
-   *
-   * For example:
-   *
-   * - In an HTML host a `['listItem', 'separator']` tuple will render: `<li role='separator'>`
-   *
-   * - In an HTML host a `listItem` string will render: `<li>`
+   * The semantic meaning of the component's content. When set, assistive technologies use this role to help users navigate the page. Accepts a single role or a tuple of two roles (for example, `['listItem', 'separator']`).
    */
   accessibilityRole?: ViewLikeAccessibilityRole;
   /**
@@ -200,42 +155,34 @@ export interface ViewProps
    */
   position?: MaybeResponsiveConditionalStyle<Position>;
   /**
-   * Specifies a two-dimensional translation of the View.
+   * A two-dimensional translation of the View along the block and inline axes.
    */
   translate?: MaybeResponsiveConditionalStyle<Translate>;
   /**
-   * Position children along the cross axis
+   * The alignment of children along the block (cross) axis.
    */
   blockAlignment?: MaybeResponsiveConditionalStyle<
     Extract<BlockAlignment, 'start' | 'center' | 'end'>
   >;
   /**
-   * Position children along the main axis
+   * The alignment of children along the inline (main) axis.
    */
   inlineAlignment?: MaybeResponsiveConditionalStyle<InlineAlignment>;
   /**
-   * Adjust the inline size.
+   * The inline size of the View.
    *
-   * `fill`: takes all the available space.
+   * - `fill`: Takes all the available space.
    */
   inlineSize?: MaybeResponsiveConditionalStyle<'fill'>;
   /**
-   * Sets the overflow behavior of the element.
+   * The overflow behavior of the element.
    *
-   * `hidden`: clips the content when it is larger than the element’s container.
-   * The element will not be scrollable and the users will not be able
-   * to access the clipped content by dragging or using a scroll wheel.
-   *
-   * `visible`: the content that extends beyond the element’s container is visible.
+   * - `visible`: Content that extends beyond the container is visible.
+   * - `hidden`: Content that extends beyond the container is clipped and not scrollable.
    *
    * @default 'visible'
    */
   overflow?: 'hidden' | 'visible';
 }
 
-/**
- *  View is a generic container component. Its contents will always be their
- * “natural” size, so this component can be useful in layout components (like `Grid`,
- * `BlockStack`, `InlineStack`) that would otherwise stretch their children to fit.
- */
 export const View = createRemoteComponent<'View', ViewProps>('View');

--- a/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/shared.ts
@@ -131,8 +131,26 @@ export type AutocompleteField =
   | 'pager email'
   | 'pager instant-message';
 
+/**
+ * A keyword that maps to a viewport-width breakpoint from the design system.
+ * Use breakpoints to apply responsive styles that adapt to the customer's screen size.
+ *
+ * - `base`: The default (smallest) breakpoint; applies to all viewport widths.
+ * - `extraSmall`: A very narrow viewport, typically small phones.
+ * - `small`: A narrow viewport, such as a large phone or small tablet.
+ * - `medium`: A medium viewport, such as a tablet in landscape.
+ * - `large`: A wide viewport, such as a desktop display.
+ */
 export type Breakpoint = 'base' | 'extraSmall' | 'small' | 'medium' | 'large';
 
+/**
+ * The display mode for a component. Learn more about [`display`](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
+ *
+ * - `auto`: The initial value; the actual behavior depends on the component and context.
+ * - `block`: The component starts on its own new line and fills its parent.
+ * - `inline`: The component flows inline with preceding and subsequent content.
+ * - `none`: Hides the component and removes it from the accessibility tree.
+ */
 export type Display = 'none' | 'auto' | 'inline' | 'block';
 
 /**
@@ -154,8 +172,14 @@ export type ShorthandProperty<T> = [T, T] | [T, T, T, T];
  */
 export type MaybeShorthandProperty<T> = T | ShorthandProperty<T>;
 
-/** @deprecated These values are deprecated and will eventually be removed.
- * Use CornerRadius instead
+/**
+ * @deprecated Use `CornerRadius` instead.
+ *
+ * - `base`: The default corner radius.
+ * - `tight`: A subtle corner radius. Use `small` on `CornerRadius` instead.
+ * - `loose`: A pronounced corner radius. Use `large` on `CornerRadius` instead.
+ * - `fullyRounded`: Fully rounds the corners into a pill or circle shape.
+ * - `none`: No corner rounding; sharp square corners.
  */
 export type BorderRadius = 'base' | 'tight' | 'loose' | 'fullyRounded' | 'none';
 /**
@@ -209,29 +233,22 @@ export interface BackgroundProps {
   /**
    * The background color of the element, set using a design-system keyword.
    *
-   * - `transparent`: No background; the parent's background shows through.
-   * - `base`: The standard surface background color.
-   * - `subdued`: A muted background for de-emphasized or secondary content.
-   *
    * @defaultValue 'transparent'
    */
   background?: MaybeConditionalStyle<Background>;
 
   /**
-   * Sets one or multiple responsive background images using URLs.
+   * One or more responsive background image URLs.
    */
   backgroundImage?: MaybeConditionalStyle<string>;
 
   /**
-   * Controls how the background image scales within its container.
-   *
-   * - `contain`: Scales the image to fit without cropping or stretching.
-   * - `cover`: Scales the image to fill the container; the image may be cropped.
+   * How the background image scales within its container.
    */
   backgroundFit?: BackgroundFit;
 
   /**
-   * Sets the initial position of the background image within its container.
+   * The initial position of the background image within its container.
    *
    * @defaultValue 'center'
    */
@@ -240,75 +257,64 @@ export interface BackgroundProps {
   /**
    * Controls how the background image is repeated within its container.
    *
-   * - `repeat`: The image is tiled to fill the container.
-   * - `noRepeat`: The image is displayed once without repetition.
-   *
    * @defaultValue 'noRepeat'
    */
   backgroundRepeat?: BackgroundRepeat;
 }
 
+/**
+ * Props for controlling the border appearance of a layout element. Both
+ * properties accept a single value for all edges or a shorthand tuple
+ * for per-edge control.
+ */
 export interface BorderProps {
   /**
-   * The border style of the element.
+   * The border style of the element. Accepts a single value for all four edges, or a shorthand tuple for per-edge control:
    *
-   * To shorten the code, it is possible to specify all the border style properties in one property.
-   *
-   * For example:
-   *
-   * - `base` means blockStart, inlineEnd, blockEnd and inlineStart border styles are `base`
-   *
-   * - `['base', 'none']` means blockStart and blockEnd border styles are `base`, inlineStart and inlineEnd border styles are `none`
-   *
-   * - `['base', 'none', 'dotted', 'base']` means blockStart border style is `base`, inlineEnd border style is `none`, blockEnd border style is `dotted` and  blockStart border style is `base`
+   * - `'base'`: Applies `base` to all edges.
+   * - `['base', 'none']`: Block edges get `base`, inline edges get `none`.
+   * - `['base', 'none', 'dotted', 'base']`: Values apply to block-start, inline-end, block-end, and inline-start respectively.
    */
   border?: MaybeResponsiveConditionalStyle<MaybeShorthandProperty<BorderStyle>>;
 
   /**
-   * The border width of the element.
+   * The border width of the element. Accepts a single value for all four edges, or a shorthand tuple for per-edge control:
    *
-   * To shorten the code, it is possible to specify all the border width properties in one property.
-   *
-   * For example:
-   *
-   * - `base` means blockStart, inlineEnd, blockEnd and inlineStart border widths are `base`
-   *
-   * - `['base', 'medium']` means blockStart and blockEnd border widths are `base`, inlineStart and inlineEnd border widths are `medium`
-   *
-   * - `['base', 'medium', 'medium', 'base']` means blockStart border width is `base`, inlineEnd border width is `medium`, blockEnd border width is `medium` and  blockStart border width is `base`
+   * - `'base'`: Applies `base` to all edges.
+   * - `['base', 'medium']`: Block edges get `base`, inline edges get `medium`.
+   * - `['base', 'medium', 'medium', 'base']`: Values apply to block-start, inline-end, block-end, and inline-start respectively.
    */
   borderWidth?: MaybeResponsiveConditionalStyle<
     MaybeShorthandProperty<BorderWidth>
   >;
 }
 
+/**
+ * Props for controlling the corner radius of a layout element. Both properties
+ * accept a single value for all corners or a shorthand tuple for per-corner control.
+ */
 export interface CornerProps {
   /**
-   * @deprecated Use `cornerRadius` instead.
+   * The corner radius of the element. Accepts a single value for all four corners, or a shorthand tuple for per-corner control:
    *
-   * The corner radius of the element. Accepts a single value for
-   * all corners or a shorthand tuple for per-corner control.
+   * - `'base'`: All four corners get `base` radius.
+   * - `['base', 'none']`: StartStart/EndEnd get `base`, StartEnd/EndStart get `none`.
+   * - `['base', 'none', 'small', 'base']`: Values apply to StartStart, StartEnd, EndEnd, and EndStart respectively.
+   *
+   * @deprecated Use `cornerRadius` instead.
    */
   borderRadius?: MaybeResponsiveConditionalStyle<
     MaybeShorthandProperty<CornerRadius>
   >;
 
   /**
-   * The corner radius of the element.
+   * The corner radius of the element. Accepts a single value for all four corners, or a shorthand tuple for per-corner control using logical (writing-mode-aware) corners:
    *
-   * Provide a single value to apply the same corner radius to all four corners, two values to apply different corner radii to opposing corners, or four values to apply different corner radii to each individual corner.
+   * - `'base'`: All four corners get `base` radius.
+   * - `['base', 'none']`: StartStart/EndEnd get `base`, StartEnd/EndStart get `none`. In left-to-right mode, StartStart and EndEnd are the top-left and bottom-right corners.
+   * - `['base', 'none', 'small', 'base']`: Values apply to StartStart, StartEnd, EndEnd, and EndStart respectively.
    *
-   * For example:
-   *
-   * - `base` means all 4 corner radii are `base`
-   *
-   * - `['base', 'none']` means the StartStart and EndEnd corner radii are `base`, StartEnd and EndStart corner radii are `none`.
-   *    When the context’s language direction is left to right, StartStart and EndEnd corners are the top left and bottom right corners
-   *    while StartEnd and EndStart corners are the top right and bottom left corners.
-   *
-   * - `['base', 'none', 'small', 'base']` means StartStart corner radius is `base`, StartEnd corner radius is `none`, EndEnd corner radius is `small` and  EndStart corner radius is `base`
-   *
-   * A `borderRadius` alias is available for this property. When both are specified, `cornerRadius` takes precedence.
+   * A `borderRadius` alias is available. When both are set, `cornerRadius` takes precedence.
    */
   cornerRadius?: MaybeResponsiveConditionalStyle<
     MaybeShorthandProperty<CornerRadius>
@@ -417,65 +423,92 @@ export interface SpacingProps {
  * - `presentation`: Strips semantic meaning but leaves visual styling intact.
  */
 export type AccessibilityRole =
-  /** Used to indicate the primary content. */
+  /** The primary content of the page. */
   | 'main'
-  /** Used to indicate the component is a header. */
+  /** A page or section header. */
   | 'header'
-  /** Used to display information such as copyright information, navigation links, and privacy statements. */
+  /** Information such as copyright, navigation links, and privacy statements. */
   | 'footer'
-  /** Used to indicate a generic section. */
+  /** A generic section that should have a heading or accessible label. */
   | 'section'
-  /** Used to designate a supporting section that relates to the main content. */
+  /** Supporting content related to the main content. */
   | 'complementary'
-  /** Used to identify major groups of links used for navigating. */
+  /** A major group of navigation links. */
   | 'navigation'
-  /** Used to identify a list of ordered items. */
+  /** A list of ordered items. */
   | 'orderedList'
-  /** Used to identify an item inside a list of items. */
+  /** An item inside a list. */
   | 'listItem'
-  /** Used to identify a list of unordered items. */
+  /** A list of unordered items. */
   | 'unorderedList'
-  /** Used to indicates the component acts as a divider that separates and distinguishes sections of content. */
+  /** A divider that separates sections of content. */
   | 'separator'
-  /** Used to define a live region containing advisory information for the user that is not important enough to be an alert. */
+  /** A live region with advisory information that is not urgent. */
   | 'status'
-  /** Used for important, and usually time-sensitive, information. */
+  /** Important, usually time-sensitive information. */
   | 'alert'
-  /** Used to indicate that an image is decorative and should be hidden from assistive technologies. */
+  /** Marks the element as purely decorative; assistive technologies skip it. */
   | 'decorative'
-  /** Used to strip the semantic meaning of an element, but leave the visual styling intact. */
+  /** Strips semantic meaning while keeping visual styling. */
   | 'presentation';
 
+/**
+ * The subset of accessibility roles available to layout components.
+ * Excludes `decorative` and `presentation`, which are only available
+ * on the full `AccessibilityRole` type.
+ *
+ * - `main`: The primary content of the page.
+ * - `header`: A page or section header.
+ * - `footer`: A section for copyright information, navigation links, and privacy statements.
+ * - `section`: A generic section; should have a heading or accessible label.
+ * - `complementary`: A supporting section related to the main content.
+ * - `navigation`: A major group of navigation links.
+ * - `orderedList`: A list of ordered items.
+ * - `listItem`: An item inside a list.
+ * - `unorderedList`: A list of unordered items.
+ * - `separator`: A divider separating sections of content.
+ * - `status`: A live region with advisory information that isn't urgent enough to be an alert.
+ * - `alert`: Important, usually time-sensitive information.
+ */
 export type NonPresentationalAccessibilityRole =
-  /** Used to indicate the primary content. */
+  /** The primary content of the page. */
   | 'main'
-  /** Used to indicate the component is a header. */
+  /** A page or section header. */
   | 'header'
-  /** Used to display information such as copyright information, navigation links, and privacy statements. */
+  /** Information such as copyright, navigation links, and privacy statements. */
   | 'footer'
-  /** Used to indicate a generic section. */
+  /** A generic section that should have a heading or accessible label. */
   | 'section'
-  /** Used to designate a supporting section that relates to the main content. */
+  /** Supporting content related to the main content. */
   | 'complementary'
-  /** Used to identify major groups of links used for navigating. */
+  /** A major group of navigation links. */
   | 'navigation'
-  /** Used to identify a list of ordered items. */
+  /** A list of ordered items. */
   | 'orderedList'
-  /** Used to identify an item inside a list of items. */
+  /** An item inside a list. */
   | 'listItem'
-  /** Used to identify a list of unordered items. */
+  /** A list of unordered items. */
   | 'unorderedList'
-  /** Used to indicates the component acts as a divider that separates and distinguishes sections of content. */
+  /** A divider that separates sections of content. */
   | 'separator'
-  /** Used to define a live region containing advisory information for the user that is not important enough to be an alert. */
+  /** A live region with advisory information that is not urgent. */
   | 'status'
-  /** Used for important, and usually time-sensitive, information. */
+  /** Important, usually time-sensitive information. */
   | 'alert';
 
+/**
+ * The accessibility role accepted by view-like layout components. Accepts a single `NonPresentationalAccessibilityRole`, or a tuple of two roles to combine semantic meaning (for example, `['listItem', 'separator']` renders as `<li role='separator'>`).
+ */
 export type ViewLikeAccessibilityRole =
   | NonPresentationalAccessibilityRole
   | [NonPresentationalAccessibilityRole, NonPresentationalAccessibilityRole];
 
+/**
+ * The accessibility role for button-like components.
+ *
+ * - `button`: A generic button that triggers an action.
+ * - `submit`: A button that submits a form.
+ */
 export type ButtonAccessibilityRole = 'button' | 'submit';
 
 export type TextAccessibilityRole =
@@ -650,7 +683,7 @@ export type Background = 'transparent' | 'base' | 'subdued';
 export type BackgroundFit = 'cover' | 'contain';
 
 /**
- * Sets the initial position of the background image within its container.
+ * The initial position of the background image within its container.
  *
  * - `top`: Positions the image at the top edge.
  * - `bottom`: Positions the image at the bottom edge.
@@ -712,6 +745,12 @@ export type Appearance =
   /** Takes the color of its parent.*/
   | 'monochrome';
 
+/**
+ * The axis along which content is arranged, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
+ *
+ * - `inline`: The horizontal axis (in horizontal writing modes).
+ * - `block`: The vertical axis (in horizontal writing modes).
+ */
 export type Direction = 'inline' | 'block';
 
 /**
@@ -726,16 +765,20 @@ export type Direction = 'inline' | 'block';
  * Learn more about the [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) property.
  */
 export type Fit =
-  /**
-   * Image maintains its aspect ratio while fitting within the frame.
-   */
+  /** Image fills the entire frame, maintaining its aspect ratio. The image may be cropped if it is larger than the frame. */
   | 'cover'
-  /**
-   * Image maintains its aspect ratio while filling the frame.
-   * If the image is larger than the frame, then it will be cropped.
-   */
+  /** Image fits within the frame, maintaining its aspect ratio. Empty space may appear if the aspect ratios differ. */
   | 'contain';
 
+/**
+ * The size of a column or row in a grid-based layout.
+ *
+ * - `'auto'`: The intrinsic size of the content.
+ * - `'fill'`: Fills the remaining available space. When multiple items use `fill`, the space is shared equally.
+ * - `number`: A fixed size in pixels.
+ * - `` `${number}fr` ``: A fractional unit of the available space.
+ * - `` `${number}%` ``: A percentage of the container's size.
+ */
 export type GridItemSize =
   | 'auto'
   | 'fill'
@@ -743,7 +786,13 @@ export type GridItemSize =
   | `${number}fr`
   | `${number}%`;
 
+/**
+ * The column sizing configuration for a grid-based layout. Accepts a single `GridItemSize` applied to all columns, or an array with one size per column.
+ */
 export type Columns = GridItemSize[] | GridItemSize;
+/**
+ * The row sizing configuration for a grid-based layout. Accepts a single `GridItemSize` applied to all rows, or an array with one size per row.
+ */
 export type Rows = GridItemSize[] | GridItemSize;
 
 /**
@@ -810,24 +859,28 @@ export type MultiPick<Base, AcceptedCombinations extends (keyof Base)[]> = {
 }[number];
 
 /**
- * The available visibility states for an element.
+ * Controls the visual visibility of an element.
  *
- * - `hidden`: Visually hides the element while keeping it accessible to assistive technologies like screen readers. Hidden elements don't occupy any visual space.
+ * - `hidden`: Visually hides the element while keeping it accessible to assistive technologies. The element does not occupy visual space.
  */
 export type Visibility = 'hidden';
 /**
- * The available accessibility visibility states for an element.
+ * Controls the visibility of an element to assistive technologies.
  *
- * - `hidden`: Hides the element from assistive technologies like screen readers while keeping it visually visible.
+ * - `hidden`: Hides the element from assistive technologies while keeping it visually visible.
  */
 export type AccessibilityVisibility = 'hidden';
+/**
+ * Props for controlling the visibility of a layout element, both visually
+ * and to assistive technologies.
+ */
 export interface VisibilityProps {
   /**
-   * Controls the visual visibility of the element.
+   * The visual visibility of the element.
    */
   visibility?: Visibility;
   /**
-   * Controls the visibility of the element to assistive technologies.
+   * The visibility of the element to assistive technologies.
    */
   accessibilityVisibility?: AccessibilityVisibility;
 }
@@ -848,8 +901,15 @@ export interface DisclosureActivatorProps {
 
 export type DisclosureOpen = boolean | string | string[];
 
+/**
+ * A percentage-based opacity value from 10 (nearly transparent) to 90 (nearly opaque). Use carefully as reduced opacity can decrease contrast ratios, making text difficult to read.
+ */
 export type Opacity = 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90;
 
+/**
+ * A keyword that maps to a predefined text size from the design system.
+ * Includes all standard `Size` values plus `medium`, which sits between `base` and `large`.
+ */
 export type TextSize =
   | Extract<Size, 'extraSmall' | 'small' | 'base' | 'large' | 'extraLarge'>
   | 'medium';

--- a/packages/ui-extensions/src/surfaces/checkout/style/types.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/style/types.ts
@@ -5,8 +5,17 @@
  */
 type Resolution = 1 | 1.3 | 1.5 | 2 | 2.6 | 3 | 3.5 | 4;
 
+/**
+ * Conditions that target interactive states of a component.
+ */
 export interface InteractiveConditions {
+  /**
+   * Applies when the user is hovering over the component with a pointer device.
+   */
   hover: true;
+  /**
+   * Applies when the component has keyboard or programmatic focus.
+   */
   focus: true;
 }
 
@@ -20,6 +29,14 @@ export interface ResolutionCondition {
   resolution: Resolution;
 }
 
+/**
+ * A keyword that maps to a viewport inline-size breakpoint from the design system.
+ *
+ * - `extraSmall`: A very narrow viewport, typically small phones.
+ * - `small`: A narrow viewport, such as a large phone or small tablet.
+ * - `medium`: A medium viewport, such as a tablet in landscape.
+ * - `large`: A wide viewport, such as a desktop display.
+ */
 type ViewportInlineSize = 'extraSmall' | 'small' | 'medium' | 'large';
 
 /**
@@ -49,20 +66,45 @@ export type BaseConditions = AtLeastOne<
   DefaultConditions & ResolutionCondition
 >;
 
-// This interface is only used to provide documentation for the Style helper.
-// It is not used in the implementation.
+/**
+ * The full set of conditions available for conditional styling. At least one
+ * condition must be specified.
+ */
 export interface StylesBaseConditions {
+  /**
+   * A minimum viewport inline-size breakpoint that must be met.
+   */
   viewportInlineSize?: {min: ViewportInlineSize};
+  /**
+   * Applies when the user is hovering over the component with a pointer device.
+   */
   hover?: true;
+  /**
+   * Applies when the component has keyboard or programmatic focus.
+   */
   focus?: true;
+  /**
+   * A minimum device pixel ratio that must be met. Higher values target high-density (Retina) displays.
+   */
   resolution?: 1 | 1.3 | 1.5 | 2 | 2.6 | 3 | 3.5 | 4;
 }
 
-// This interface is only used to provide documentation for the Style helper.
-// It is not used in the implementation.
+/**
+ * The set of conditions available for viewport-responsive and interactive styling.
+ * At least one condition must be specified.
+ */
 export interface StylesConditions {
+  /**
+   * A minimum viewport inline-size breakpoint that must be met.
+   */
   viewportInlineSize?: {min: ViewportInlineSize};
+  /**
+   * Applies when the user is hovering over the component with a pointer device.
+   */
   hover?: true;
+  /**
+   * Applies when the component has keyboard or programmatic focus.
+   */
   focus?: true;
 }
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -200,7 +200,6 @@ export interface Docs_StandardApi extends Omit<StandardApi<any>, 'router'> {}
 export interface Docs_FullPageApi extends FullPageApi {}
 
 /**
- * Supported props for Buttons used inside Page `primary-action` slot.
  * @publicDocs
  */
 export interface Docs_Page_Button_PrimaryAction
@@ -213,16 +212,56 @@ export interface Docs_Page_Button_PrimaryAction
     | 'loadingLabel'
     | 'disabled'
     | 'accessibilityLabel'
-  > {}
+  > {
+  /**
+   * A callback fired when the button is pressed.
+   */
+  onPress?: ButtonProps['onPress'];
+  /**
+   * An overlay component rendered when the user interacts with the button, such as a modal or popover.
+   */
+  overlay?: ButtonProps['overlay'];
+  /**
+   * A destination URL that the button navigates to. When set, the button behaves as a link.
+   */
+  to?: ButtonProps['to'];
+  /**
+   * Whether to replace the button content with a loading indicator.
+   *
+   * @defaultValue false
+   */
+  loading?: ButtonProps['loading'];
+  /**
+   * An accessible label for the loading indicator, announced when the user prefers reduced motion. Only used when `loading` is `true`.
+   */
+  loadingLabel?: ButtonProps['loadingLabel'];
+  /**
+   * Whether the button is disabled. A disabled button is non-interactive and visually de-emphasized.
+   *
+   * @defaultValue false
+   */
+  disabled?: ButtonProps['disabled'];
+  /**
+   * A label announced by assistive technologies that describes the button's purpose. When set, the button's visible `children` are not announced to screen readers.
+   */
+  accessibilityLabel?: ButtonProps['accessibilityLabel'];
+}
 
 /**
- * Supported props for Button used inside Page `secondary-actions` slot.
  * @publicDocs
  */
 export interface Docs_Page_Button_SecondaryAction
   extends Pick<ButtonProps, 'onPress' | 'to'> {
   /**
-   * A label used for buyers using assistive technologies. Needed because `children` passed to this component will be discarded.
+   * A callback fired when the button is pressed.
+   */
+  onPress?: ButtonProps['onPress'];
+  /**
+   * A destination URL that the button navigates to. When set, the button behaves as a link.
+   */
+  to?: ButtonProps['to'];
+  /**
+   * A label announced by assistive technologies that describes the button's purpose. Required because `children` passed to this component are discarded.
    */
   accessibilityLabel: ButtonProps['accessibilityLabel'];
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Card/Card.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Card/Card.ts
@@ -1,14 +1,14 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
 /**
- * Group related content and functionality together in a familiar and consistent style.
  * @publicDocs
  */
 export interface CardProps {
   /**
-   * Adjust the padding of all edges.
+   * Whether to apply default padding to all edges of the card.
    *
-   * `true` applies a default padding that is appropriate for the component.
+   * - `true`: Applies context-appropriate padding.
+   * - `false` (or omitted): No padding is applied.
    */
   padding?: boolean;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page/Page.ts
@@ -2,50 +2,45 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {RemoteFragment} from '@remote-ui/core';
 
 /**
- * Display the page layout with a title, actions, and content.
  * @publicDocs
  */
 export interface PageProps {
   /**
-   * The text to be used as title.
+   * The title displayed at the top of the page.
    */
   title: string;
 
   /**
-   * The text to be used as subtitle.
+   * An optional subtitle displayed below the title.
    */
   subtitle?: string;
 
   /**
-   * The action grouping, provided as button(s), that is placed in the primary position of the page.
+   * The primary action slot, rendered as one or more buttons in the primary position of the page. Accepts a `RemoteFragment` containing `Button` components.
    */
   primaryAction?: RemoteFragment;
 
   /**
-   * Label for the primary action grouping. If a label is not provided, default text is used.
+   * A visible label for the primary action grouping. Displayed as the text trigger when actions overflow into a menu.
    *
    * @defaultValue "More actions"
    */
   primaryActionLabel?: string;
 
   /**
-   * Accessibility label for the primary action grouping. If an accessibility label is not provided,
-   * default text is used.
+   * A label announced by assistive technologies for the primary action grouping.
    *
    * @defaultValue "More actions"
    */
   primaryActionAccessibilityLabel?: string;
 
   /**
-   * The action grouping, provided as button(s), that is placed in the secondary position of the page.
+   * The secondary action slot, rendered as one or more buttons in the secondary position of the page. Accepts a `RemoteFragment` containing `Button` components.
    */
   secondaryAction?: RemoteFragment;
 
   /**
-   * Indicates that the page is in a loading state.
-   *
-   * When `true`, the page shows loading indicators for the UI elements that it is owns.
-   * The page is not responsible for the loading indicators of any content that is passed as `children`.
+   * Whether the page is in a loading state. When `true`, the page shows loading indicators for its own UI elements. The page is not responsible for loading indicators on content passed as `children`.
    *
    * @defaultValue false
    */


### PR DESCRIPTION
## This PR:

- Improves JSDoc descriptions for layout and structure components in the **2025-07** checkout and customer account surfaces to align with admin UI extensions documentation style — declarative opening sentences, bulleted value descriptions for enum/union props, and inline "Learn more about" links replacing `@see` tags.
- Adds missing type-level and interface-level JSDoc across `shared.ts` for all public types referenced by layout components (`Breakpoint`, `Display`, `CornerRadius`, `NonPresentationalAccessibilityRole`, `ViewLikeAccessibilityRole`, `Opacity`, `GridItemSize`, `Columns`, `Rows`, `Visibility`, etc.) and their container interfaces (`BackgroundProps`, `BorderProps`, `CornerProps`, `SizingProps`, `SpacingProps`, `VisibilityProps`).
- Removes duplicate bullet-point descriptions from props that already reference a named type (e.g., `background`, `backgroundFit`, `display` on View, `visibility`) — values are now documented once on the type, not on both the type and the prop.
- Adds prop-level descriptions for `StylesBaseConditions`, `StylesConditions`, `InteractiveConditions`, and `ViewportInlineSize` in the StyleHelper types so the docs page renders descriptions for `focus`, `hover`, `resolution`, and `viewportInlineSize`.
- Adds full property-level descriptions for `Docs_Page_Button_PrimaryAction` and `Docs_Page_Button_SecondaryAction` in the customer account API docs.
- Fixes swapped `cover`/`contain` member descriptions on the `Fit` type.
- Replaces imperative phrasing ("Sets the…", "Adjust the…") with declarative noun phrases across all layout component files.
- Relates to https://github.com/shop/world/pull/579467
- Partially closes https://github.com/shop/issues-learn/issues/1008