### PR TITLE
Remove Props/Events/Slots intro sentences from shared .d.ts files (2025-10)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Abbreviation.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {AbbreviationProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-abbreviation";
-/**
- * Configure the following properties on the abbreviation component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface AbbreviationProps extends Pick<AbbreviationProps$1, 'title' | 'id'> {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Announcement.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Announcement.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {AnnouncementProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -65,9 +62,7 @@ declare const tagName = "s-announcement";
 /** @publicDocs */
 export interface AnnouncementEvents extends Pick<AnnouncementProps$1, 'onAfterToggle' | 'onDismiss' | 'onToggle'> {
 }
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface AnnouncementElementEvents {
     /**
      * A callback that fires when the element state changes, after any toggle animations have finished.
@@ -112,9 +107,7 @@ export interface AnnouncementMethods {
      */
     dismiss: () => void;
 }
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface AnnouncementElementMethods {
     /**
      * Programmatically dismisses the announcement. This triggers the `dismiss` event callback.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {BadgeProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -37,9 +34,7 @@ declare const CHECKOUT_AVAILABLE_ICONS: readonly ["alert-circle", "alert-triangl
 export type ReducedIconTypes = (typeof CHECKOUT_AVAILABLE_ICONS)[number];
 
 declare const tagName = "s-badge";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BadgeProps extends Pick<BadgeProps$1, 'color' | 'icon' | 'iconPosition' | 'id' | 'size' | 'tone'> {
     /**
      * The size of the badge.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {BannerProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,9 +39,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-banner";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BannerElementProps extends Pick<BannerProps$1, 'collapsible' | 'dismissible' | 'heading' | 'hidden' | 'id' | 'tone'> {
     /**
      * Whether the banner content can be collapsed and expanded by the user. A collapsible banner conceals child elements initially, allowing the user to expand the banner to reveal them.
@@ -98,9 +93,7 @@ export interface BannerElementProps extends Pick<BannerProps$1, 'collapsible' | 
 /** @publicDocs */
 export interface BannerEvents extends Pick<BannerProps$1, 'onAfterHide' | 'onDismiss'> {
 }
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BannerElementEvents {
     /**
      * A callback that fires when the banner has fully hidden, including after any hide animations have completed.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Box.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Box.d.ts
@@ -33,10 +33,7 @@ export type ReducedColorKeyword = Extract<ColorKeyword, 'base'>;
  * @publicDocs
  */
 export type BorderShorthand = ReducedBorderSizeKeyword | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword}` | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword} ${BorderStyleKeyword}`;
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ButtonProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,12 +39,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-button";
-/**
- * The button component triggers actions or events, such as submitting forms, opening dialogs, or navigating to other pages. Use buttons to let users perform specific tasks or initiate interactions throughout the interface.
- *
- * Buttons support various visual styles, tones, and interaction patterns to communicate intent and hierarchy. They can also function as links, guiding users to internal or external destinations. For navigation-focused interactions within text, use [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link). For grouping multiple related buttons, use [button group](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button-group).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'disabled' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'loading' | 'target' | 'tone' | 'type' | 'variant'> {
     target?: Extract<ButtonProps$1['target'], 'auto' | '_blank'>;
     tone?: Extract<ButtonProps$1['tone'], 'auto' | 'neutral' | 'critical'>;
@@ -57,10 +49,7 @@ export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLa
 /** @publicDocs */
 export interface ButtonEvents extends Pick<ButtonProps$1, 'onClick'> {
 }
-/**
- * The button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ButtonElementEvents {
     /**
      * A callback fired when the button is clicked. This will be called before the action indicated by `type`.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {CheckboxProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,20 +32,14 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-checkbox";
-/**
- * Configure the following properties on the checkbox component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface CheckboxElementProps extends Pick<CheckboxProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'required' | 'value'> {
     command?: Extract<CheckboxProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
 }
 /** @publicDocs */
 export interface CheckboxEvents extends Pick<CheckboxProps$1, 'onChange'> {
 }
-/**
- * The checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface CheckboxElementEvents {
     /**
      * A callback fired when the checkbox value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Chip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Chip.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ChipProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,16 +25,10 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-chip";
-/**
- * Configure the following properties on the chip component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChipElementProps extends Pick<ChipProps$1, 'accessibilityLabel' | 'id'> {
 }
-/**
- * The chip component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChipElementSlots {
     /**
      * The graphic to display inside of the chip.
@@ -46,12 +37,7 @@ export interface ChipElementSlots {
      */
     graphic?: HTMLElement;
 }
-/**
- * The chip component displays static labels, categories, or attributes that help classify and organize content. Use chip to show product tags, categories, or metadata near the items they describe, helping users identify items with similar properties.
- *
- * Chips support multiple visual variants for different levels of emphasis and can include icons to provide additional visual context. For system-generated status indicators, use [badge](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/feedback-and-status-indicators/badge). For interactive or removable chips, use [clickable chip](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/clickable-chip).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChipProps extends ChipElementProps {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Choice.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Choice.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ChoiceProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,16 +25,10 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-choice";
-/**
- * Configure the following properties on the choice component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceProps extends Pick<ChoiceProps$1, 'accessibilityLabel' | 'defaultSelected' | 'disabled' | 'id' | 'selected' | 'error' | 'value'> {
 }
-/**
- * The choice component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceElementSlots {
     /**
      * Additional text to provide context or guidance for the input.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ChoiceListProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,19 +39,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-choice-list";
-/**
- * Configure the following properties on the choice list component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceListElementProps extends Pick<ChoiceListProps$1, 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'multiple' | 'name' | 'values' | 'variant'> {
 }
 /** @publicDocs */
 export interface ChoiceListEvents extends Pick<ChoiceListProps$1, 'onChange'> {
 }
-/**
- * The choice list component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceListElementEvents {
     /**
      * A callback fired when the choice list selection changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Clickable.d.ts
@@ -33,10 +33,7 @@ export type ReducedColorKeyword = Extract<ColorKeyword, 'base'>;
  * @publicDocs
  */
 export type BorderShorthand = ReducedBorderSizeKeyword | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword}` | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword} ${BorderStyleKeyword}`;
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -65,12 +62,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-clickable";
-/**
- * The clickable component wraps content to make it interactive and clickable. Use it when you need more styling control than [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) or [link](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/link) provide, such as custom backgrounds, padding, or borders around your clickable content.
- *
- * Clickable supports button, link, and submit modes with built-in accessibility properties for keyboard navigation and screen reader support.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableElementProps extends Pick<ClickableProps$1, 'accessibilityLabel' | 'accessibilityVisibility' | 'background' | 'blockSize' | 'border' | 'borderRadius' | 'borderStyle' | 'borderWidth' | 'command' | 'commandFor' | 'disabled' | 'display' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'lang' | 'loading' | 'maxBlockSize' | 'maxInlineSize' | 'minBlockSize' | 'minInlineSize' | 'overflow' | 'padding' | 'paddingBlock' | 'paddingBlockEnd' | 'paddingBlockStart' | 'paddingInline' | 'paddingInlineEnd' | 'paddingInlineStart' | 'target' | 'type'> {
     background?: Extract<ClickableProps$1['background'], 'transparent' | 'subdued' | 'base'>;
     border?: BorderShorthand;
@@ -82,10 +74,7 @@ export interface ClickableElementProps extends Pick<ClickableProps$1, 'accessibi
 /** @publicDocs */
 export interface ClickableEvents extends Pick<ClickableProps$1, 'onBlur' | 'onClick' | 'onFocus'> {
 }
-/**
- * The clickable component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableElementEvents {
     /**
      * A callback fired when the component loses focus.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClickableChip.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ClickableChipProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,19 +39,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-clickable-chip";
-/**
- * Configure the following properties on the clickable chip component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableChipElementProps extends Pick<ClickableChipProps$1, 'accessibilityLabel' | 'disabled' | 'hidden' | 'href' | 'id' | 'removable'> {
 }
 /** @publicDocs */
 export interface ClickableChipEvents extends Pick<ClickableChipProps$1, 'onAfterHide' | 'onClick' | 'onRemove'> {
 }
-/**
- * The clickable chip component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableChipElementEvents {
     /**
      * A callback fired after the chip is hidden. The `hidden` property will be `true` when this event fires.
@@ -71,10 +62,7 @@ export interface ClickableChipElementEvents {
      */
     remove?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The clickable chip component supports slots for additional content placement. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClickableChipElementSlots {
     /**
      * The graphic to display inside of the chip.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ClipboardItemProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,19 +32,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-clipboard-item";
-/**
- * Enables copying text to the user’s clipboard. Use alongside Button or Link components to let users easily copy content. `<s-clipboard-item>` doesn’t render visually.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClipboardItemElementProps extends Pick<ClipboardItemProps$1, 'id' | 'text'> {
 }
 /** @publicDocs */
 export interface ClipboardItemEvents extends Pick<ClipboardItemProps$1, 'onCopy' | 'onCopyError'> {
 }
-/**
- * The clipboard item component provides event callbacks for handling copy interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClipboardItemElementEvents {
     /**
      * A callback fired when the text is successfully copied to the clipboard. Use this to show a confirmation message or update the UI.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ConsentCheckboxProps$1,CheckboxProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,10 +32,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName$1 = "s-checkbox";
-/**
- * Configure the following properties on the checkbox component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface CheckboxElementProps extends Pick<CheckboxProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'required' | 'value'> {
     command?: Extract<CheckboxProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
 }
@@ -66,20 +60,14 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-consent-checkbox";
-/**
- * Configure the following properties on the consent checkbox component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentCheckboxElementProps extends Pick<ConsentCheckboxProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'policy' | 'value'> {
     command?: Extract<ConsentCheckboxProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
 }
 /** @publicDocs */
 export interface ConsentCheckboxEvents extends Pick<CheckboxEvents, 'onChange'> {
 }
-/**
- * The consent checkbox component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentCheckboxElementEvents {
     /**
      * A callback fired when the consent checkbox value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {PhoneFieldProps$1, ConsentPhoneFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,10 +39,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName$1 = "s-phone-field";
-/**
- * Configure the following properties on the phone field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldElementProps extends Pick<PhoneFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'name' | 'readOnly' | 'required' | 'value' | 'type'> {
     /**
      * @deprecated Use `label` instead.
@@ -80,10 +74,7 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-consent-phone-field";
-/**
- * Configure the following properties on the consent phone field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentPhoneFieldElementProps extends Pick<ConsentPhoneFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'name' | 'policy' | 'readOnly' | 'required' | 'type' | 'value'> {
     /**
      * @deprecated Use `label` instead.
@@ -94,10 +85,7 @@ export interface ConsentPhoneFieldElementProps extends Pick<ConsentPhoneFieldPro
 /** @publicDocs */
 export interface ConsentPhoneFieldEvents extends Pick<PhoneFieldEvents, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The consent phone field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentPhoneFieldElementEvents {
     /**
 <<<<<<< HEAD
@@ -147,10 +135,7 @@ export interface ConsentPhoneFieldElement extends ConsentPhoneFieldElementProps,
     onfocus: ConsentPhoneFieldEvents['onFocus'];
     oninput: ConsentPhoneFieldEvents['onInput'];
 }
-/**
- * The consent phone field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentPhoneFieldElementSlots {
     /**
      * Additional interactive content displayed within the field.

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {DateFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,10 +32,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-date-field";
-/**
- * Configure the following properties on the date field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DateFieldElementProps extends Pick<DateFieldProps$1, 'allow' | 'allowDays' | 'autocomplete' | 'defaultValue' | 'defaultView' | 'disabled' | 'disallow' | 'disallowDays' | 'error' | 'id' | 'label' | 'name' | 'readOnly' | 'required' | 'value' | 'view'> {
     /**
      * @deprecated Use `label` instead.
@@ -49,10 +43,7 @@ export interface DateFieldElementProps extends Pick<DateFieldProps$1, 'allow' | 
 /** @publicDocs */
 export interface DateFieldEvents extends Pick<DateFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput' | 'onInvalid' | 'onViewChange'> {
 }
-/**
- * The date field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface DateFieldElementEvents {
     /**
 <<<<<<< HEAD

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {DatePickerProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,19 +32,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-date-picker";
-/**
- * Configure the following properties on the date picker component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DatePickerElementProps extends Pick<DatePickerProps$1, 'allow' | 'allowDays' | 'defaultValue' | 'defaultView' | 'disabled' | 'disallow' | 'disallowDays' | 'id' | 'name' | 'type' | 'value' | 'view'> {
 }
 /** @publicDocs */
 export interface DatePickerEvents extends Pick<DatePickerProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput' | 'onViewChange'> {
 }
-/**
- * The date picker component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface DatePickerElementEvents {
     /**
 <<<<<<< HEAD

--- a/packages/ui-extensions/src/surfaces/checkout/components/Details.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Details.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {DetailsProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -49,19 +46,13 @@ export interface ToggleArgumentsEvent {
 }
 
 declare const tagName = "s-details";
-/**
- * Configure the following properties on the details component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DetailsElementProps extends Pick<DetailsProps$1, 'defaultOpen' | 'id' | 'open' | 'toggleTransition'> {
 }
 /** @publicDocs */
 export interface DetailsEvents extends Pick<DetailsProps$1, 'onToggle' | 'onAfterToggle'> {
 }
-/**
- * The details component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface DetailsElementEvents {
     /**
      * A callback fired immediately when the element state changes, before any animations.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Divider.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Divider.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {DividerProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/DropZone.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DropZone.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {DropZoneProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,19 +32,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-drop-zone";
-/**
- * Configure the following properties on the drop zone component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DropZoneElementProps extends Pick<DropZoneProps$1, 'accept' | 'accessibilityLabel' | 'disabled' | 'error' | 'id' | 'label' | 'multiple' | 'name' | 'required' | 'value'> {
 }
 /** @publicDocs */
 export interface DropZoneEvents extends Pick<DropZoneProps$1, 'onDropRejected' | 'onInput' | 'onChange'> {
 }
-/**
- * The drop zone component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface DropZoneElementEvents {
     /**
      * A callback fired when the drop zone value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/EmailField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/EmailField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {EmailFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,10 +39,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-email-field";
-/**
- * Configure the following properties on the email field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface EmailFieldElementProps extends Pick<EmailFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'maxLength' | 'minLength' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'name' | 'readOnly' | 'required' | 'value'> {
     /**
      * @deprecated Use `label` instead.
@@ -56,10 +50,7 @@ export interface EmailFieldElementProps extends Pick<EmailFieldProps$1, 'autocom
 /** @publicDocs */
 export interface EmailFieldEvents extends Pick<EmailFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The email field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface EmailFieldElementEvents {
     /**
 <<<<<<< HEAD
@@ -102,10 +93,7 @@ export interface EmailFieldElementEvents {
      */
     focus?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The email field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface EmailFieldElementSlots {
     /**
      * Additional interactive content displayed within the field.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {FormProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,10 +39,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-form";
-/**
- * Configure the following properties on the form component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface FormElementProps extends Pick<FormProps$1, 'disabled' | 'id'> {
 }
 /** @publicDocs */
@@ -55,10 +49,7 @@ export interface FormEvents extends Pick<FormProps$1, 'onSubmit'> {
      */
     onSubmit?: () => void;
 }
-/**
- * The form component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface FormElementEvents {
     /**
      * A callback fired when the form is submitted.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid.d.ts
@@ -89,10 +89,7 @@ export type ReducedColorKeyword = Extract<ColorKeyword, 'base'>;
  * @publicDocs
  */
 export type BorderShorthand = ReducedBorderSizeKeyword | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword}` | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword} ${BorderStyleKeyword}`;
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem.d.ts
@@ -33,10 +33,7 @@ export type ReducedColorKeyword = Extract<ColorKeyword, 'base'>;
  * @publicDocs
  */
 export type BorderShorthand = ReducedBorderSizeKeyword | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword}` | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword} ${BorderStyleKeyword}`;
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {HeadingProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-heading";
-/**
- * Configure the following properties on the heading component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface HeadingProps extends Pick<HeadingProps$1, 'accessibilityRole' | 'id'> {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Icon.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {IconProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Image.d.ts
@@ -33,10 +33,7 @@ export type ReducedColorKeyword = Extract<ColorKeyword, 'base'>;
  * @publicDocs
  */
 export type BorderShorthand = ReducedBorderSizeKeyword | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword}` | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword} ${BorderStyleKeyword}`;
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {LinkProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,12 +39,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-link";
-/**
- * The link component makes text interactive, allowing users to navigate to other pages or perform specific actions. Use link for navigation, external references, or triggering actions while maintaining standard link semantics and accessibility.
- *
- * Links support standard URLs, custom protocols, navigation within Shopify admin pages, and can open in new windows for external destinations. For prominent actions or form submissions, use [button](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/actions/button) instead.
- * @publicDocs
- */
+/** @publicDocs */
 export interface LinkElementProps extends Pick<LinkProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'href' | 'id' | 'interestFor' | 'lang' | 'target' | 'tone'> {
     target?: Extract<LinkProps$1['target'], 'auto' | '_blank'>;
     tone?: Extract<LinkProps$1['tone'], 'auto' | 'neutral'>;
@@ -55,10 +47,7 @@ export interface LinkElementProps extends Pick<LinkProps$1, 'accessibilityLabel'
 /** @publicDocs */
 export interface LinkEvents extends Pick<LinkProps$1, 'onClick'> {
 }
-/**
- * The link component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface LinkElementEvents {
     /**
      * A callback fired when the link is clicked, before navigating to the location specified by `href`.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ListItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ListItem.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ListItemProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-list-item";
-/**
- * Configure the following properties on the list item component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ListItemProps extends Pick<ListItemProps$1, 'id'> {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Map.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {MapProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.
@@ -57,10 +54,7 @@ declare const tagName = "s-map";
 /** @publicDocs */
 export interface MapElementProps extends Pick<MapProps$1, 'accessibilityLabel' | 'apiKey' | 'blockSize' | 'id' | 'inlineSize' | 'latitude' | 'longitude' | 'maxBlockSize' | 'maxInlineSize' | 'maxZoom' | 'minBlockSize' | 'minInlineSize' | 'minZoom' | 'zoom'> {
 }
-/**
- * The event handlers for the map component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MapEvents extends Pick<MapProps$1, 'onBoundsChange' | 'onClick' | 'onDblClick' | 'onViewChange'> {
 }
 /**
@@ -145,10 +139,7 @@ export interface MapElement extends MapElementProps, Omit<HTMLElement, 'id' | 'o
     ondblclick: MapEvents['onDblClick'];
     onviewchange: MapEvents['onViewChange'];
 }
-/**
- * The properties for the map component when it's used in JSX.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MapProps extends MapElementProps, MapEvents {
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MapMarker.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {MapMarkerProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -60,10 +57,7 @@ export interface MapMarkerElementProps extends Pick<MapMarkerProps$1, 'accessibi
      */
     commandFor?: MapMarkerProps$1['commandFor'];
 }
-/**
- * The event handlers for the map marker component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MapMarkerEvents extends Pick<MapMarkerProps$1, 'onClick'> {
 }
 /** @publicDocs */
@@ -73,10 +67,7 @@ export interface MapMarkerElementEvents {
      */
     click?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The named slots for the map marker component. Slots allow you to insert custom content into specific areas of the marker.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MapMarkerElementSlots {
     /**
      * A custom graphic element to use as the marker. If not provided, the map provider’s default marker pin is displayed.
@@ -90,10 +81,7 @@ export interface MapMarkerElementSlots {
 export interface MapMarkerElement extends MapMarkerElementProps, Omit<HTMLElement, 'id' | 'onclick'> {
     onclick: MapMarkerEvents['onClick'];
 }
-/**
- * The properties for the map marker component when it's used in JSX.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MapMarkerProps extends MapMarkerElementProps, MapMarkerEvents {
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Modal.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ModalProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.
@@ -81,10 +78,7 @@ export interface ModalElementSlots {
      */
     'secondary-actions'?: HTMLElement;
 }
-/**
- * The event callbacks for monitoring modal visibility changes.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ModalEvents extends Pick<ModalProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
 /** @publicDocs */
@@ -119,10 +113,7 @@ export interface ModalElement extends ModalElementProps, ModalElementMethods, Om
     onhide: ModalEvents['onHide'];
     onshow: ModalEvents['onShow'];
 }
-/**
- * The properties for the modal component when it's used in JSX.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ModalProps extends ModalElementProps, ModalEvents {
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/MoneyField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/MoneyField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {MoneyFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,19 +32,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-money-field";
-/**
- * Configure the following properties on the money field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface MoneyFieldElementProps extends Pick<MoneyFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'max' | 'min' | 'name' | 'readOnly' | 'required' | 'step' | 'value'> {
 }
 /** @publicDocs */
 export interface MoneyFieldEvents extends Pick<MoneyFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The money field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface MoneyFieldElementEvents {
     /**
 <<<<<<< HEAD

--- a/packages/ui-extensions/src/surfaces/checkout/components/NumberField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/NumberField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {IconProps$1, NumberFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -73,10 +70,7 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-number-field";
-/**
- * Configure the following properties on the number field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface NumberFieldElementProps extends Pick<NumberFieldProps$1, 'autocomplete' | 'controls' | 'defaultValue' | 'disabled' | 'error' | 'icon' | 'inputMode' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'max' | 'min' | 'name' | 'prefix' | 'readOnly' | 'required' | 'step' | 'suffix' | 'value'> {
     icon?: IconProps['type'];
     /**
@@ -88,10 +82,7 @@ export interface NumberFieldElementProps extends Pick<NumberFieldProps$1, 'autoc
 /** @publicDocs */
 export interface NumberFieldEvents extends Pick<NumberFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The number field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface NumberFieldElementEvents {
     /**
 <<<<<<< HEAD
@@ -134,10 +125,7 @@ export interface NumberFieldElementEvents {
      */
     focus?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The number field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface NumberFieldElementSlots {
     /**
      * Additional interactive content displayed within the field.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Option.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Option.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {OptionProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-option";
-/**
- * Configure the following properties on the option component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface OptionProps extends Pick<OptionProps$1, 'accessibilityLabel' | 'defaultSelected' | 'disabled' | 'id' | 'selected' | 'value'> {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/OrderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/OrderedList.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {OrderedListProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-ordered-list";
-/**
- * Configure the following properties on the ordered list component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface OrderedListProps extends OrderedListProps$1 {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Paragraph.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ParagraphProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-paragraph";
-/**
- * Configure the following properties on the paragraph component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ParagraphProps extends Pick<ParagraphProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'id' | 'lang' | 'tone' | 'type'> {
     color?: Extract<ParagraphProps$1['color'], 'subdued' | 'base'>;
     tone?: Extract<ParagraphProps$1['tone'], 'auto' | 'info' | 'success' | 'warning' | 'critical' | 'neutral' | 'custom'>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/PasswordField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PasswordField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {PasswordFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,19 +39,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-password-field";
-/**
- * Configure the following properties on the password field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PasswordFieldElementProps extends Pick<PasswordFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'maxLength' | 'minLength' | 'name' | 'readOnly' | 'required' | 'value'> {
 }
 /** @publicDocs */
 export interface PasswordFieldEvents extends Pick<PasswordFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The password field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface PasswordFieldElementEvents {
     /**
 <<<<<<< HEAD
@@ -97,10 +88,7 @@ export interface PasswordFieldElementEvents {
      */
     focus?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The password field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface PasswordFieldElementSlots {
     /**
      * Additional interactive content displayed within the field.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PaymentIcon.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {PaymentIconProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {PhoneFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,10 +39,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-phone-field";
-/**
- * Configure the following properties on the phone field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldElementProps extends Pick<PhoneFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'name' | 'readOnly' | 'required' | 'value' | 'type'> {
     /**
      * @deprecated Use `label` instead.
@@ -56,10 +50,7 @@ export interface PhoneFieldElementProps extends Pick<PhoneFieldProps$1, 'autocom
 /** @publicDocs */
 export interface PhoneFieldEvents extends Pick<PhoneFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The phone field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldElementEvents {
     /**
 <<<<<<< HEAD
@@ -102,10 +93,7 @@ export interface PhoneFieldElementEvents {
      */
     focus?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The phone field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldElementSlots {
     /**
      * Additional interactive content displayed within the field.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Popover.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {PopoverProps$1,SizeUnitsOrAuto, SizeUnitsOrNone, SizeUnits} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.
@@ -93,10 +90,7 @@ export interface PopoverElementProps extends Pick<PopoverProps$1, 'id'> {
      */
     minInlineSize?: SizeUnits;
 }
-/**
- * The event callbacks for monitoring popover visibility changes.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PopoverEvents extends Pick<PopoverProps$1, 'onHide' | 'onShow'> {
 }
 /** @publicDocs */
@@ -118,10 +112,7 @@ export interface PopoverElement extends Omit<PopoverProps, 'onHide' | 'onShow'>,
     onhide: PopoverProps['onHide'];
     onshow: PopoverProps['onShow'];
 }
-/**
- * The properties for the popover component when it's used in JSX.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PopoverProps extends PopoverElementProps, PopoverEvents {
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/PressButton.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PressButton.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {PressButtonProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,19 +39,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-press-button";
-/**
- * Allows users to toggle between active/inactive states. Use to represent a persistent on/off or selected/unselected status.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PressButtonElementProps extends Pick<PressButtonProps$1, 'accessibilityLabel' | 'id' | 'inlineSize' | 'lang' | 'disabled' | 'loading' | 'pressed' | 'defaultPressed'> {
 }
 /** @publicDocs */
 export interface PressButtonEvents extends Pick<PressButtonProps$1, 'onClick' | 'onBlur' | 'onFocus'> {
 }
-/**
- * The press button component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface PressButtonElementEvents {
     /**
      * A callback fired when the button is clicked.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ProductThumbnail.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ProductThumbnailProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {ProgressProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -21,9 +18,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-progress";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface ProgressProps extends Pick<ProgressProps$1, 'accessibilityLabel' | 'id' | 'max' | 'tone' | 'value'> {
     /**
      * A label announced by assistive technologies that describes what is progressing. Use this to provide context about the ongoing task, such as "Loading order details" or "Uploading file".

--- a/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QRCode.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {QRCodeProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.
@@ -47,10 +44,7 @@ declare const tagName = "s-qr-code";
 /** @publicDocs */
 export interface QRCodeElementProps extends QRCodeProps$1 {
 }
-/**
- * The event handlers for the QR code component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface QRCodeEvents extends Pick<QRCodeProps$1, 'onError'> {
 }
 /** @publicDocs */
@@ -67,10 +61,7 @@ export interface QRCodeElementEvents {
 export interface QRCodelement extends QRCodeElementProps, Omit<HTMLElement, 'id' | 'onerror'> {
     onerror: QRCodeEvents['onError'];
 }
-/**
- * The properties for the QR code component when it's used in JSX.
- * @publicDocs
- */
+/** @publicDocs */
 export interface QRCodeProps extends QRCodeElementProps, QRCodeEvents {
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/QueryContainer.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/QueryContainer.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {QueryContainerProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollBox.d.ts
@@ -33,10 +33,7 @@ export type ReducedColorKeyword = Extract<ColorKeyword, 'base'>;
  * @publicDocs
  */
 export type BorderShorthand = ReducedBorderSizeKeyword | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword}` | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword} ${BorderStyleKeyword}`;
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Section.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {SectionProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {SelectProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,19 +39,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-select";
-/**
- * Configure the following properties on the select component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SelectElementProps extends Pick<SelectProps$1, 'autocomplete' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'placeholder' | 'required' | 'value'> {
 }
 /** @publicDocs */
 export interface SelectEvents extends Pick<SelectProps$1, 'onBlur' | 'onChange' | 'onFocus'> {
 }
-/**
- * The select component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface SelectElementEvents {
     /**
 <<<<<<< HEAD

--- a/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Sheet.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {SheetProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.
@@ -61,10 +58,7 @@ export interface SheetElementProps extends Pick<SheetProps$1, 'defaultOpen' | 'h
      */
     accessibilityLabel?: string;
 }
-/**
- * The event callbacks for monitoring sheet visibility changes.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SheetEvents extends Pick<SheetProps$1, 'onAfterHide' | 'onAfterShow' | 'onHide' | 'onShow'> {
 }
 /** @publicDocs */
@@ -112,10 +106,7 @@ export interface SheetElement extends SheetElementProps, SheetElementMethods, Om
     onafterhide: SheetEvents['onAfterHide'];
     onaftershow: SheetEvents['onAfterShow'];
 }
-/**
- * The properties for the sheet component when it's used in JSX.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SheetProps extends SheetElementProps, SheetEvents {
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonParagraph.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {SkeletonParagraphProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -21,10 +18,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-skeleton-paragraph";
-/**
- * Configure the following properties on the skeleton paragraph component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SkeletonParagraphProps extends SkeletonParagraphProps$1 {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {SpinnerProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -21,9 +18,7 @@ export interface BaseElementProps<TClass = HTMLElement> {
 }
 
 declare const tagName = "s-spinner";
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface SpinnerProps extends SpinnerProps$1 {
     /**
      * A label that describes the purpose of the spinner for assistive technologies like screen readers. Provide an `accessibilityLabel` when there is no visible text that conveys a loading state.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stack.d.ts
@@ -33,10 +33,7 @@ export type ReducedColorKeyword = Extract<ColorKeyword, 'base'>;
  * @publicDocs
  */
 export type BorderShorthand = ReducedBorderSizeKeyword | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword}` | `${ReducedBorderSizeKeyword} ${ReducedColorKeyword} ${BorderStyleKeyword}`;
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/Summary.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Summary.d.ts
@@ -11,10 +11,7 @@
 import type {SummaryProps$1} from './components-shared.d.ts';
 
 declare const tagName = "s-summary";
-/**
- * Configure the following properties on the summary component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SummaryProps extends Pick<SummaryProps$1, 'id'> {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Switch.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Switch.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {SwitchProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,20 +32,14 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-switch";
-/**
- * Configure the following properties on the switch component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SwitchElementProps extends Pick<SwitchProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'id' | 'label' | 'name' | 'value'> {
     command?: Extract<SwitchProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
 }
 /** @publicDocs */
 export interface SwitchEvents extends Pick<SwitchProps$1, 'onChange'> {
 }
-/**
- * The switch component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface SwitchElementEvents {
     /**
      * A callback fired when the switch value changes.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {TextProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-text";
-/**
- * Configure the following properties on the text component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextProps extends Pick<TextProps$1, 'accessibilityVisibility' | 'color' | 'dir' | 'display' | 'id' | 'lang' | 'tone' | 'type'> {
     color?: Extract<TextProps$1['color'], 'subdued' | 'base'>;
     tone?: Extract<TextProps$1['tone'], 'auto' | 'neutral' | 'info' | 'success' | 'warning' | 'critical' | 'custom'>;

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextArea.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextArea.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {TextAreaProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -35,10 +32,7 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-text-area";
-/**
- * Configure the following properties on the text area component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextAreaElementProps extends Pick<TextAreaProps$1, 'id' | 'label' | 'name' | 'required' | 'value' | 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'readOnly' | 'rows' | 'maxLength' | 'minLength' | 'labelAccessibilityVisibility'> {
     /**
      * @deprecated Use `label` instead.
@@ -49,10 +43,7 @@ export interface TextAreaElementProps extends Pick<TextAreaProps$1, 'id' | 'labe
 /** @publicDocs */
 export interface TextAreaEvents extends Pick<TextAreaProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The text area component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextAreaElementEvents {
     /**
 <<<<<<< HEAD

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {IconProps$1, TextFieldProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -73,10 +70,7 @@ declare module 'preact' {
 }
 
 declare const tagName = "s-text-field";
-/**
- * Configure the following properties on the text field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextFieldElementProps extends Pick<TextFieldProps$1, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'icon' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'maxLength' | 'minLength' | 'name' | 'prefix' | 'readOnly' | 'required' | 'suffix' | 'value'> {
     icon?: IconProps['type'];
     /**
@@ -88,10 +82,7 @@ export interface TextFieldElementProps extends Pick<TextFieldProps$1, 'autocompl
 /** @publicDocs */
 export interface TextFieldEvents extends Pick<TextFieldProps$1, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The text field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextFieldElementEvents {
     /**
 <<<<<<< HEAD
@@ -134,10 +125,7 @@ export interface TextFieldElementEvents {
      */
     focus?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The text field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextFieldElementSlots {
     /**
      * Additional interactive content displayed within the field.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Time.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Time.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {TimeProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-time";
-/**
- * Configure the following properties on the time component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TimeProps extends Pick<TimeProps$1, 'dateTime' | 'id'> {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tooltip.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {TooltipProps$1} from './components-shared.d.ts';
 
-/**
- * The base properties for elements that don't have children, providing essential attributes like keys and refs for component management.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     /**
      * A unique identifier for this element within its parent. Used by the rendering engine for efficient reconciliation when lists change.
@@ -49,10 +46,7 @@ export interface TooltipElementProps extends Pick<TooltipProps$1, 'id'> {
  */
 export interface TooltipElement extends TooltipElementProps {
 }
-/**
- * The properties for the tooltip component when it's used in JSX.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TooltipProps extends TooltipElementProps {
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UnorderedList.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {UnorderedListProps$1} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -28,10 +25,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 }
 
 declare const tagName = "s-unordered-list";
-/**
- * Configure the following properties on the unordered list component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface UnorderedListProps extends UnorderedListProps$1 {
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/checkout/components/UrlField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/UrlField.d.ts
@@ -10,10 +10,7 @@
 /// <reference lib="DOM" />
 import type {URLFieldProps} from './components-shared.d.ts';
 
-/**
- * Used when an element does not have children.
- * @publicDocs
- */
+/** @publicDocs */
 export interface BaseElementProps<TClass = HTMLElement> {
     key?: preact.Key;
     ref?: preact.Ref<TClass>;
@@ -42,19 +39,13 @@ export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, 
 }) | null;
 
 declare const tagName = "s-url-field";
-/**
- * Configure the following properties on the URL field component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface UrlFieldElementProps extends Pick<URLFieldProps, 'autocomplete' | 'defaultValue' | 'disabled' | 'error' | 'id' | 'label' | 'labelAccessibilityVisibility' | 'maxLength' | 'minLength' | 'name' | 'readOnly' | 'required' | 'value'> {
 }
 /** @publicDocs */
 export interface UrlFieldEvents extends Pick<URLFieldProps, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
 }
-/**
- * The URL field component provides event callbacks for handling user interactions. Learn more about [handling events](/docs/api/polaris/using-polaris-web-components#handling-events).
- * @publicDocs
- */
+/** @publicDocs */
 export interface UrlFieldElementEvents {
     /**
      * A callback fired when the URL field value changes.
@@ -81,10 +72,7 @@ export interface UrlFieldElementEvents {
      */
     focus?: CallbackEventListener<typeof tagName>;
 }
-/**
- * The URL field component supports slots for additional content placement within the component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
- * @publicDocs
- */
+/** @publicDocs */
 export interface UrlFieldElementSlots {
     /**
      * Additional interactive content displayed within the field.


### PR DESCRIPTION
## Summary
Removes all interface-level intro descriptions from @publicDocs Props, Events, Slots, and Methods interfaces across shared checkout component files. These intro sentences will be added in world instead, allowing surface-specific customization for CA vs CO.

Cascaded from the 2026-04-rc version.

## Test plan
- [ ] `yarn build` passes
- [ ] Verify generated docs render correctly after regen

Made with [Cursor](https://cursor.com)