### PR TITLE
Add missing Navigation API doc wrapper type (2025-10)

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -1,5 +1,5 @@
 import {OrderStatusApi} from './order-status/order-status';
-import {StandardApi} from './standard-api/standard-api';
+import {StandardApi, Navigation} from './standard-api/standard-api';
 import {CartLineItemApi} from './cart-line/cart-line-item';
 
 /**
@@ -313,6 +313,14 @@ export interface Docs_Standard_ToastApi
  */
 export interface Docs_Standard_QueryApi
   extends Pick<StandardApi<any>, 'query'> {}
+
+/**
+ * The base API object provided to `customer-account` extension targets that support in-page navigation and history management.
+ * @publicDocs
+ */
+export interface Docs_Standard_NavigationApi {
+  navigation: Navigation;
+}
 
 export interface Docs_StandardApi extends Omit<StandardApi<any>, 'router'> {}
 


### PR DESCRIPTION
Adds Docs_Standard_NavigationApi wrapper type. Navigation exists on this version but had no docs wrapper.

Made with [Cursor](https://cursor.com)