### PR TITLE
Port: Update POS event base data connectivity type to use signal type

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/BaseData.ts
@@ -1,4 +1,8 @@
-import type {ConnectivityState, Device, Session} from '../../../point-of-sale';
+import type {
+  ConnectivityApiContent,
+  Device,
+  Session,
+} from '../../../point-of-sale';
 
 /**
  * Base data object provided to all extension targets containing device information, session context, and connectivity state. This data is available at extension initialization and provides essential context about the runtime environment.
@@ -7,7 +11,7 @@ export interface BaseData {
   /**
    * The current Internet connectivity state of the POS device. Indicates whether the device is connected to or disconnected from the Internet. This state updates in real-time as connectivity changes, allowing extensions to adapt behavior for offline scenarios, show connectivity warnings, or queue operations for when connectivity is restored.
    */
-  connectivity: ConnectivityState;
+  connectivity: ConnectivityApiContent;
   /**
    * Comprehensive information about the physical POS device where the extension is currently running. Includes the device name, unique device ID, and form factor information (tablet vs other). This data is static for the session and helps extensions adapt to different device types, log device-specific information, or implement device-based configurations.
    */


### PR DESCRIPTION
## What

Port of https://github.com/Shopify/ui-extensions/pull/3976 from `2026-01` to `2026-04-rc`.

Changes `BaseData.connectivity` from `ConnectivityState` to `ConnectivityApiContent`, which wraps the state in a `ReadonlySignalLike` for reactive connectivity handling. This aligns `BaseData` with the `ConnectivityApi` interface.

## Why

This fix landed on `2026-01` (March 23) after `2026-04-rc` was branched (January 26) and was never ported over. Without this, `BaseData.connectivity` is inconsistent with the `ConnectivityApi` interface which already uses `ConnectivityApiContent`.