### PR TITLE
feat(pos): add Extension API (apiVersion + target) to POS StandardApi

### DIFF
--- a/packages/ui-extensions-tester/src/point-of-sale/factories.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/factories.ts
@@ -109,6 +109,10 @@ function createMockStandardApi<T extends RenderExtensionTarget>(
 ): StandardApi<T> {
   return {
     extensionPoint: target,
+    extension: {
+      apiVersion: '2026-04',
+      target,
+    },
     i18n: createMockI18n(),
     locale: {current: createReadonlySignalLike('en-US')},
     toast: {show: () => {}},

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -12,6 +12,10 @@ export type {CashDrawerApi} from './api/cash-drawer-api/cash-drawer-api';
 export type {ActionApi, ActionApiContent} from './api/action-api/action-api';
 
 export type {StandardApi} from './api/standard/standard-api';
+export type {
+  ExtensionApi,
+  ExtensionApiContent,
+} from './api/extension-api/extension-api';
 export type {ActionTargetApi} from './api/action-target-api/action-target-api';
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/extension-api/extension-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/extension-api/extension-api.ts
@@ -1,0 +1,51 @@
+import type {ApiVersion} from '../../../../shared';
+
+/**
+ * The Extension API lets you read metadata about the currently running
+ * extension. Use it to implement version-aware behaviour or to identify which
+ * target is active when the same extension module is registered against
+ * multiple targets. Access these properties through `shopify.extension`.
+ *
+ * @example
+ * <caption>Read the API version and active target</caption>
+ * <description>Display the configured API version and the active extension target. Use `shopify.extension.apiVersion` for version-aware logic and `shopify.extension.target` when a single module handles multiple targets.</description>
+ * ```jsx
+ * const Extension = () => {
+ *   const {apiVersion, target} = shopify.extension;
+ *   return (
+ *     <s-page heading="Extension Info">
+ *       <s-stack direction="block">
+ *         <s-text>API Version: {apiVersion}</s-text>
+ *         <s-text>Target: {target}</s-text>
+ *       </s-stack>
+ *     </s-page>
+ *   );
+ * };
+ * ```
+ * @publicDocs
+ */
+export interface ExtensionApiContent<T> {
+  /**
+   * The API version that was set in the extension configuration file.
+   *
+   * @example '2026-01', '2026-04'
+   */
+  apiVersion: ApiVersion;
+  /**
+   * The extension target that is currently running, as configured in the
+   * extension's `shopify.extension.toml` file.
+   *
+   * @example 'pos.home.tile.render', 'pos.home.modal.render'
+   */
+  target: T;
+}
+
+/**
+ * The `ExtensionApi` object provides metadata about the currently running
+ * extension, including the configured API version and the active extension
+ * target. Access these properties through `shopify.extension`.
+ * @publicDocs
+ */
+export interface ExtensionApi<T> {
+  extension: ExtensionApiContent<T>;
+}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/standard/standard-api.ts
@@ -1,6 +1,7 @@
 import {CameraApi} from '../camera-api/camera-api';
 import {ConnectivityApi} from '../connectivity-api/connectivity-api';
 import {DeviceApi} from '../device-api/device-api';
+import {ExtensionApi} from '../extension-api/extension-api';
 import {LocaleApi} from '../locale-api/locale-api';
 import {SessionApi} from '../session-api/session-api';
 import {ToastApi} from '../toast-api/toast-api';
@@ -14,9 +15,13 @@ import type {I18n} from '../../../../api';
  * @publicDocs
  */
 export type StandardApi<T> = {[key: string]: any} & {
+  /**
+   * @deprecated Use `extension.target` instead.
+   */
   extensionPoint: T;
   i18n: I18n;
-} & LocaleApi &
+} & ExtensionApi<T> &
+  LocaleApi &
   ToastApi &
   SessionApi &
   PrintApi &


### PR DESCRIPTION
## Summary

Implements the `extension` API for POS UI extensions, as designed in [ui-api-design#1473](https://github.com/Shopify/ui-api-design/pull/1473).

Exposes `shopify.extension.apiVersion` and `shopify.extension.target` on the POS `StandardApi`, aligning POS with the approach already used by Checkout.

## Changes

### Source
- **`src/surfaces/point-of-sale/api/extension-api/extension-api.ts`** _(new)_ — `ExtensionApiContent<T>` and `ExtensionApi<T>` interfaces with `apiVersion: ApiVersion` and `target: T`
- **`src/surfaces/point-of-sale/api/standard/standard-api.ts`** — added `ExtensionApi<T>` to the `StandardApi` intersection type
- **`src/surfaces/point-of-sale/api.ts`** — exported `ExtensionApi` and `ExtensionApiContent`

### Documentation
- **`docs/surfaces/point-of-sale/reference/apis/extension-api.doc.ts`** _(new)_ — API reference doc
- **`docs/surfaces/point-of-sale/reference/examples/extension-api/extension-info.jsx`** _(new)_ — usage example

### Tests / Mocks
- **`packages/ui-extensions-tester/src/point-of-sale/factories.ts`** — added `extension: { apiVersion: '2026-04', target }` to the `createMockStandardApi` factory

## Usage

```jsx
const Extension = () => {
  const {apiVersion, target} = shopify.extension;
  return (
    <s-text>Running {target} on API {apiVersion}</s-text>
  );
};
```