### PR TITLE
Fix broken and incorrect documentation links across CA pages (2025-07)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
@@ -123,7 +123,7 @@ export interface AddressAutocompleteStandardApi<
    *
    * If the previous token expires, this value will reflect a new session token with a new signature and expiry.
    *
-   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).
    */
   sessionToken: SessionToken;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -671,7 +671,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * If the previous token expires, this value will reflect a new session token with a new signature and expiry.
    *
-   * Refer to [session token examples](https://shopify.dev/docs/api/checkout-ui-extensions/apis/session-token) for more information.
+   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).
    */
   sessionToken: SessionToken;
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -42,7 +42,7 @@ export interface Metafield {
 }
 
 /**
- * Represents a custom metadata field attached to a resource, requested through the [`shopify.extension.toml`](/docs/api/customer-account-ui-extensions/latest#configuration) file.
+ * Represents a custom metadata field attached to a resource, requested through the [`shopify.extension.toml`](/docs/apps/build/customer-accounts/metafields#create-the-metafield-definition) file.
  */
 export interface AppMetafield {
   /** The unique identifier for the metafield within its namespace. */
@@ -211,7 +211,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
 
   /**
    * The metafields requested in the
-   * [`shopify.extension.toml`](/docs/api/customer-account-ui-extensions/latest#configuration)
+   * [`shopify.extension.toml`](/docs/apps/build/customer-accounts/metafields#create-the-metafield-definition)
    * file. These metafields are updated when there’s a change in the merchandise items
    * being purchased by the customer.
    *
@@ -273,7 +273,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   lines: StatefulRemoteSubscribable<CartLine[]>;
 
   /**
-   * Details about the buyer's location, language, and currency on the **Order status** page. For utilities to format and translate content based on these details, use the `i18n` object from the [Localization API](/docs/api/customer-account-ui-extensions/target-apis/platform-apis/localization-api) instead.
+   * Details about the buyer's location, language, and currency on the **Order status** page. For utilities to format and translate content based on these details, use the `i18n` object from the [Localization API](/docs/api/customer-account-ui-extensions/{API_VERSION}/target-apis/platform-apis/localization-api) instead.
    */
   localization: OrderStatusLocalization;
 
@@ -300,8 +300,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   /**
    * The token that represents the checkout session used to create this order.
    *
-   * Matches the `token` field in the [WebPixel checkout payload](/docs/api/pixels/customer-events#checkout)
-   * and the `checkout_token` field in the [Admin REST API Order resource](/docs/api/admin-rest/unstable/resources/order#resource-object).
+   * Matches the `token` field in the [WebPixel checkout payload](/docs/api/pixels/customer-events#checkout).
    */
   checkoutToken: StatefulRemoteSubscribable<CheckoutToken | undefined>;
 
@@ -725,7 +724,7 @@ export interface SelectedPaymentOption {
   /**
    * The unique handle referencing `PaymentOption.handle`.
    *
-   * See [availablePaymentOptions](https://shopify.dev/docs/api/checkout-ui-extensions/apis/standardapi#properties-propertydetail-availablepaymentoptions).
+   * See [availablePaymentOptions](/docs/api/customer-account-ui-extensions/{API_VERSION}/target-apis/order-apis/payments-api).
    */
   handle: string;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/CustomerAccountAction/CustomerAccountAction.doc.ts
@@ -3,7 +3,7 @@ import type {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 const data: ReferenceEntityTemplateSchema = {
   name: 'CustomerAccountAction',
   description:
-    'A modal to complete an order action flow. This component can only be used to populate the [customer-account.order.action.render](/docs/api/customer-account-ui-extensions/unstable/targets/order-action-menu/customer-account-order-action-render) extension target, which renders as a result of the customer clicking the order action button rendered via the [customer-account.order.action.menu-item.render](/docs/api/customer-account-ui-extensions/unstable/targets/order-action-menu/customer-account-order-action-menu-item-render) extension target.',
+    'A modal to complete an order action flow. This component can only be used to populate the [customer-account.order.action.render](/docs/api/customer-account-ui-extensions/{API_VERSION}/targets/order-action-menu/customer-account-order-action-render) extension target, which renders as a result of the customer clicking the order action button rendered via the [customer-account.order.action.menu-item.render](/docs/api/customer-account-ui-extensions/{API_VERSION}/targets/order-action-menu/customer-account-order-action-menu-item-render) extension target.',
   thumbnail: 'customeraccountaction-thumbnail.png',
   requires: '',
   isVisualComponent: true,


### PR DESCRIPTION
Cascaded from 2026-04-rc (#4300). Fixes session token, appMetafields, availablePaymentOptions, and other broken links.

## Changes
- Session token links → `/docs/apps/build/authentication-authorization/session-tokens`
- `shopify.extension.toml` links → metafields configuration (2 occurrences)
- Removed deprecated REST Admin API reference from checkoutToken
- Fixed `availablePaymentOptions` link to CA surface (was pointing to checkout surface with full shopify.dev URL)
- Added `{API_VERSION}` to Localization API link
- Changed `unstable` to `{API_VERSION}` in CustomerAccountAction doc

Note: This version has a different file structure. The following fixes were not applicable:
- `components-shared.d.ts` (file does not exist)
- `ButtonGroup.doc.ts` (component does not exist)
- `ImageGroup.doc.ts` Section link (different wording)
- `Avatar.doc.ts` events link (different wording)
- `app owned metafields` link (not present)
- `localization.language` link (not present)

Made with [Cursor](https://cursor.com)