### PR TITLE
Adding in types for purchaseType and recurringCycleLimit fields

### DIFF
--- a/.changeset/add-purchase-type-and-recurring-cycle-limit.md
+++ b/.changeset/add-purchase-type-and-recurring-cycle-limit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add purchaseType and recurringCycleLimit subscribable fields to the DiscountsApi for discount function settings extensions.

--- a/.changeset/add-purchase-type-and-recurring-cycle-limit.md
+++ b/.changeset/add-purchase-type-and-recurring-cycle-limit.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 Add purchaseType and recurringCycleLimit subscribable fields to the DiscountsApi for discount function settings extensions.

--- a/packages/ui-extensions-tester/src/admin/factories.ts
+++ b/packages/ui-extensions-tester/src/admin/factories.ts
@@ -212,6 +212,11 @@ function createDiscountFunctionSettingsMock<T extends ExtensionTarget>(
       discountClasses: createReadonlySignalLike([]),
       updateDiscountClasses: () => createResult('updateDiscountClasses'),
       discountMethod: createReadonlySignalLike('automatic' as const),
+      purchaseType: createReadonlySignalLike('one_time_purchase' as const),
+      updatePurchaseType: () => createResult('updatePurchaseType'),
+      recurringCycleLimit: createReadonlySignalLike(null),
+      updateRecurringCycleLimit: () =>
+        createResult('updateRecurringCycleLimit'),
     },
   };
 }

--- a/packages/ui-extensions-tester/src/admin/index.ts
+++ b/packages/ui-extensions-tester/src/admin/index.ts
@@ -58,6 +58,10 @@ export interface AdminMutationResults {
     | Awaited<ReturnType<ValidationApplyMetafieldChange>>
     | Awaited<ReturnType<DiscountApplyMetafieldChange>>;
   updateDiscountClasses: ReturnType<DiscountsApi['updateDiscountClasses']>;
+  updatePurchaseType: ReturnType<DiscountsApi['updatePurchaseType']>;
+  updateRecurringCycleLimit: ReturnType<
+    DiscountsApi['updateRecurringCycleLimit']
+  >;
 }
 
 const adminMutationDefaults: {
@@ -65,6 +69,11 @@ const adminMutationDefaults: {
 } = {
   applyMetafieldChange: () => ({type: 'success'}),
   updateDiscountClasses: () => ({success: true as const, value: []}),
+  updatePurchaseType: () => ({
+    success: true as const,
+    value: 'one_time_purchase' as const,
+  }),
+  updateRecurringCycleLimit: () => ({success: true as const, value: null}),
 };
 
 /**

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/discount-function-settings.doc.ts
@@ -35,6 +35,12 @@ const data: ReferenceEntityTemplateSchema = {
         'The `data` object exposed to the extension containing the discount function settings. Provides access to the discount identifier and associated [metafields](/docs/apps/build/metafields) that store function configuration values. Use this data to populate your settings UI and understand the current function configuration in the `admin.discount-details.function-settings.render` target.',
       type: 'DiscountFunctionSettingsData',
     },
+    {
+      title: 'discounts',
+      description:
+        'The reactive API for managing discount function configuration, including discount classes, discount method, purchase type, and recurring cycle limit.',
+      type: 'DiscountsApi',
+    },
   ],
   examples: {
     description: 'Configure discount function settings',

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
@@ -35,6 +35,11 @@ export type DiscountClass = 'product' | 'order' | 'shipping';
 export type DiscountMethod = 'automatic' | 'code';
 
 /**
+ * The purchase type that determines which purchases the discount applies to. Use `'one_time_purchase'` for one-time purchases only, `'subscription'` for subscription purchases only, or `'both'` for both.
+ */
+export type PurchaseType = 'one_time_purchase' | 'subscription' | 'both';
+
+/**
  * The `data` object exposed to discount function settings extensions in the `admin.discount-details.function-settings.render` target. Use this to access the current discount configuration and populate your settings interface with existing values.
  * @publicDocs
  */
@@ -62,4 +67,20 @@ export interface DiscountsApi {
    * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.
    */
   discountMethod: ReadonlySignalLike<DiscountMethod>;
+  /**
+   * A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both.
+   */
+  purchaseType: ReadonlySignalLike<PurchaseType>;
+  /**
+   * A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`).
+   */
+  updatePurchaseType: UpdateSignalFunction<PurchaseType>;
+  /**
+   * A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set.
+   */
+  recurringCycleLimit: ReadonlySignalLike<number | null>;
+  /**
+   * A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit.
+   */
+  updateRecurringCycleLimit: UpdateSignalFunction<number | null>;
 }


### PR DESCRIPTION
## Add purchaseType and recurringCycleLimit to DiscountsApi

### Background

Follow-up to the admin-web changes in https://github.com/shop/world/pull/411309 and https://github.com/shop/world/pull/411407, which add support for purchase type and recurring cycle limit fields in the discounts plugin.

This PR adds the corresponding types to `@shopify/ui-extensions` so that discount function settings extensions have access to these new fields in their type contract.

Part of this release plan: https://docs.google.com/document/d/1cchvYA3UEDO2o651f_FgsdRqkBSRJLBO3Ac-EAMGCb8/edit?tab=t.0#heading=h.3twiyx2rdsvm

### Changes

- Added `PurchaseType` type (`'one_time_purchase' | 'subscription' | 'both'`)
- Added `purchaseType` / `updatePurchaseType` signals to `DiscountsApi`
- Added `recurringCycleLimit` / `updateRecurringCycleLimit` signals to `DiscountsApi`
- Added `discounts` definition to the doc schema (pre-existing gap)

### References

- Similar prior PR for discount classes and method: https://github.com/Shopify/ui-extensions/pull/3641