### PR TITLE
Add ConsentPolicy description to consent component .d.ts files (2025-10)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentCheckbox.d.ts
@@ -63,6 +63,12 @@ declare const tagName = "s-consent-checkbox";
 /** @publicDocs */
 export interface ConsentCheckboxElementProps extends Pick<ConsentCheckboxProps$1, 'accessibilityLabel' | 'checked' | 'command' | 'commandFor' | 'defaultChecked' | 'disabled' | 'error' | 'id' | 'label' | 'name' | 'policy' | 'value'> {
     command?: Extract<ConsentCheckboxProps$1['command'], '--auto' | '--show' | '--hide' | '--toggle'>;
+    /**
+     * The policy for which buyer consent is being collected. Used by the [consent checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/consent-checkbox) and [consent phone field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/consent-phone-field) components to identify the type of marketing permission requested.
+     *
+     * - `sms-marketing`: Represents the policy for SMS marketing consent.
+     */
+    policy?: ConsentCheckboxProps$1['policy'];
 }
 /** @publicDocs */
 export interface ConsentCheckboxEvents extends Pick<CheckboxEvents, 'onChange'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/ConsentPhoneField.d.ts
@@ -81,6 +81,12 @@ export interface ConsentPhoneFieldElementProps extends Pick<ConsentPhoneFieldPro
      * @private
      */
     placeholder?: string;
+    /**
+     * The policy for which buyer consent is being collected. Used by the [consent checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/consent-checkbox) and [consent phone field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/consent-phone-field) components to identify the type of marketing permission requested.
+     *
+     * - `sms-marketing`: Represents the policy for SMS marketing consent.
+     */
+    policy?: ConsentPhoneFieldProps$1['policy'];
 }
 /** @publicDocs */
 export interface ConsentPhoneFieldEvents extends Pick<PhoneFieldEvents, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {
@@ -88,45 +94,29 @@ export interface ConsentPhoneFieldEvents extends Pick<PhoneFieldEvents, 'onBlur'
 /** @publicDocs */
 export interface ConsentPhoneFieldElementEvents {
     /**
-<<<<<<< HEAD
-     * A callback fired when the element loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event
-     */
-    blur?: CallbackEventListener<typeof tagName>;
-    /**
-     * Callback when the user has **finished editing** a field, for example, once they have blurred the field.
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event
-     */
-    change?: CallbackEventListener<typeof tagName>;
-    /**
-     * A callback fired when the element receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
-=======
-     * A callback fired when the consent phone field value changes.
-     *
-     * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
-     */
-    change?: CallbackEventListener<typeof tagName>;
-    /**
-     * A callback fired when the user inputs data into the consent phone field.
->>>>>>> 8763c703b (Improve Forms component descriptions to match admin quality)
-     *
-     * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).
-     */
-    input?: CallbackEventListener<typeof tagName>;
-    /**
      * A callback fired when the consent phone field loses focus.
      *
      * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
      */
     blur?: CallbackEventListener<typeof tagName>;
     /**
+     * A callback fired when the consent phone field value changes.
+     *
+     * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
+     */
+    change?: CallbackEventListener<typeof tagName>;
+    /**
      * A callback fired when the consent phone field receives focus.
      *
      * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
      */
     focus?: CallbackEventListener<typeof tagName>;
+    /**
+     * A callback fired when the user inputs data into the consent phone field.
+     *
+     * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).
+     */
+    input?: CallbackEventListener<typeof tagName>;
 }
 /** @publicDocs */
 export interface ConsentPhoneFieldElement extends ConsentPhoneFieldElementProps, Omit<ConsentPhoneFieldEvents, 'onBlur' | 'onChange' | 'onFocus' | 'onInput'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -2110,7 +2110,7 @@ export type AnyAutocompleteField = "additional-name" | "address-level1" | "addre
 /** @publicDocs */
 export type TextAutocompleteField = ExtractStrict<AnyAutocompleteField, "additional-name" | "address-level1" | "address-level2" | "address-level3" | "address-level4" | "address-line1" | "address-line2" | "address-line3" | "country-name" | "country" | "family-name" | "given-name" | "honorific-prefix" | "honorific-suffix" | "language" | "name" | "nickname" | "one-time-code" | "organization-title" | "organization" | "postal-code" | "sex" | "street-address" | "transaction-currency" | "username" | "cc-name" | "cc-given-name" | "cc-additional-name" | "cc-family-name" | "cc-type">;
 /**
- * The policy for which buyer consent is being collected. Used by the [consent checkbox](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/consent-checkbox) and [consent phone field](/docs/api/{API_NAME}/{API_VERSION}/polaris-web-components/forms/consent-phone-field) components to identify the type of marketing permission requested.
+ * The policy for which buyer consent is being collected. Used by the [consent checkbox](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/consent-checkbox) and [consent phone field](/docs/api/{API_NAME}/{API_VERSION}/web-components/forms/consent-phone-field) components to identify the type of marketing permission requested.
  * @publicDocs
  */
 export type ConsentPolicy = "sms-marketing";


### PR DESCRIPTION
Adds inline JSDoc for the policy property so the ConsentPolicy type description flows through the doc generator. Also resolves pre-existing merge conflicts in ConsentPhoneField.d.ts.

Made with [Cursor](https://cursor.com)