### PR TITLE
Fix broken and incorrect documentation links across CA pages (2026-01)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
@@ -128,7 +128,7 @@ export interface AddressAutocompleteStandardApi<
    *
    * If the previous token expires, this value will reflect a new session token with a new signature and expiry.
    *
-   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).
    */
   sessionToken: SessionToken;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -741,7 +741,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * If the previous token expires, this value reflects a new session token with a new signature and expiry.
    *
-   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/session-token) for more information.
+   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).
    */
   sessionToken: SessionToken;
 

--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -953,7 +953,7 @@ export type AccessibilityRole =
  * Used to indicate the component is a header.
  *
  * In an HTML host `header` will render a `<header>` element.
- * Learn more about the [`<header>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/main_role) in the MDN web docs.
+ * Learn more about the [`<header>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) and its [implicit role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/banner_role) in the MDN web docs.
  */
  | "header"
 /**

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -235,7 +235,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
 
   /**
    * The [metafields](/docs/apps/build/custom-data/metafields) requested in the
-   * [`shopify.extension.toml`](/docs/api/customer-account-ui-extensions/latest#configuration)
+   * [`shopify.extension.toml`](/docs/apps/build/customer-accounts/metafields#create-the-metafield-definition)
    * file. Metafields are custom data fields that store additional information on Shopify resources
    * such as products, variants, customers, and the shop. These metafields are updated when there's
    * a change in the merchandise items being purchased by the customer.
@@ -308,7 +308,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   /**
    * The buyer's locale, currency, time zone, country, and market context for the order.
    * Use these values to adapt your extension's content to the buyer's region. For formatted
-   * dates, numbers, and translated strings, use the [Localization API](/docs/api/customer-account-ui-extensions/target-apis/platform-apis/localization-api)
+   * dates, numbers, and translated strings, use the [Localization API](/docs/api/customer-account-ui-extensions/{API_VERSION}/target-apis/platform-apis/localization-api)
    * instead.
    */
   localization: OrderStatusLocalization;
@@ -336,8 +336,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   /**
    * The token that identifies the checkout session used to create the order. Use this value
    * to correlate the order with analytics events or backend API calls. This matches the
-   * `token` field in the [WebPixel checkout payload](/docs/api/pixels/customer-events#checkout)
-   * and the `checkout_token` field in the [Admin REST API Order resource](/docs/api/admin-rest/unstable/resources/order#resource-object).
+   * `token` field in the [WebPixel checkout payload](/docs/api/pixels/customer-events#checkout).
    * The value is `undefined` if the checkout token is unavailable.
    */
   checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;
@@ -785,7 +784,7 @@ export interface SelectedPaymentOption {
   /**
    * The handle of the payment option the buyer selected, corresponding to a `PaymentOption.handle` value.
    *
-   * See [availablePaymentOptions](/docs/api/checkout-ui-extensions/apis/payments#standardapi-propertydetail-selectedpaymentoptions).
+   * See [availablePaymentOptions](/docs/api/customer-account-ui-extensions/{API_VERSION}/target-apis/order-apis/payments-api).
    */
   handle: string;
 }
@@ -961,7 +960,7 @@ export interface PaymentTermsTemplate {
    */
   id: string;
   /**
-   * The name of the payment terms translated to the buyer's current language, such as "Net 30" or "Due on receipt". See [localization.language](/docs/api/customer-account-ui-extensions/apis/localization#standardapi-propertydetail-localization).
+   * The name of the payment terms translated to the buyer's current language, such as "Net 30" or "Due on receipt". See [localization.language](/docs/api/customer-account-ui-extensions/{API_VERSION}/apis/localization#standardapi-propertydetail-localization).
    */
   name: string;
   /**

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar/Avatar.doc.ts
@@ -17,7 +17,7 @@ const data: ReferenceEntityTemplateSchema = {
     {
       title: 'Events',
       description:
-        'Learn more about [registering events](/docs/api/customer-account-ui-extensions/using-web-components#handling-events).',
+        'Learn more about [handling events](/docs/api/customer-account-ui-extensions/{API_VERSION}/using-web-components#handling-events).',
       type: 'AvatarEventsDocs',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ButtonGroup/ButtonGroup.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Button group',
   description: `ButtonGroup is used to display multiple buttons in a layout that is contextual based on the screen width or parent component. When there is more than one secondary action, they get collapsed.
     
-When used within a [Section](/docs/api/customer-account-ui-extensions/web-components/structure/section) component, the buttons will fill the width of the section.
+When used within a [Section](/docs/api/customer-account-ui-extensions/{API_VERSION}/web-components/structure/section) component, the buttons will fill the width of the section.
 `,
   thumbnail: 'buttongroup-thumbnail.png',
   requires: '',

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
@@ -3,7 +3,7 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Customer account action',
   description:
-    'A modal to complete an order action flow. This component can only be used to populate the [customer-account.order.action.render](/docs/api/customer-account-ui-extensions/unstable/targets/order-action-menu/customer-account-order-action-render) extension target, which renders as a result of the customer clicking the order action button rendered via the [customer-account.order.action.menu-item.render](/docs/api/customer-account-ui-extensions/unstable/targets/order-action-menu/customer-account-order-action-menu-item-render) extension target.',
+    'A modal to complete an order action flow. This component can only be used to populate the [customer-account.order.action.render](/docs/api/customer-account-ui-extensions/{API_VERSION}/targets/order-action-menu/customer-account-order-action-render) extension target, which renders as a result of the customer clicking the order action button rendered via the [customer-account.order.action.menu-item.render](/docs/api/customer-account-ui-extensions/{API_VERSION}/targets/order-action-menu/customer-account-order-action-menu-item-render) extension target.',
   thumbnail: 'customeraccountaction-thumbnail.png',
   requires: '',
   isVisualComponent: true,

--- a/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/ImageGroup/ImageGroup.doc.ts
@@ -3,7 +3,7 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'Image group',
   description:
-    'Display up to 4 images in a grid or stacked layout. The images are displayed as a grid when used within a [Section](/docs/api/customer-account-ui-extensions/web-components/structure/section) component. For example, images of products in a wishlist or subscription. When there are more than 4 images, the component indicates how many more images are not displayed.',
+    'Display up to 4 images in a grid or stacked layout. The images are displayed as a grid when used within a [Section](/docs/api/customer-account-ui-extensions/{API_VERSION}/web-components/structure/section) component. For example, images of products in a wishlist or subscription. When there are more than 4 images, the component indicates how many more images are not displayed.',
   thumbnail: 'imagegroup-thumbnail.png',
   requires: '',
   isVisualComponent: true,


### PR DESCRIPTION
Cascaded from 2026-04-rc (#4300). Fixes session token, appMetafields, availablePaymentOptions, and other broken links.

## Changes
- Session token links → `/docs/apps/build/authentication-authorization/session-tokens`
- `shopify.extension.toml` link → metafields configuration
- Removed deprecated REST Admin API reference from checkoutToken
- Fixed `availablePaymentOptions` link to CA surface
- Added `{API_VERSION}` to Localization API and localization.language links
- Fixed `<header>` ARIA role `main_role` → `banner_role`
- Added `{API_VERSION}` to ImageGroup, ButtonGroup, Avatar doc links
- Changed `unstable` to `{API_VERSION}` in CustomerAccountAction doc

Note: `app owned metafields` link fix was not applicable (different wording in this version).

Made with [Cursor](https://cursor.com)