### PR TITLE
Update Typography and Content component descriptions (2025-10)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation.d.ts
@@ -29,7 +29,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-abbreviation";
 /**
- * Displays abbreviated text or acronyms, revealing their full meaning or additional context through a tooltip on hover or focus. Use to clarify shortened terms, initialisms, or technical language without interrupting the reading flow.
+ * Configure the following properties on the abbreviation component.
  * @publicDocs
  */
 export interface AbbreviationProps extends Pick<AbbreviationProps$1, 'title' | 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip.d.ts
@@ -43,9 +43,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 
 declare const tagName = "s-clickable-chip";
 /**
- * The clickable chip component displays interactive labels or categories that users can click or remove. Use clickable chip to show filter tags, selected options, or merchant-created labels that users need to interact with or dismiss.
- *
- * Clickable chips support multiple visual variants, optional icons, and can function as both clickable buttons and removable tags for flexible interaction patterns. For non-interactive labels, use [chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/chip).
+ * Configure the following properties on the clickable chip component.
  * @publicDocs
  */
 export interface ClickableChipElementProps extends Pick<ClickableChipProps$1, 'accessibilityLabel' | 'disabled' | 'hidden' | 'href' | 'id' | 'removable'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Details.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Details.d.ts
@@ -50,7 +50,7 @@ export interface ToggleArgumentsEvent {
 
 declare const tagName = "s-details";
 /**
- * Creates a collapsible content area that can be expanded or collapsed by users. Use with Summary to provide expandable sections for additional information or settings.
+ * Configure the following properties on the details component.
  * @publicDocs
  */
 export interface DetailsElementProps extends Pick<DetailsProps$1, 'defaultOpen' | 'id' | 'open' | 'toggleTransition'> {
@@ -59,33 +59,30 @@ export interface DetailsElementProps extends Pick<DetailsProps$1, 'defaultOpen' 
 export interface DetailsEvents extends Pick<DetailsProps$1, 'onToggle' | 'onAfterToggle'> {
 }
 /**
- * Learn more about [registering events](/docs/api/checkout-ui-extensions/latest/using-polaris-components#event-handling).
+ * The details component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
  * @publicDocs
  */
 export interface DetailsElementEvents {
     /**
-     * Callback straight after the element state changes.
+     * A callback fired immediately when the element state changes, before any animations.
      *
      * - If the element is transitioning from hidden to showing, the `oldState` property will be set to `closed` and the
      *   `newState` property will be set to `open`.
-     * - If the element is transitioning from showing to hidden, then `oldState` property will be set to `open` and the
+     * - If the element is transitioning from showing to hidden, then the `oldState` property will be set to `open` and the
      *   `newState` will be `closed`.
      *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState
+     * Learn more about the [`toggle` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event), and the [`newState`](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState) and [`oldState`](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState) properties.
      */
     toggle?: CallbackEventListener<typeof tagName, ToggleArgumentsEvent>;
     /**
-     * Callback fired when the element state changes **after** any animations have finished.
+     * A callback fired when the element state changes, after any toggle animations have finished.
      *
      * - If the element transitioned from hidden to showing, the `oldState` property will be set to `closed` and the
      *   `newState` property will be set to `open`.
      * - If the element transitioned from showing to hidden, the `oldState` property will be set to `open` and the
      *   `newState` will be `closed`.
      *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState
+     * Learn more about the [`newState` property](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState) and [`oldState` property](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
      */
     aftertoggle?: CallbackEventListener<typeof tagName, ToggleArgumentsEvent>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading.d.ts
@@ -29,9 +29,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-heading";
 /**
- * The heading component renders hierarchical titles to communicate the structure and organization of page content. Use heading to create section titles and content headers that help users understand information hierarchy and navigate content.
- *
- * Heading levels adjust automatically based on nesting within parent [section](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/section) components, ensuring meaningful and accessible page outlines without manual level management.
+ * Configure the following properties on the heading component.
  * @publicDocs
  */
 export interface HeadingProps extends Pick<HeadingProps$1, 'accessibilityRole' | 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ListItem.d.ts
@@ -29,9 +29,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-list-item";
 /**
- * The list item component represents a single entry within an ordered list or unordered list. Use list item to structure individual points, steps, or items within a list, with each item automatically receiving appropriate list markers (bullets or numbers) from its parent list.
- *
- * List item must be used as a direct child of ordered list or unordered list components. Each list item can contain text, inline formatting, or other components to create rich list content.
+ * Configure the following properties on the list item component.
  * @publicDocs
  */
 export interface ListItemProps extends Pick<ListItemProps$1, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList.d.ts
@@ -29,9 +29,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-ordered-list";
 /**
- * The ordered list component displays a numbered list of related items in a specific sequence. Use ordered list to present step-by-step instructions, ranked items, procedures, or any content where order and sequence matter to understanding.
- *
- * Ordered lists automatically number items and support nested lists for hierarchical content organization. For items where order doesn't matter, use [unordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/unordered-list).
+ * Configure the following properties on the ordered list component.
  * @publicDocs
  */
 export interface OrderedListProps extends OrderedListProps$1 {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
@@ -29,9 +29,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-paragraph";
 /**
- * The paragraph component displays blocks of text content and can contain inline elements like buttons, links, or emphasized text. Use paragraph to present standalone blocks of readable content, descriptions, or explanatory text.
- *
- * Paragraphs support alignment options and can wrap inline components to create rich, formatted content blocks. For inline text styling, use [text](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/text).
+ * Configure the following properties on the paragraph component.
  * @publicDocs
  */
 export interface ParagraphProps extends Pick<ParagraphProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'id' | 'lang' | 'tone' | 'type'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph.d.ts
@@ -22,7 +22,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 
 declare const tagName = "s-skeleton-paragraph";
 /**
- * Displays a placeholder representation of text content while it loads. Use to improve perceived performance by showing users where text will appear.
+ * Configure the following properties on the skeleton paragraph component.
  * @publicDocs
  */
 export interface SkeletonParagraphProps extends SkeletonParagraphProps$1 {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Summary.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Summary.d.ts
@@ -12,7 +12,7 @@ import type {SummaryProps$1} from './components-shared.d.ts';
 
 declare const tagName = "s-summary";
 /**
- * Provides a clickable label for collapsible Details content. Use to create clear, accessible disclosure controls that show or hide additional information.
+ * Configure the following properties on the summary component.
  * @publicDocs
  */
 export interface SummaryProps extends Pick<SummaryProps$1, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
@@ -29,15 +29,13 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-text";
 /**
- * The text component displays inline text with specific visual styles or tones. Use text to emphasize or differentiate words or phrases within paragraphs or other block-level components, applying weight, color, or semantic styling.
- *
- * Text supports multiple visual variants, alignment options, and line clamping for flexible inline typography control. For block-level text content, use [paragraph](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/typography-and-content/paragraph).
+ * Configure the following properties on the text component.
  * @publicDocs
  */
 export interface TextProps extends Pick<TextProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'display' | 'id' | 'lang' | 'tone' | 'type'> {
     color?: Extract<TextProps$1['color'], 'subdued' | 'base'>;
     tone?: Extract<TextProps$1['tone'], 'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'custom'>;
-    type?: Extract<TextProps$1['type'], 'address' | 'redundant' | 'mark' | 'emphasis' | 'offset' | 'small' | 'strong' | 'generic'>;
+    type?: Extract<TextProps$1['type'], 'address' | 'redundant' | 'mark' | 'emphasis' | 'offset' | 'strong' | 'small' | 'generic'>;
 }
 /** @publicDocs */
 export interface TextElement extends TextProps, Omit<HTMLElement, 'id' | 'dir' | 'lang'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Time.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Time.d.ts
@@ -29,7 +29,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-time";
 /**
- * Represents a specific point or duration in time. Use to display dates, times, or durations clearly and consistently. May include a machine-readable `datetime` attribute for improved accessibility and functionality.
+ * Configure the following properties on the time component.
  * @publicDocs
  */
 export interface TimeProps extends Pick<TimeProps$1, 'dateTime' | 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList.d.ts
@@ -29,9 +29,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-unordered-list";
 /**
- * The unordered list component displays a bulleted list of related items where sequence isn't critical. Use unordered list to present collections of features, options, requirements, or any group of items where order doesn't affect meaning.
- *
- * Unordered lists automatically add bullet points and support nested lists for hierarchical content organization. For sequential items where order is important, use [ordered list](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/layout-and-structure/ordered-list).
+ * Configure the following properties on the unordered list component.
  * @publicDocs
  */
 export interface UnorderedListProps extends UnorderedListProps$1 {

--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -23,17 +23,13 @@ export interface GlobalProps {
 }
 interface AbbreviationProps$1 extends GlobalProps {
 	/**
-	 * The content of the abbreviation or acronym.
+	 * The abbreviated text content displayed within the abbreviation component. Pair with the `title` attribute to provide the full expansion for accessibility.
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Defines the full expansion of the abbreviation or acronym.
-	 *
-	 * Helps user agents and users understand the meaning of the abbreviated text.
+	 * Defines the full expansion of the abbreviation or acronym, helping user agents and users understand the meaning of the abbreviated text. Learn more about the [abbreviation element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr).
 	 *
 	 * @default ''
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
 	 */
 	title?: string;
 }
@@ -117,7 +113,7 @@ export interface ToggleEventProps {
 	 * - If the element transitioned from showing to hidden, the `oldState` property will be set to `open` and the
 	 *   `newState` will be `closed`.
 	 *
-	 * Learn more about [ToggleEvent.newState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState) and [ToggleEvent.oldState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
+	 * Learn more about the [`newState` property](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState) and [`oldState` property](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
 	 */
 	onAfterToggle?: (event: ToggleEvent$1) => void;
 	/**
@@ -125,10 +121,10 @@ export interface ToggleEventProps {
 	 *
 	 * - If the element is transitioning from hidden to showing, the `oldState` property will be set to `closed` and the
 	 *   `newState` property will be set to `open`.
-	 * - If the element is transitioning from showing to hidden, then `oldState` property will be set to `open` and the
+	 * - If the element is transitioning from showing to hidden, then the `oldState` property will be set to `open` and the
 	 *   `newState` will be `closed`.
 	 *
-	 * Learn more about the [toggle event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event), [ToggleEvent.newState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState), and [ToggleEvent.oldState](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState).
+	 * Learn more about the [`toggle` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event), and the [`newState`](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/newState) and [`oldState`](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent/oldState) properties.
 	 */
 	onToggle?: (event: ToggleEvent$1) => void;
 }
@@ -924,7 +920,8 @@ export interface DisplayProps {
 	 * - `auto`: the component’s initial value. The actual value depends on the component and context.
 	 * - `none`: hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.
 	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/display
+	 * Learn more about the [display property](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
+	 *
 	 * @default 'auto'
 	 */
 	display?: MaybeResponsive<"auto" | "none">;
@@ -1062,11 +1059,11 @@ export type AccessibilityRole =
 /** @publicDocs */
 export interface AccessibilityVisibilityProps {
 	/**
-	 * Changes the visibility of the element.
+	 * Controls how the element is exposed to sighted users and to assistive technologies such as screen readers.
 	 *
-	 * - `visible`: the element is visible to all users.
-	 * - `hidden`: the element is removed from the accessibility tree but remains visible.
-	 * - `exclusive`: the element is visually hidden but remains in the accessibility tree.
+	 * - `visible`: The element is visible to all users (both sighted users and screen readers).
+	 * - `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don’t provide meaningful information.
+	 * - `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.
 	 *
 	 * @default 'visible'
 	 */
@@ -1872,21 +1869,25 @@ interface CheckboxProps$1 extends GlobalProps, BaseCheckableProps, FieldErrorPro
 /** @publicDocs */
 export interface ChipProps$1 {
 	/**
-	 * The content of the chip.
+	 * The text content displayed within the chip.
 	 */
 	children?: ComponentChildren;
 	/**
-	 * The graphic to display inside of the chip.
+	 * The graphic element (typically an icon) displayed inside the chip.
 	 *
 	 * @implementation Only `s-icon` is supported.
 	 */
 	graphic?: ComponentChildren;
 	/**
-	 * A label that describes the purpose or contents of the chip. It will be read to users using assistive technologies such as screen readers.
+	 * A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn’t clearly convey the component’s purpose.
 	 */
 	accessibilityLabel?: string;
 	/**
-	 * Modify the color to be more or less intense.
+	 * The color emphasis level that controls visual intensity.
+	 *
+	 * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
+	 * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
+	 * - `strong`: Emphasized color for headings, key labels, and interactive elements that need prominence.
 	 *
 	 * @default 'base'
 	 */
@@ -1999,7 +2000,7 @@ interface ClickableProps$1 extends GlobalProps, BaseBoxProps, BaseClickableProps
 }
 interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
 	/**
-	 * Callback when the chip is clicked.
+	 * A callback fired when the chip is clicked. Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).
 	 */
 	onClick?: (event: Event) => void;
 	/**
@@ -2007,13 +2008,13 @@ interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
 	 */
 	href?: string;
 	/**
-	 * Whether the chip is removable.
+	 * Whether the chip displays a remove button, allowing users to dismiss it. When `true`, clicking the remove button fires the `remove` event.
 	 *
 	 * @default false
 	 */
 	removable?: boolean;
 	/**
-	 * Callback when the chip is removed.
+	 * A callback fired when the chip is removed by the user clicking the remove button.
 	 */
 	onRemove?: (event: Event) => void;
 	/**
@@ -2029,7 +2030,7 @@ interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
 	 */
 	hidden?: boolean;
 	/**
-	 * Event handler when the chip has fully hidden.
+	 * A callback fired when the chip has fully hidden after a removal animation.
 	 *
 	 * The `hidden` property will be `true` when this event fires.
 	 *
@@ -2039,7 +2040,7 @@ interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
 	 */
 	onAfterHide?: (event: Event) => void;
 	/**
-	 * Disables the chip, disallowing any interaction.
+	 * Disables the chip, preventing all user interaction including clicks and removal. Disabled chips are visually dimmed to indicate they are not interactive.
 	 *
 	 * @default false
 	 */
@@ -2316,37 +2317,32 @@ interface DateFieldProps$1 extends GlobalProps, BaseTextFieldProps, Pick<DatePic
 export type DateAutocompleteField = ExtractStrict<AnyAutocompleteField, "bday" | "bday-day" | "bday-month" | "bday-year" | "cc-expiry" | "cc-expiry-month" | "cc-expiry-year">;
 interface DetailsProps$1 extends GlobalProps, ToggleEventProps {
 	/**
-	 * The content of the details.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
+	 * The content displayed within the collapsible details section. This can include any elements that should be shown or hidden when the details component is toggled. Learn more about the [details element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details).
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Name of the element.
+	 * The `name` attribute for the element. Use this to create multiple named disclosure groups where only one can be open at a time.
 	 *
-	 * This can be used to create multiple named disclosure boxes that where only one can be open at a time.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#multiple_named_disclosure_boxes
+	 * Learn more about [multiple named disclosure boxes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#multiple_named_disclosure_boxes).
 	 */
 	name?: string;
 	/**
-	 * Whether the element is open.
-	 *
-	 * This does not reflect to any attribute.
+	 * Whether the element is currently open. Use this for controlled component patterns where your application manages the open state directly. This does not reflect to any attribute.
 	 *
 	 * @default false
 	 */
 	open?: boolean;
 	/**
-	 * Indicates whether the element should be open by default.
-	 *
-	 * This reflects to the `open` attribute.
+	 * Whether the element should be open when it first renders. This reflects to the `open` attribute and only takes effect on the initial render.
 	 *
 	 * @default false
 	 */
 	defaultOpen?: boolean;
 	/**
-	 * Sets the transition between the two states.
+	 * The transition style used when toggling between open and closed states.
+	 *
+	 * - `none`: Switches states immediately without animation.
+	 * - `auto`: Uses the default animated transition.
 	 *
 	 * @default 'auto'
 	 */
@@ -2582,7 +2578,11 @@ interface GridItemProps$1 extends GlobalProps, BaseBoxPropsWithRole {
 /** @publicDocs */
 export interface BaseTypographyProps {
 	/**
-	 * Modify the color to be more or less intense.
+	 * The color emphasis level that controls visual intensity.
+	 *
+	 * - `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.
+	 * - `base`: Primary color for body text, standard UI elements, and general content with good readability.
+	 * - `strong`: Emphasized color for headings, key labels, and interactive elements that need prominence.
 	 *
 	 * @default 'base'
 	 */
@@ -2594,9 +2594,7 @@ export interface BaseTypographyProps {
 	 */
 	tone?: ToneKeyword;
 	/**
-	 * Set the numeric properties of the font.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric
+	 * Set the numeric properties of the font. Learn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
 	 *
 	 * @default 'auto' - inherit from the parent element
 	 */
@@ -2613,12 +2611,12 @@ export interface BaseTypographyProps {
 	/**
 	 * Indicates the directionality of the element’s text.
 	 *
-	 * - `ltr`: languages written from left to right (such as English)
-	 * - `rtl`: languages written from right to left (such as Arabic)
-	 * - `auto`: the user agent determines the direction based on the content
-	 * - `''`: direction is inherited from parent elements (equivalent to not setting the attribute)
+	 * - `ltr`: The languages written from left to right (such as English).
+	 * - `rtl`: The languages written from right to left (such as Arabic).
+	 * - `auto`: The user agent determines the direction based on the content.
+	 * - `""`: The direction is inherited from parent elements (equivalent to not setting the attribute).
 	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir
+	 * Learn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).
 	 *
 	 * @default ''
 	 */
@@ -2627,9 +2625,7 @@ export interface BaseTypographyProps {
 /** @publicDocs */
 export interface BlockTypographyProps {
 	/**
-	 * Truncates the text content to the specified number of lines.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+	 * Truncates the text content to the specified number of lines. Learn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).
 	 *
 	 * @default Infinity - no truncation is applied
 	 */
@@ -2637,7 +2633,7 @@ export interface BlockTypographyProps {
 }
 interface HeadingProps$1 extends GlobalProps, AccessibilityVisibilityProps, BlockTypographyProps {
 	/**
-	 * The content of the Heading.
+	 * The heading text displayed within the heading component, which provides a title or section header for content.
 	 */
 	children?: ComponentChildren;
 	/**
@@ -2836,7 +2832,7 @@ interface LinkProps$1 extends GlobalProps, LinkBehaviorProps {
 }
 interface ListItemProps$1 extends GlobalProps {
 	/**
-	 * The content of the ListItem.
+	 * The content displayed within the list item, which represents a single entry in an ordered or unordered list.
 	 */
 	children?: ComponentChildren;
 }
@@ -3055,11 +3051,11 @@ interface OrderedListProps$1 extends GlobalProps {
 }
 interface ParagraphProps$1 extends GlobalProps, BaseTypographyProps, BlockTypographyProps, AccessibilityVisibilityProps {
 	/**
-	 * The content of the Text.
+	 * The paragraph text content displayed within the paragraph component, which presents a block of related text with appropriate styling.
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Provide semantic meaning and default styling to the paragraph.
+	 * The semantic type and styling treatment for the paragraph content.
 	 *
 	 * Other presentation properties on `s-paragraph` override the default styling.
 	 *
@@ -3070,20 +3066,19 @@ interface ParagraphProps$1 extends GlobalProps, BaseTypographyProps, BlockTypogr
 /** @publicDocs */
 export type ParagraphType = 
 /**
- * Indicate the text is a structural grouping of related content.
+ * A semantic type that indicates the text is a structural grouping of related content.
  *
- * In an HTML host, the text will be rendered in an `<p>` element.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
+ * In an HTML host, the text will be rendered in an `<p>` element. Learn more about the [p element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p).
  */
 "paragraph"
 /**
- * Indicates the text is considered less important than the main content, but is still necessary for the reader to understand.
+ * A semantic type that indicates the text is considered less important than the main content, but is still necessary for the reader to understand.
+ *
  * It can be used for secondary content but also for disclaimers, terms and conditions, or legal information.
  *
  * Surfaces should apply a smaller font size than the default size.
  *
- * In an HTML host, the text will be rendered in a `<small>` element.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
+ * In an HTML host, the text will be rendered in a `<small>` element. Learn more about the [small element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small).
  */
  | "small";
 interface PasswordFieldProps$1 extends GlobalProps, BaseTextFieldProps, MinMaxLengthProps, AutocompleteProps<PasswordAutocompleteField> {
@@ -3413,12 +3408,10 @@ interface StackProps$1 extends GlobalProps, BaseBoxPropsWithRole, GapProps {
 }
 interface SummaryProps$1 extends GlobalProps {
 	/**
-	 * The content to use as the label.
+	 * The text or elements displayed as the summary label for the collapsible details section.
 	 *
-	 * Interactive content is disallowed. For example, you can use a `<Text>` element for extra formatting but
-	 * elements like buttons and fields are not allowed.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
+	 * Interactive content is disallowed. For example, you can use an `s-text` element for extra formatting but
+	 * elements like buttons and fields are not allowed. Learn more about the [summary element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary).
 	 *
 	 * @implementation Surfaces may apply styling to this element. An icon suggesting the state (open or closed) of the
 	 * details element is recommended.
@@ -3431,13 +3424,13 @@ interface SwitchProps$1 extends GlobalProps, BaseCheckableProps, BasicFieldProps
 }
 interface TextProps$1 extends GlobalProps, AccessibilityVisibilityProps, BaseTypographyProps, DisplayProps, Pick<InteractionProps, "interestFor"> {
 	/**
-	 * The content of the Text.
+	 * The text content displayed within the text component, which applies semantic meaning and styling appropriate to the specified text type.
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Provide semantic meaning and default styling to the text.
+	 * The semantic type and styling treatment for the text content.
 	 *
-	 * Other presentation properties on Text override the default styling.
+	 * Other presentation properties on `s-text` override the default styling.
 	 *
 	 * @default 'generic'
 	 */
@@ -3446,7 +3439,7 @@ interface TextProps$1 extends GlobalProps, AccessibilityVisibilityProps, BaseTyp
 /** @publicDocs */
 export type TextType = 
 /**
- * Indicate the text is contact information. Typically used for addresses.
+ * A semantic type that indicates the text is contact information. Typically used for addresses.
  *
  * This must have `inline` layout (despite the default being `block` in HTML hosts).
  *
@@ -3456,65 +3449,60 @@ export type TextType =
  *
  * @implementation vertical alignment should be `baseline` (`vertical-align: baseline`)
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
+ * Learn more about the [address element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address).
  */
 "address"
 /**
- * Indicate the text is no longer accurate or no longer relevant. One such use-case is discounted prices.
+ * A semantic type that indicates the text is no longer accurate or no longer relevant. One such use-case is discounted prices.
  *
  * Surfaces should apply styling to this type to suggest its content no longer applies.
  *
- * In an HTML host, the text will be rendered in a `<s>` element.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
+ * In an HTML host, the text will be rendered in a `<s>` element. Learn more about the [s element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s).
  */
  | "redundant"
 /**
- * Indicate the text is marked or highlighted and relevant to the user’s current action.
+ * A semantic type that indicates the text is marked or highlighted and relevant to the user’s current action.
  * One such use-case is to indicate the characters that matched a search query.
  *
  * Surfaces should apply styling to this type to draw attention to the content.
  *
- * In an HTML host, the text will be rendered in a `<mark>` element.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
+ * In an HTML host, the text will be rendered in a `<mark>` element. Learn more about the [mark element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark).
  */
  | "mark"
 /**
- * Indicate emphatic stress. Typically for words that have a stressed emphasis compared to surrounding text.
+ * A semantic type that indicates emphatic stress. Typically for words that have a stressed emphasis compared to surrounding text.
  *
  * Surfaces should apply styling to this type to distinguish it from surrounding text. Italicization is a common choice, but not required.
  *
- * In an HTML host, the text will be rendered in an `<em>` element.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
+ * In an HTML host, the text will be rendered in an `<em>` element. Learn more about the [em element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em).
  */
  | "emphasis"
 /**
- * Indicate an offset from the normal prose of the text. Typically used to indicate
- * a foreign word, fictional character thoughts, or when the text refers to the definition of a word
- * instead of representing its semantic meaning.
+ * A semantic type that indicates an offset from the normal prose of the text.
+ *
+ * Typically used to indicate a foreign word, fictional character thoughts, or when the text refers to the definition of a word instead of representing its semantic meaning.
  *
  * Surfaces should italicize this content by default.
  *
- * In an HTML host, the text will be rendered in a `<i>` tag.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
+ * In an HTML host, the text will be rendered in a `<i>` tag. Learn more about the [i element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i).
  */
  | "offset"
 /**
- * Indicate strong importance, seriousness, or urgency.
+ * A semantic type that indicates strong importance, seriousness, or urgency.
  *
  * Surfaces should render this content bold by default.
  *
- * In an HTML host, the text will be rendered in a `<strong>` tag.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
+ * In an HTML host, the text will be rendered in a `<strong>` tag. Learn more about the [strong element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong).
  */
  | "strong"
 /**
- * Indicates the text is considered less important than the main content, but is still necessary for the reader to understand.
+ * A semantic type that indicates the text is considered less important than the main content, but is still necessary for the reader to understand.
+ *
  * It can be used for secondary content but also for disclaimers, terms and conditions, or legal information.
  *
  * Surfaces should apply a smaller font size than the default size.
  *
- * In an HTML host, the text will be rendered in a `<small>` element.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
+ * In an HTML host, the text will be rendered in a `<small>` element. Learn more about the [small element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small).
  */
  | "small"
 /**
@@ -3522,8 +3510,7 @@ export type TextType =
  *
  * Surfaces must not apply any default styling to this type.
  *
- * In an HTML host, the text will be rendered in a `<span>` tag.
- * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
+ * In an HTML host, the text will be rendered in a `<span>` tag. Learn more about the [span element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span).
  */
  | "generic";
 interface TextAreaProps$1 extends GlobalProps, BaseTextFieldProps, MinMaxLengthProps, AutocompleteProps<TextAutocompleteField> {
@@ -3538,15 +3525,13 @@ interface TextFieldProps$1 extends GlobalProps, BaseTextFieldProps, MinMaxLength
 }
 interface TimeProps$1 extends GlobalProps {
 	/**
-	 * The content of the Time.
+	 * The text content displayed within the time component, representing a human-readable date or time value.
 	 */
 	children?: ComponentChildren;
 	/**
-	 * Set the time and/or date of the element.
+	 * The machine-readable date and/or time value for the element. Use this to provide a datetime string that browsers, search engines, and assistive technologies can parse for improved semantics and functionality.
 	 *
-	 * It must be a [valid date string](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time#valid_datetime_values).
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values
+	 * The value must be a [valid datetime string](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time#valid_datetime_values), such as `2024-01-15`, `14:30`, or `2024-01-15T14:30:00`.
 	 *
 	 * @default ''
 	 */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/OrderedList/OrderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/OrderedList/OrderedList.doc.ts
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = createComponentDoc({
     definitions: {properties: true},
   },
   bestPractices: `- Use \`s-ordered-list\` when you need to present items in a specific sequence or order.
-- Each item in the list should be wrapped in a \`s-list-item\` component.
+- Each item in the list should be wrapped in an \`s-list-item\` component.
 - Keep list items concise and consistent in length when possible.
 - Use \`s-ordered-list\` for step-by-step instructions, numbered procedures, or ranked items.
 - Consider using \`s-ordered-list\` when the order of items is important for understanding.`,

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Time/Time.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Time/Time.doc.ts
@@ -6,11 +6,11 @@ import {createComponentDoc} from '../../../../docs/shared/component-definitions'
 const data: ReferenceEntityTemplateSchema = createComponentDoc({
   ...sharedContent,
   definitions: {properties: true},
-  bestPractices: `- Use the Time component for all time values to keep formatting consistent.
+  bestPractices: `- Use the time component for all time values to keep formatting consistent.
 - Show times in a clear, readable format.
 - Consider 24-hour format for international audiences.
 - Include timezone information when relevant.
-- Use the Time component for time-related content to maintain clear semantics.`,
+- Use the time component for time-related content to maintain clear semantics.`,
 });
 
 export default data;

--- a/packages/ui-extensions/src/surfaces/customer-account/components/UnorderedList/UnorderedList.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/UnorderedList/UnorderedList.doc.ts
@@ -12,7 +12,7 @@ const data: ReferenceEntityTemplateSchema = createComponentDoc({
     definitions: {properties: true},
   },
   bestPractices: `- Use \`s-unordered-list\` when you need to present a list of related items or options.
-- Each item in the list should be wrapped in a \`s-list-item\` component.
+- Each item in the list should be wrapped in an \`s-list-item\` component.
 - Keep list items concise and consistent in length when possible.
 - Use \`s-unordered-list\` for navigation menus, feature lists, or any collection of related items.
 - Consider using \`s-unordered-list\` when you want to present information in a clear, scannable format.`,


### PR DESCRIPTION
## Summary
- Cascades Typography and Content component description updates from 2026-04-rc to 2025-10
- Enriches shared property descriptions, converts `@see` tags to inline links, aligns with admin quality bar

## Test plan
- [ ] `yarn build` passes
- [ ] Verify no generated files included
- [ ] Regen docs locally to verify descriptions


Made with [Cursor](https://cursor.com)