### PR TITLE
Add banners in 3 places in customer account API

### DIFF
--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.page.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.order.page.render.doc.ts
@@ -7,7 +7,10 @@ import {
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'customer-account.order.page.render',
-  description: `This [full-page extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#full-page-extension-full-page-extension-(order-specific)) allows you to create a new page in customer accounts, **tied to a specific order**. It renders in the main content area—below the header, and above the footer.
+  description: `> Note:
+> Customer accounts are getting layout and design updates. Enable the **Customer account improvements** feature preview to get early access. See the [developer changelog](/changelog/feature-preview-customer-account-improvements) and [where extension targets will render](/docs/apps/build/customer-accounts/feature-preview-customer-account-improvements) in the new layout.
+
+This [full-page extension target](/docs/api/customer-account-ui-extensions/extension-targets-overview#full-page-extension-full-page-extension-(order-specific)) allows you to create a new page in customer accounts, **tied to a specific order**. It renders in the main content area—below the header, and above the footer.
 
 If the page you're building is not tied to a specific order, use [customer-account.page.render](/docs/api/customer-account-ui-extensions/targets/full-page/customer-account-page-render) instead.
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/reference/targets/customer-account.page.render.doc.ts
@@ -4,7 +4,10 @@ import {CUSTOMER_ACCOUNT_STANDARD_API_DEFINITION} from '../helper.docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'customer-account.page.render',
-  description: `This [full-page extension](/docs/api/customer-account-ui-extensions/unstable/extension-targets-overview#full-page-extension-full-page-extension) allows you to create a new page in customer accounts. It renders in the main content area—below the header, and above the footer.\n
+  description: `> Note:
+> Customer accounts are getting layout and design updates. Enable the **Customer account improvements** feature preview to get early access. See the [developer changelog](/changelog/feature-preview-customer-account-improvements) and [where extension targets will render](/docs/apps/build/customer-accounts/feature-preview-customer-account-improvements) in the new layout.
+
+This [full-page extension](/docs/api/customer-account-ui-extensions/unstable/extension-targets-overview#full-page-extension-full-page-extension) allows you to create a new page in customer accounts. It renders in the main content area—below the header, and above the footer.\n
 
 If the page you're building is tied to a specific order, use [customer-account.order.page.render](/docs/api/customer-account-ui-extensions/targets/full-page/customer-account-order-page-render) instead.
 

--- a/packages/ui-extensions/docs/surfaces/customer-account/staticPages/extension-targets-overview.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/customer-account/staticPages/extension-targets-overview.doc.ts
@@ -246,7 +246,7 @@ You register for targets in your [configuration file](/docs/api/checkout-ui-exte
       anchorLink: 'full-page-extension-target',
       title: 'Full-page extension',
       sectionContent:
-        'Build new pages for customer accounts. Full-page extensions render in the main content area—below the header, and above the footer.',
+        '> Note:\n> Customer accounts are getting layout and design updates. Enable the **Customer account improvements** feature preview to get early access. See the [developer changelog](/changelog/feature-preview-customer-account-improvements) and [where extension targets will render](/docs/apps/build/customer-accounts/feature-preview-customer-account-improvements) in the new layout.\n\nBuild new pages for customer accounts. Full-page extensions render in the main content area—below the header, and above the footer.',
       accordionContent: [
         {
           title: 'Full-page extension',


### PR DESCRIPTION
## Summary

- Adds banners in three places in the customer account API docs:
  - `customer-account.order.page.render` target
  - `customer-account.page.render` target
  - Extension targets overview static page

## Test plan

- [ ] Review banner placement and wording in the three updated files
- [ ] Run `yarn docs:customer-account` to verify docs generate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)