### PR TITLE
Remove Props/Events/Slots intro sentences from shared .d.ts files

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-abbreviation";
-/**
- * The element props interface for the Abbreviation component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface AbbreviationElementProps extends Pick<AbbreviationProps$1, 'title' | 'id'> {
 }
 export interface AbbreviationElement extends AbbreviationElementProps, Omit<HTMLElement, 'id' | 'title'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Announcement.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Announcement.d.ts
@@ -60,9 +60,7 @@ export interface ToggleArgumentsEvent {
 declare const tagName = "s-announcement";
 export interface AnnouncementEvents extends Pick<AnnouncementProps$1, 'onAfterToggle' | 'onDismiss' | 'onToggle'> {
 }
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface AnnouncementElementEvents {
     /**
      * A callback that fires when the element state changes, after any toggle animations have finished.
@@ -104,9 +102,7 @@ export interface AnnouncementMethods {
      */
     dismiss: () => void;
 }
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface AnnouncementElementMethods {
     /**
      * Programmatically dismisses the announcement. This triggers the `dismiss` event callback.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge.d.ts
@@ -35,9 +35,7 @@ declare const CHECKOUT_AVAILABLE_ICONS: readonly ["alert-circle", "alert-triangl
 export type ReducedIconTypes = (typeof CHECKOUT_AVAILABLE_ICONS)[number];
 
 declare const tagName = "s-badge";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BadgeElementProps extends Pick<BadgeProps$1, 'color' | 'icon' | 'iconPosition' | 'id' | 'size' | 'tone'> {
     /**
      * The size of the badge.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner.d.ts
@@ -38,9 +38,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-banner";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BannerElementProps extends Pick<BannerProps$1, 'collapsible' | 'dismissible' | 'heading' | 'hidden' | 'id' | 'tone'> {
     /**
      * Whether the banner content can be collapsed and expanded by the user. A collapsible banner conceals child elements initially, allowing the user to expand the banner to reveal them.
@@ -93,9 +91,7 @@ export interface BannerElementProps extends Pick<BannerProps$1, 'collapsible' | 
 }
 export interface BannerEvents extends Pick<BannerProps$1, 'onAfterHide' | 'onDismiss'> {
 }
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BannerElementEvents {
     /**
      * A callback that fires when the banner has fully hidden, including after any hide animations have completed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Box.d.ts
@@ -46,9 +46,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-box";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BoxElementProps extends Pick<BoxProps$1, 'accessibilityLabel' | 'accessibilityRole' | 'accessibilityVisibility' | 'background' | 'blockSize' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'display' | 'id' | 'inlineSize' | 'maxBlockSize' | 'maxInlineSize' | 'minBlockSize' | 'minInlineSize' | 'overflow' | 'padding' | 'paddingBlock' | 'paddingBlockEnd' | 'paddingBlockStart' | 'paddingInline' | 'paddingInlineEnd' | 'paddingInlineStart'> {
     /**
      * The background color of the box.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
@@ -38,10 +38,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-button";
-/**
- * Configure the following properties on the button component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'disabled' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'loading' | 'target' | 'tone' | 'type' | 'variant'> {
     target?: Extract<ButtonProps$1['target'], 'auto' | '_blank'>;
     tone?: Extract<ButtonProps$1['tone'], 'auto' | 'neutral' | 'critical'>;
@@ -50,10 +47,7 @@ export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLa
 }
 export interface ButtonEvents extends Pick<ButtonProps$1, 'onClick'> {
 }
-/**
- * The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ButtonElementEvents {
     /**
      * A callback fired when the button is clicked. This will be called before the action indicated by `type`.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox.d.ts
@@ -32,20 +32,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-checkbox";
-/**
- * Configure the following properties on the checkbox component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface CheckboxElementProps extends Pick<CheckboxProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'required' | 'value'> {
     command?: Extract<CheckboxProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
 }
 export interface CheckboxEvents extends Pick<CheckboxProps$1, 'onChange'> {
 }
-/**
- * The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface CheckboxElementEvents {
     /**
      * A callback fired when the checkbox value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Chip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Chip.d.ts
@@ -26,16 +26,10 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-chip";
-/**
- * Configure the following properties on the chip component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChipElementProps extends Pick<ChipProps$1, 'accessibilityLabel' | 'id'> {
 }
-/**
- * The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChipElementSlots {
     /**
      * The graphic to display inside of the chip.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Choice.d.ts
@@ -26,16 +26,10 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-choice";
-/**
- * Configure the following properties on the choice component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceElementProps extends Pick<ChoiceProps$1, 'accessibilityLabel' | 'defaultSelected' | 'disabled' | 'id' | 'selected' | 'error' | 'value'> {
 }
-/**
- * The choice component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceElementSlots {
     /**
      * Additional text to provide context or guidance for the input.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList.d.ts
@@ -38,19 +38,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-choice-list";
-/**
- * Configure the following properties on the choice list component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceListElementProps extends Pick<ChoiceListProps$1, 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'multiple' | 'name' | 'values' | 'variant'> {
 }
 export interface ChoiceListEvents extends Pick<ChoiceListProps$1, 'onChange'> {
 }
-/**
- * The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceListElementEvents {
     /**
      * A callback fired when the choice list value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Clickable.d.ts
@@ -58,10 +58,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-clickable";
-/**
- * Configure the following properties on the clickable component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableElementProps extends Pick<ClickableProps$1, 'accessibilityLabel' | 'accessibilityVisibility' | 'background' | 'blockSize' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'command' | 'commandFor' | 'disabled' | 'display' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'lang' | 'loading' | 'maxBlockSize' | 'maxInlineSize' | 'minBlockSize' | 'minInlineSize' | 'overflow' | 'padding' | 'paddingBlock' | 'paddingBlockEnd' | 'paddingBlockStart' | 'paddingInline' | 'paddingInlineEnd' | 'paddingInlineStart' | 'target' | 'type'> {
     background?: Extract<ClickableProps$1['background'], 'transparent' | 'subdued' | 'base'>;
     border?: BorderShorthand;
@@ -72,10 +69,7 @@ export interface ClickableElementProps extends Pick<ClickableProps$1, 'accessibi
 }
 export interface ClickableEvents extends Pick<ClickableProps$1, 'onBlur' | 'onClick' | 'onFocus'> {
 }
-/**
- * The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableElementEvents {
     /**
      * A callback fired when the component loses focus.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip.d.ts
@@ -38,18 +38,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-clickable-chip";
-/**
- * Configure the following properties on the clickable chip component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableChipElementProps extends Pick<ClickableChipProps$1, 'accessibilityLabel' | 'disabled' | 'hidden' | 'href' | 'id' | 'removable'> {
 }
 export interface ClickableChipEvents extends Pick<ClickableChipProps$1, 'onAfterHide' | 'onClick' | 'onRemove'> {
 }
-/**
- * The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableChipElementEvents {
     /**
      * A callback fired after the chip is hidden. The `hidden` property will be `true` when this event fires.
@@ -66,10 +60,7 @@ export interface ClickableChipElementEvents {
      */
     remove?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The clickable chip component supports slots for additional content placement. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableChipElementSlots {
     /**
      * The graphic to display inside of the chip.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem.d.ts
@@ -32,18 +32,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-clipboard-item";
-/**
- * Configure the following properties on the clipboard item component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClipboardItemElementProps extends Pick<ClipboardItemProps$1, 'id' | 'text'> {
 }
 export interface ClipboardItemEvents extends Pick<ClipboardItemProps$1, 'onCopy' | 'onCopyError'> {
 }
-/**
- * The clipboard item component provides event callbacks for handling copy interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClipboardItemElementEvents {
     /**
      * A callback fired when the text is successfully copied to the clipboard. Use this to show a confirmation message or update the UI.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox.d.ts
@@ -56,20 +56,13 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-consent-checkbox";
-/**
- * Configure the following properties on the consent checkbox component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentCheckboxElementProps extends Pick<ConsentCheckboxProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'policy' | 'value'> {
     command?: Extract<ConsentCheckboxProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
 }
 export interface ConsentCheckboxEvents extends Pick<CheckboxEvents, 'onChange'> {
 }
-/**
- * The consent checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentCheckboxElementEvents {
     /**
      * A callback fired when the consent checkbox value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField.d.ts
@@ -69,10 +69,7 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-consent-phone-field";
-/**
- * Configure the following properties on the consent phone field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentPhoneFieldElementProps extends Pick<ConsentPhoneFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'name' | 'policy' | 'readOnly' | 'required' | 'type' | 'value'> {
     /**
      * @deprecated Use `label` instead.
@@ -82,11 +79,7 @@ export interface ConsentPhoneFieldElementProps extends Pick<ConsentPhoneFieldPro
 }
 export interface ConsentPhoneFieldEvents extends Pick<PhoneFieldEvents, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The consent phone field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentPhoneFieldElementEvents {
     /**
      * A callback fired when the consent phone field loses focus.
@@ -119,11 +112,7 @@ export interface ConsentPhoneFieldElement extends ConsentPhoneFieldElementProps,
     onfocus: ConsentPhoneFieldEvents['onFocus'];
     oninput: ConsentPhoneFieldEvents['onInput'];
 }
-/**
- * The consent phone field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentPhoneFieldElementSlots {
     /**
      * Additional interactive content displayed within the field. Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
@@ -32,10 +32,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-date-field";
-/**
- * Configure the following properties on the date field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DateFieldElementProps extends Pick<DateFieldProps$1, 'allow' | 'allowDays' | 'autocomplete' | 'defaultValue' | 'defaultView' | 'disabled' | 'disallow' | 'disallowDays' | 'error' | 'id' | 'label' | 'name' | 'readOnly' | 'required' | 'value' | 'view'> {
     /**
      * @deprecated Use `label` instead.
@@ -45,11 +42,7 @@ export interface DateFieldElementProps extends Pick<DateFieldProps$1, 'allow' | 
 }
 export interface DateFieldEvents extends Pick<DateFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput' | 'onInvalid' | 'onViewChange'> {
 }
-/**
- * The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface DateFieldElementEvents {
     /**
      * A callback fired when the date field loses focus.

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
@@ -32,19 +32,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-date-picker";
-/**
- * Configure the following properties on the date picker component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DatePickerElementProps extends Pick<DatePickerProps$1, 'allow' | 'allowDays' | 'defaultValue' | 'defaultView' | 'disabled' | 'disallow' | 'disallowDays' | 'id' | 'name' | 'type' | 'value' | 'view'> {
 }
 export interface DatePickerEvents extends Pick<DatePickerProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput' | 'onViewChange'> {
 }
-/**
- * The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface DatePickerElementEvents {
     /**
      * A callback fired when the date picker loses focus.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Details.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Details.d.ts
@@ -43,18 +43,12 @@ export interface ToggleArgumentsEvent {
 }
 
 declare const tagName = "s-details";
-/**
- * The element props interface for the Details component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DetailsElementProps extends Pick<DetailsProps$1, 'defaultOpen' | 'id' | 'open' | 'toggleTransition'> {
 }
 export interface DetailsEvents extends Pick<DetailsProps$1, 'onToggle' | 'onAfterToggle'> {
 }
-/**
- * The events interface for the Details component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DetailsElementEvents {
     /**
      * Callback straight after the element state changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/DropZone.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DropZone.d.ts
@@ -32,19 +32,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-drop-zone";
-/**
- * Configure the following properties on the drop zone component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DropZoneElementProps extends Pick<DropZoneProps$1, 'accept' | 'accessibilityLabel' | 'disabled' | 'error' | 'id' | 'label' | 'multiple' | 'name' | 'required' | 'value'> {
 }
 export interface DropZoneEvents extends Pick<DropZoneProps$1, 'onDropRejected' | 'onInput' | 'onChange'> {
 }
-/**
- * The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface DropZoneElementEvents {
     /**
      * A callback fired when files are rejected based on the `accept` prop.

--- a/packages/ui-extensions/src/surfaces/checkout/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/EmailField.d.ts
@@ -38,10 +38,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-email-field";
-/**
- * Configure the following properties on the email field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface EmailFieldElementProps extends Pick<EmailFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'maxLength' | 'minLength' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'name' | 'readOnly' | 'required' | 'value'> {
     /**
      * @deprecated Use `label` instead.
@@ -51,11 +48,7 @@ export interface EmailFieldElementProps extends Pick<EmailFieldProps$1, 'autocom
 }
 export interface EmailFieldEvents extends Pick<EmailFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface EmailFieldElementEvents {
     /**
      * A callback fired when the email field loses focus.
@@ -82,11 +75,7 @@ export interface EmailFieldElementEvents {
      */
     input?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The email field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface EmailFieldElementSlots {
     /**
      * Additional interactive content displayed within the field. Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form.d.ts
@@ -38,10 +38,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-form";
-/**
- * Configure the following properties on the form component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface FormElementProps extends Pick<FormProps$1, 'disabled' | 'id'> {
 }
 export interface FormEvents extends Pick<FormProps$1, 'onSubmit'> {
@@ -50,11 +47,7 @@ export interface FormEvents extends Pick<FormProps$1, 'onSubmit'> {
      */
     onSubmit?: () => void;
 }
-/**
- * The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface FormElementEvents {
     /**
      * A callback fired when the form is submitted.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid.d.ts
@@ -102,9 +102,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-grid";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface GridElementProps extends Pick<GridProps$1, 'accessibilityLabel' | 'accessibilityRole' | 'accessibilityVisibility' | 'alignContent' | 'alignItems' | 'background' | 'blockSize' | 'border' | 'borderColor' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'columnGap' | 'display' | 'gap' | 'gridTemplateColumns' | 'gridTemplateRows' | 'id' | 'inlineSize' | 'justifyContent' | 'justifyItems' | 'maxBlockSize' | 'maxInlineSize' | 'minBlockSize' | 'minInlineSize' | 'overflow' | 'padding' | 'paddingBlock' | 'paddingBlockEnd' | 'paddingBlockStart' | 'paddingInline' | 'paddingInlineEnd' | 'paddingInlineStart' | 'placeContent' | 'placeItems' | 'rowGap'> {
     /**
      * Controls how the grid's rows are distributed along the block (column) axis when there is extra space. Set to an empty string to use the default.

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem.d.ts
@@ -46,9 +46,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-grid-item";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface GridItemElementProps extends Pick<GridItemProps$1, 'accessibilityLabel' | 'accessibilityRole' | 'accessibilityVisibility' | 'background' | 'blockSize' | 'border' | 'borderColor' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'display' | 'gridColumn' | 'gridRow' | 'id' | 'inlineSize' | 'maxBlockSize' | 'maxInlineSize' | 'minBlockSize' | 'minInlineSize' | 'overflow' | 'padding' | 'paddingBlock' | 'paddingBlockEnd' | 'paddingBlockStart' | 'paddingInline' | 'paddingInlineEnd' | 'paddingInlineStart'> {
     /**
      * The background color of the grid item.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-heading";
-/**
- * The element props interface for the Heading component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface HeadingElementProps extends Pick<HeadingProps$1, 'accessibilityRole' | 'id'> {
 }
 export interface HeadingElement extends HeadingElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link.d.ts
@@ -38,20 +38,14 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-link";
-/**
- * Configure the following properties on the link component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface LinkElementProps extends Pick<LinkProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'href' | 'id' | 'interestFor' | 'lang' | 'target' | 'tone'> {
     target?: Extract<LinkProps$1['target'], 'auto' | '_blank'>;
     tone?: Extract<LinkProps$1['tone'], 'auto' | 'neutral'>;
 }
 export interface LinkEvents extends Pick<LinkProps$1, 'onClick'> {
 }
-/**
- * The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface LinkElementEvents {
     /**
      * A callback fired when the link is clicked, before navigating to the location specified by `href`.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ListItem.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-list-item";
-/**
- * The element props interface for the ListItem component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ListItemElementProps extends Pick<ListItemProps$1, 'id'> {
 }
 export interface ListItemElement extends ListItemElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
@@ -68,10 +68,7 @@ export interface MapMarkerElementEvents {
      */
     click?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The named slots for the map marker component. Slots allow you to insert custom content into specific areas of the marker.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MapMarkerElementSlots {
     /**
      * A custom graphic element to use as the marker. If not provided, the map provider’s default marker pin is displayed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MoneyField.d.ts
@@ -32,19 +32,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-money-field";
-/**
- * Configure the following properties on the money field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MoneyFieldElementProps extends Pick<MoneyFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'max' | 'min' | 'name' | 'readOnly' | 'required' | 'step' | 'value'> {
 }
 export interface MoneyFieldEvents extends Pick<MoneyFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface MoneyFieldElementEvents {
     /**
      * A callback fired when the money field loses focus.

--- a/packages/ui-extensions/src/surfaces/checkout/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/NumberField.d.ts
@@ -68,10 +68,7 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-number-field";
-/**
- * Configure the following properties on the number field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface NumberFieldElementProps extends Pick<NumberFieldProps$1, 'autocomplete' | 'controls' | 'defaultValue' | 'disabled' | 'error' | 'icon' | 'inputMode' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'max' | 'min' | 'name' | 'prefix' | 'readOnly' | 'required' | 'step' | 'suffix' | 'value'> {
     icon?: IconProps['type'];
     /**
@@ -82,11 +79,7 @@ export interface NumberFieldElementProps extends Pick<NumberFieldProps$1, 'autoc
 }
 export interface NumberFieldEvents extends Pick<NumberFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface NumberFieldElementEvents {
     /**
      * A callback fired when the number field loses focus.
@@ -113,11 +106,7 @@ export interface NumberFieldElementEvents {
      */
     input?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The number field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface NumberFieldElementSlots {
     /**
      * Additional interactive content displayed within the field. Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Option.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-option";
-/**
- * Configure the following properties on the option component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface OptionElementProps extends Pick<OptionProps$1, 'accessibilityLabel' | 'defaultSelected' | 'disabled' | 'id' | 'selected' | 'value'> {
 }
 export interface OptionElement extends OptionElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-ordered-list";
-/**
- * The element props interface for the OrderedList component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface OrderedListElementProps extends OrderedListProps$1 {
 }
 export interface OrderedListElement extends OrderedListElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-paragraph";
-/**
- * The element props interface for the Paragraph component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ParagraphElementProps extends Pick<ParagraphProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'id' | 'lang' | 'tone' | 'type'> {
     color?: Extract<ParagraphProps$1['color'], 'subdued' | 'base'>;
     tone?: Extract<ParagraphProps$1['tone'], 'auto' | 'info' | 'success' | 'warning' | 'critical' | 'neutral' | 'custom'>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PasswordField.d.ts
@@ -38,19 +38,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-password-field";
-/**
- * Configure the following properties on the password field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PasswordFieldElementProps extends Pick<PasswordFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'maxLength' | 'minLength' | 'name' | 'readOnly' | 'required' | 'value'> {
 }
 export interface PasswordFieldEvents extends Pick<PasswordFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface PasswordFieldElementEvents {
     /**
      * A callback fired when the password field loses focus.
@@ -77,11 +70,7 @@ export interface PasswordFieldElementEvents {
      */
     input?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The password field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface PasswordFieldElementSlots {
     /**
      * Additional interactive content displayed within the field. Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField.d.ts
@@ -38,10 +38,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-phone-field";
-/**
- * Configure the following properties on the phone field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldElementProps extends Pick<PhoneFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'name' | 'readOnly' | 'required' | 'value' | 'type'> {
     /**
      * @deprecated Use `label` instead.
@@ -51,11 +48,7 @@ export interface PhoneFieldElementProps extends Pick<PhoneFieldProps$1, 'autocom
 }
 export interface PhoneFieldEvents extends Pick<PhoneFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The phone field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldElementEvents {
     /**
      * A callback fired when the phone field loses focus.
@@ -82,11 +75,7 @@ export interface PhoneFieldElementEvents {
      */
     input?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The phone field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldElementSlots {
     /**
      * Additional interactive content displayed within the field. Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PressButton.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PressButton.d.ts
@@ -38,18 +38,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-press-button";
-/**
- * Configure the following properties on the press button component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PressButtonElementProps extends Pick<PressButtonProps$1, 'accessibilityLabel' | 'id' | 'inlineSize' | 'lang' | 'disabled' | 'loading' | 'pressed' | 'defaultPressed'> {
 }
 export interface PressButtonEvents extends Pick<PressButtonProps$1, 'onClick' | 'onBlur' | 'onFocus'> {
 }
-/**
- * The press button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface PressButtonElementEvents {
     /**
      * A callback fired when the button is clicked.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress.d.ts
@@ -20,9 +20,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-progress";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface ProgressElementProps extends Pick<ProgressProps$1, 'accessibilityLabel' | 'id' | 'max' | 'tone' | 'value'> {
     /**
      * A label announced by assistive technologies that describes what is progressing. Use this to provide context about the ongoing task, such as "Loading order details" or "Uploading file".

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox.d.ts
@@ -46,9 +46,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-scroll-box";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface ScrollBoxElementProps extends Pick<ScrollBoxProps$1, 'accessibilityLabel' | 'accessibilityRole' | 'accessibilityVisibility' | 'background' | 'blockSize' | 'border' | 'borderColor' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'display' | 'id' | 'inlineSize' | 'maxBlockSize' | 'maxInlineSize' | 'minBlockSize' | 'minInlineSize' | 'overflow' | 'padding' | 'paddingBlock' | 'paddingBlockEnd' | 'paddingBlockStart' | 'paddingInline' | 'paddingInlineEnd' | 'paddingInlineStart'> {
     /**
      * The background color of the scroll box.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select.d.ts
@@ -38,19 +38,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-select";
-/**
- * Configure the following properties on the select component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SelectElementProps extends Pick<SelectProps$1, 'autocomplete' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'placeholder' | 'required' | 'value'> {
 }
 export interface SelectEvents extends Pick<SelectProps$1, 'onBlur' | 'onChange' | 'onFocus'> {
 }
-/**
- * The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface SelectElementEvents {
     /**
      * A callback fired when the select loses focus.

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph.d.ts
@@ -20,10 +20,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-skeleton-paragraph";
-/**
- * The element props interface for the SkeletonParagraph component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SkeletonParagraphElementProps extends SkeletonParagraphProps$1 {
 }
 export interface SkeletonParagraphElement extends SkeletonParagraphElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner.d.ts
@@ -20,9 +20,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-spinner";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface SpinnerElementProps extends SpinnerProps$1 {
     /**
      * A label that describes the purpose of the spinner for assistive technologies like screen readers. Provide an `accessibilityLabel` when there is no visible text that conveys a loading state.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stack.d.ts
@@ -46,9 +46,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-stack";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface StackElementProps extends Pick<StackProps$1, 'accessibilityLabel' | 'accessibilityRole' | 'alignContent' | 'alignItems' | 'background' | 'blockSize' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'columnGap' | 'direction' | 'display' | 'gap' | 'id' | 'inlineSize' | 'justifyContent' | 'maxBlockSize' | 'maxInlineSize' | 'minBlockSize' | 'minInlineSize' | 'overflow' | 'padding' | 'paddingBlock' | 'paddingBlockEnd' | 'paddingBlockStart' | 'paddingInline' | 'paddingInlineEnd' | 'paddingInlineStart' | 'rowGap'> {
     /**
      * The semantic meaning of the stack's content, used by assistive technologies.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Summary.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Summary.d.ts
@@ -11,10 +11,7 @@
 import type {SummaryProps$1} from './components-shared.d.ts';
 
 declare const tagName = "s-summary";
-/**
- * The element props interface for the Summary component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SummaryElementProps extends Pick<SummaryProps$1, 'id'> {
 }
 export interface SummaryElement extends SummaryElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Switch.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Switch.d.ts
@@ -32,20 +32,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-switch";
-/**
- * Configure the following properties on the switch component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SwitchElementProps extends Pick<SwitchProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'id' | 'label' | 'name' | 'value'> {
     command?: Extract<SwitchProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
 }
 export interface SwitchEvents extends Pick<SwitchProps$1, 'onChange'> {
 }
-/**
- * The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface SwitchElementEvents {
     /**
      * A callback fired when the switch value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-text";
-/**
- * The element props interface for the Text component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextElementProps extends Pick<TextProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'display' | 'id' | 'lang' | 'tone' | 'type'> {
     color?: Extract<TextProps$1['color'], 'subdued' | 'base'>;
     tone?: Extract<TextProps$1['tone'], 'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'custom'>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextArea.d.ts
@@ -32,10 +32,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-text-area";
-/**
- * Configure the following properties on the text area component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextAreaElementProps extends Pick<TextAreaProps$1, 'id' | 'label' | 'name' | 'required' | 'value' | 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'readOnly' | 'rows' | 'maxLength' | 'minLength' | 'labelAccessibilityVisibility'> {
     /**
      * @deprecated Use `label` instead.
@@ -45,11 +42,7 @@ export interface TextAreaElementProps extends Pick<TextAreaProps$1, 'id' | 'labe
 }
 export interface TextAreaEvents extends Pick<TextAreaProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextAreaElementEvents {
     /**
      * A callback fired when the text area loses focus.

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField.d.ts
@@ -68,10 +68,7 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-text-field";
-/**
- * Configure the following properties on the text field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextFieldElementProps extends Pick<TextFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'icon' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'maxLength' | 'minLength' | 'name' | 'prefix' | 'readOnly' | 'required' | 'suffix' | 'value'> {
     icon?: IconProps['type'];
     /**
@@ -82,11 +79,7 @@ export interface TextFieldElementProps extends Pick<TextFieldProps$1, 'autocompl
 }
 export interface TextFieldEvents extends Pick<TextFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextFieldElementEvents {
     /**
      * A callback fired when the text field loses focus.
@@ -113,11 +106,7 @@ export interface TextFieldElementEvents {
      */
     input?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextFieldElementSlots {
     /**
      * Additional interactive content displayed within the field. Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Time.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Time.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-time";
-/**
- * The element props interface for the Time component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TimeElementProps extends Pick<TimeProps$1, 'dateTime' | 'id'> {
 }
 export interface TimeElement extends TimeElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList.d.ts
@@ -26,10 +26,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-unordered-list";
-/**
- * The element props interface for the UnorderedList component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface UnorderedListElementProps extends UnorderedListProps$1 {
 }
 export interface UnorderedListElement extends UnorderedListElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/UrlField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UrlField.d.ts
@@ -38,19 +38,12 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-url-field";
-/**
- * Configure the following properties on the URL field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface URLFieldElementProps extends Pick<URLFieldProps, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'maxLength' | 'minLength' | 'name' | 'readOnly' | 'required' | 'value'> {
 }
 export interface UrlFieldEvents extends Pick<URLFieldProps, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface URLFieldElementEvents {
     /**
      * A callback fired when the URL field loses focus.
@@ -77,11 +70,7 @@ export interface URLFieldElementEvents {
      */
     input?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The URL field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- *
- * @publicDocs
- */
+/** @publicDocs */
 export interface URLFieldElementSlots {
     /**
      * Additional interactive content displayed within the field. Accepts button and clickable components with text content only. Other component types or complex layouts are not supported.


### PR DESCRIPTION
## Summary
Removes all interface-level intro descriptions from `@publicDocs` Props, Events, Slots, and Methods interfaces across all 49 shared checkout component `.d.ts` files. These intro sentences will be added in world instead, allowing surface-specific customization for CA vs CO.

Interfaces are reduced to bare `/** @publicDocs */` tags. Property-level JSDoc descriptions remain unchanged.

**49 files changed**, 357 lines of intro text removed.

## Test plan
- [ ] `yarn build` passes
- [ ] Verify no property-level descriptions were affected
- [ ] Verify generated docs still render correctly after regen


Made with [Cursor](https://cursor.com)