### PR TITLE
Remove Props/Events/Slots intro sentences from shared .d.ts files (2025-07)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Badge/Badge.ts
@@ -12,9 +12,7 @@ import type {IconSource} from '../Icon/Icon';
  */
 type Tone = 'default' | 'critical' | 'subdued';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BadgeProps extends VisibilityProps {
   /**
    * The semantic meaning and color treatment of the badge.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Banner/Banner.ts
@@ -2,9 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, Status} from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BannerProps extends IdProps {
   /**
    * The title text displayed at the top of the banner to summarize the message or alert.

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockLayout/BlockLayout.ts
@@ -4,9 +4,7 @@ import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {Rows} from '../shared';
 import type {GridProps} from '../Grid/Grid';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BlockLayoutProps extends Omit<GridProps, 'columns' | 'rows'> {
   /**
    * The sizes for each row of the layout.

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockSpacer/BlockSpacer.ts
@@ -3,9 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps, Spacing} from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BlockSpacerProps extends IdProps {
   /**
    * The size of the spacer.

--- a/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/BlockStack/BlockStack.ts
@@ -13,9 +13,7 @@ import type {
 } from '../shared';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface BlockStackProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button/Button.ts
@@ -10,10 +10,7 @@ import type {
   InteractionProps,
 } from '../shared';
 
-/**
- * Buttons are used for actions, such as “Add”, “Continue”, “Pay now”, or “Save”.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ButtonProps
   extends OverlayActivatorProps,
     DisclosureActivatorProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Chat/Chat.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Chat/Chat.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * Use the Chat component to create real-time chat applications. > Note: The Chat component can only be added to the chat targets of [checkout](/docs/api/checkout-ui-extensions/latest/targets/overlays/purchase-checkout-chat-render) and [Thank you](/docs/api/checkout-ui-extensions/latest/targets/overlays/purchase-thank-you-chat-render) pages.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChatProps extends IdProps {
   /**
    * Adjust the inline size.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox/Checkbox.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {DisclosureActivatorProps} from '../shared';
 
-/**
- * Use checkboxes to give customers a single binary option, such as signing up for marketing, or agreeing to terms and conditions.
- * @publicDocs
- */
+/** @publicDocs */
 export interface CheckboxProps extends DisclosureActivatorProps {
   /**
    * A unique identifier for the field. When no `id` is set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Choice/Choice.ts
@@ -1,12 +1,7 @@
 import type {RemoteFragment} from '@remote-ui/core';
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * Options inside a `ChoiceList`.
-
-The wrapping `ChoiceList` component will dictate if the choice renders as radio buttons or checkboxes.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceProps {
   /**
    * A unique identifier for the choice.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList/ChoiceList.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ChoiceList/ChoiceList.ts
@@ -1,9 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * Use choice lists to present a list of choices where users can make a single selection or multiple selections.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ChoiceListProps<T extends string | string[]> {
   /**
    * A unique identifier for the field in the closest `Form` component.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/ClipboardItem.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ClipboardItem/ClipboardItem.ts
@@ -2,12 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * Enables clipboard functionality when its `id` is referenced by the `activateTarget` property of a `Button`, `Pressable`, or `Link` component. When activated, it copies the text to the clipboard and displays a `Tooltip` confirmation. 
-
- `ClipboardItem` is a non-rendering component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ClipboardItemProps extends IdProps {
   /**
    * The plain text content to copy to the clipboard when this component is activated. For example, a discount code, order number, or tracking URL.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox/ConsentCheckbox.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {CheckboxProps} from '../Checkbox/Checkbox';
 
-/**
- * Use buyer consent checkboxes for collecting the buyer's approval for a given policy.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentCheckboxProps extends Omit<CheckboxProps, 'value'> {
   /**
    * The policy for which buyer consent is being collected for.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField/ConsentPhoneField.ts
@@ -4,10 +4,7 @@ import type {PhoneFieldProps} from '../PhoneField/PhoneField';
 
 export type ConsentPolicy = 'sms-marketing';
 
-/**
- * Display a phone field for customers to sign up for text message marketing, noting that the phone field value will be automatically saved during checkout.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ConsentPhoneFieldProps extends Omit<PhoneFieldProps, 'value'> {
   /**
    * The policy for which buyer consent is being collected for.

--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField/DateField.ts
@@ -3,10 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {DatePickerProps, SelectedDate} from '../DatePicker/DatePicker';
 import type {TextFieldProps} from '../TextField/TextField';
 
-/**
- * Use a date field to get a date input from a customer.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DateFieldProps
   extends Pick<
       TextFieldProps<string>,

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker/DatePicker.ts
@@ -28,10 +28,7 @@ export type YearMonth = {year: number; month: number} | YearMonthString;
 export type SelectedDate = DateString | DateString[] | DateRange;
 export type DisabledDate = DateString | DateRange | DayString;
 
-/**
- * The date picker component is a calendar picker UI that allows users to select a single date or a date range.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DatePickerProps<T extends SelectedDate> {
   /**
    * [Controlled](https://reactjs.org/docs/forms.html#controlled-components) year and month to display.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Disclosure/Disclosure.ts
@@ -3,10 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {DisclosureOpen} from '../shared';
 
-/**
- * Configure the following properties on the disclosure component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DisclosureProps {
   /**
    * For uncontrolled disclosure components, the default `open` state on the initial render.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Divider/Divider.ts
@@ -2,9 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {Alignment, Direction, IdProps, Size} from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface DividerProps extends IdProps {
   /**
    * The thickness of the divider line.

--- a/packages/ui-extensions/src/surfaces/checkout/components/DropZone/DropZone.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DropZone/DropZone.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * The drop zone component allows file uploads through drag-and-drop functionality into a designated area on a page, or by activating a button. At present, DropZone does not offer image upload preview capabilities. The use of object URLs directly in an image component is not possible due to the extension and host operating on separate domains. Any element focused within the drop zone component, including child elements such as the 'Add file' button, will initiate the file selector when the Enter or Spacebar key is pressed.
- * @publicDocs
- */
+/** @publicDocs */
 export interface DropZoneProps extends IdProps {
   /**
    * Whether the drop zone is disabled, preventing any user interaction.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Form/Form.ts
@@ -1,11 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * The form component should be used to wrap one or more form controls. This component provides an "implicit submit" behavior, where customers can submit the form from any input by pressing "Enter" on their keyboards. This behavior is widely expected, and should be respected as often as possible.
-
-Unlike an HTML `form` element, this component does not support configuring the descendant fields to be submitted via HTTP automatically. Instead, you must provide an `onSubmit` callback that will perform the necessary HTTP requests in JavaScript.
- * @publicDocs
- */
+/** @publicDocs */
 export interface FormProps {
   /**
    * Whether the form is disabled, preventing submission and the implicit submit behavior from inputs. When set to `true`, pressing Enter in a field will not submit the form.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Grid/Grid.ts
@@ -16,9 +16,7 @@ import type {
   ViewLikeAccessibilityRole,
 } from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface GridProps
   extends Pick<BackgroundProps, 'background'>,
     IdProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/GridItem/GridItem.ts
@@ -11,9 +11,7 @@ import type {
   ViewLikeAccessibilityRole,
 } from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface GridItemProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Heading/Heading.ts
@@ -4,10 +4,7 @@ import type {InlineAlignment, AccessibilityRole} from '../shared';
 
 type Level = 1 | 2 | 3 | 4;
 
-/**
- * Configure the following properties on the heading component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface HeadingProps {
   /**
    * A unique identifier for the component.

--- a/packages/ui-extensions/src/surfaces/checkout/components/HeadingGroup/HeadingGroup.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/HeadingGroup/HeadingGroup.ts
@@ -1,9 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * Configure the following properties on the heading group component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface HeadingGroupProps {}
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineLayout/InlineLayout.ts
@@ -10,9 +10,7 @@ import type {
 } from '../shared';
 import type {GridProps} from '../Grid/Grid';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface InlineLayoutProps
   extends Omit<GridProps, 'columns' | 'rows'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineSpacer/InlineSpacer.ts
@@ -3,9 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 import type {IdProps, Spacing} from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface InlineSpacerProps extends IdProps {
   /**
    * The size of the spacer.

--- a/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/InlineStack/InlineStack.ts
@@ -14,9 +14,7 @@ import type {
   ViewLikeAccessibilityRole,
 } from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface InlineStackProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Link/Link.ts
@@ -7,10 +7,7 @@ import type {
   InteractionProps,
 } from '../shared';
 
-/**
- * Link makes text interactive so customers can perform an action, such as navigating to another location.
- * @publicDocs
- */
+/** @publicDocs */
 export interface LinkProps
   extends OverlayActivatorProps,
     DisclosureActivatorProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/List/List.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/List/List.ts
@@ -5,10 +5,7 @@ import type {MaybeResponsiveConditionalStyle} from '../../style/types';
 
 export type Marker = 'none' | 'bullet' | 'number';
 
-/**
- * Configure the following properties on the list component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ListProps extends IdProps {
   /**
    * Adjusts the vertical spacing between list items. Use a design system spacing keyword to control the density of the list.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ListItem/ListItem.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ListItem/ListItem.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * Configure the following properties on the list item component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ListItemProps extends IdProps {}
 
 /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/PhoneField/PhoneField.ts
@@ -4,10 +4,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {Autocomplete} from '../shared';
 import type {IconSource} from '../Icon/Icon';
 
-/**
- * A phone field is an input field that users can type into optimized for phone numbers with a country code base auto-formatting. The country code is required for the initial render of the field but it can be overriden later by the user either by selecting a country in the country selection dropdown or by manually editing the country phone code directly in the text field.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PhoneFieldProps {
   /**
    * Any content to render at the end of the text field. Commonly used

--- a/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Pressable/Pressable.ts
@@ -18,10 +18,7 @@ import type {
   IdProps,
 } from '../shared';
 
-/**
- * Pressable is a generic interactive component. It shares the same styling properties as View but also adds pressable behavior, meaning that you can execute some logic in response to user interaction. Use this component for creating interactive elements without the default styling that comes with `Button` and `Link`.
- * @publicDocs
- */
+/** @publicDocs */
 export interface PressableProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Progress/Progress.ts
@@ -2,9 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps} from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface ProgressProps extends IdProps {
   /**
    * How much of the task has been completed. Must be a valid floating point number between 0 and `max`, or between 0 and 1 if `max` is omitted. When no value is set, the progress bar is indeterminate, indicating an ongoing activity with no estimated completion time.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ScrollView/ScrollView.ts
@@ -34,9 +34,7 @@ export interface ScrollViewEvent {
   };
 }
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface ScrollViewProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,

--- a/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Select/Select.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {Autocomplete} from '../shared';
 
-/**
- * Selects let users choose one option from an options menu. Consider select when you have 4 or more options, to avoid cluttering the interface.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SelectOptionProps {
   /**
    * The value that will be passed to the select’s `onChange` callback
@@ -22,10 +19,7 @@ export interface SelectOptionProps {
   disabled?: boolean;
 }
 
-/**
- * Selects let users choose one option from an options menu. Consider select when you have 4 or more options, to avoid cluttering the interface.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SelectProps {
   /**
    * A unique identifier for the field. When no `id` is set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonText/SkeletonText.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonText/SkeletonText.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, TextSize, Size} from '../shared';
 
-/**
- * Configure the following properties on the skeleton text component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SkeletonTextProps extends IdProps {
   /**
    * @private

--- a/packages/ui-extensions/src/surfaces/checkout/components/SkeletonTextBlock/SkeletonTextBlock.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/SkeletonTextBlock/SkeletonTextBlock.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, TextSize} from '../shared';
 
-/**
- * Configure the following properties on the skeleton text block component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SkeletonTextBlockProps extends IdProps {
   /**
    * @private

--- a/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Spinner/Spinner.ts
@@ -2,9 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {Appearance, IdProps, Size} from '../shared';
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface SpinnerProps extends IdProps {
   /**
    * The size of the spinner icon.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Stepper/Stepper.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IconSource} from '../Icon/Icon';
 
-/**
- * Use a stepper to increase or decrease a value, like changing the quantity from 1 to 2.
- * @publicDocs
- */
+/** @publicDocs */
 export interface StepperProps {
   /**
    * A detailed description for screen readers.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Switch/Switch.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Switch/Switch.ts
@@ -2,10 +2,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 
 import type {IdProps, DisclosureActivatorProps} from '../shared';
 
-/**
- * Use a switch to represent an on or off state that takes effect immediately when tapped.
- * @publicDocs
- */
+/** @publicDocs */
 export interface SwitchProps extends IdProps, DisclosureActivatorProps {
   /**
    * An identifier for the field that is unique within the nearest

--- a/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Tag/Tag.ts
@@ -3,10 +3,7 @@ import {createRemoteComponent} from '@remote-ui/core';
 import type {IconSource} from '../Icon/Icon';
 import type {IdProps} from '../shared';
 
-/**
- * Configure the following properties on the tag component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TagProps extends IdProps {
   children?: string;
   /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Text/Text.ts
@@ -8,10 +8,7 @@ import type {
   VisibilityProps,
 } from '../shared';
 
-/**
- * Configure the following properties on the text component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextProps extends VisibilityProps {
   /**
    * A keyword that sets the size of the text. Sizes map to the design system's type scale.

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextBlock/TextBlock.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextBlock/TextBlock.ts
@@ -8,10 +8,7 @@ import type {
   TextSize,
 } from '../shared';
 
-/**
- * Configure the following properties on the text block component.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextBlockProps extends IdProps {
   /**
    * A keyword that sets the size of the text block. Sizes map to the design system's type scale.

--- a/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/TextField/TextField.ts
@@ -6,10 +6,7 @@ import type {IconSource} from '../Icon/Icon';
 
 type Type = 'text' | 'email' | 'number' | 'telephone';
 
-/**
- * Use a text field to get text input from a customer.
- * @publicDocs
- */
+/** @publicDocs */
 export interface TextFieldProps<T extends string | number | undefined> {
   /**
    * A unique identifier for the field. When no `id` is set,

--- a/packages/ui-extensions/src/surfaces/checkout/components/ToggleButton/ToggleButton.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ToggleButton/ToggleButton.ts
@@ -1,9 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * Options inside a [ToggleButtonGroup](/docs/api/checkout-ui-extensions/components/forms/togglebuttongroup).
- * @publicDocs
- */
+/** @publicDocs */
 export interface ToggleButtonProps {
   /**
    * A unique identifier for the toggle button.

--- a/packages/ui-extensions/src/surfaces/checkout/components/ToggleButtonGroup/ToggleButtonGroup.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ToggleButtonGroup/ToggleButtonGroup.ts
@@ -1,11 +1,6 @@
 import {createRemoteComponent} from '@remote-ui/core';
 
-/**
- * `ToggleButtonGroup` allows you to make a single choice out of the number of options provided. This is similar to the [ChoiceList](/docs/api/checkout-ui-extensions/components/forms/choicelist) component, but without controls such as checkbox or radio button.
-
-You can utilize our layout components to arrange `ToggleButtonGroup`.
- * @publicDocs
- */
+/** @publicDocs */
 export interface ToggleButtonGroupProps<T extends string> {
   /**
    * An id of the selected button.

--- a/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/View/View.ts
@@ -105,9 +105,7 @@ export interface Translate {
   inline?: number | `${number}%`;
 }
 
-/**
- * @publicDocs
- */
+/** @publicDocs */
 export interface ViewProps
   extends Pick<BackgroundProps, 'background'>,
     BorderProps,


### PR DESCRIPTION
## Summary
Removes all interface-level intro descriptions from @publicDocs Props, Events, Slots, and Methods interfaces across shared checkout component files. These intro sentences will be added in world instead, allowing surface-specific customization for CA vs CO.

Cascaded from the 2026-04-rc version.

## Test plan
- [ ] `yarn build` passes
- [ ] Verify generated docs render correctly after regen

Made with [Cursor](https://cursor.com)