### PR TITLE
Add JSDoc type value descriptions to Text and Paragraph

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
@@ -29,6 +29,17 @@ declare const tagName = "s-paragraph";
 export interface ParagraphElementProps extends Pick<ParagraphProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'id' | 'lang' | 'tone' | 'type'> {
     color?: Extract<ParagraphProps$1['color'], 'subdued' | 'base'>;
     tone?: Extract<ParagraphProps$1['tone'], 'auto' | 'info' | 'success' | 'warning' | 'critical' | 'neutral' | 'custom'>;
+    /**
+     * The semantic type and styling treatment for the paragraph content.
+     *
+     * Other presentation properties on `s-paragraph` override the default styling.
+     *
+     * - `paragraph`: A semantic type that indicates a structural grouping of related content.
+     * - `small`: A semantic type that indicates less important text.
+     *
+     * @default 'paragraph'
+     */
+    type?: Extract<ParagraphProps$1['type'], 'paragraph' | 'small'>;
 }
 /** @publicDocs */
 export interface ParagraphElement extends ParagraphElementProps, Omit<HTMLElement, 'id' | 'dir' | 'lang'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
@@ -29,6 +29,22 @@ declare const tagName = "s-text";
 export interface TextElementProps extends Pick<TextProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'display' | 'id' | 'lang' | 'tone' | 'type'> {
     color?: Extract<TextProps$1['color'], 'subdued' | 'base'>;
     tone?: Extract<TextProps$1['tone'], 'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'custom'>;
+    /**
+     * The semantic type and styling treatment for the text content.
+     *
+     * Other presentation properties on `s-text` override the default styling.
+     *
+     * - `address`: A semantic type that indicates the text is contact information. Typically used for addresses.
+     * - `redundant`: A semantic type that indicates the text is no longer accurate or no longer relevant.
+     * - `mark`: A semantic type that indicates the text is marked or highlighted.
+     * - `emphasis`: A semantic type that indicates emphatic stress.
+     * - `offset`: A semantic type that indicates an offset from the normal prose.
+     * - `strong`: A semantic type that indicates strong importance, seriousness, or urgency.
+     * - `small`: A semantic type that indicates less important text.
+     * - `generic`: No additional semantics or styling is applied.
+     *
+     * @default 'generic'
+     */
     type?: Extract<TextProps$1['type'], 'address' | 'redundant' | 'mark' | 'emphasis' | 'offset' | 'strong' | 'small' | 'generic'>;
 }
 /** @publicDocs */


### PR DESCRIPTION
## Summary
- Adds inline JSDoc value descriptions for the `type` property on `TextElementProps` in `Text.d.ts`, documenting all semantic type options (`address`, `redundant`, `mark`, `emphasis`, `offset`, `small`, `strong`, `generic`) with `@default 'generic'`.
- Adds explicit `type` property with JSDoc value descriptions on `ParagraphElementProps` in `Paragraph.d.ts`, documenting `paragraph` and `small` with `@default 'paragraph'`.

Mirrors the JSDoc changes already applied on `2026-04-rc`.

Made with [Cursor](https://cursor.com)