### PR TITLE
Fix CA docs cleanup (2025-07)

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -260,8 +260,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    * extension’s configuration file.
    *
    * @example 'customer-account.order-status.block.render'
-   * @see https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
-   * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
+   * Learn more about [targets](/docs/api/customer-account-ui-extensions/{API_VERSION}/targets) and [target configuration](/docs/api/customer-account-ui-extensions/{API_VERSION}#configuration).
    *
    * @deprecated Deprecated as of version `2023-07`, use `extension.target` instead.
    */


### PR DESCRIPTION
Cascaded from 2026-04. Only the order-status.ts @see tag fix applies on this older branch.

Most fixes (ConsentPolicy, commandFor, DatePicker, Progress, ChoiceList, PhoneField, Sheet, onClick) don't apply — the checkout component `.d.ts` files don't exist on 2025-07, and the commandFor/command properties weren't yet added to docs.ts.

Made with [Cursor](https://cursor.com)