### PR TITLE
Fix Customer.id JSDoc: clarify shop-scoping (2026-04)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -1456,7 +1456,7 @@ export type Interceptor = (
  */
 export interface Customer {
   /**
-   * A globally-unique identifier for the customer in the format `gid://shopify/Customer/<id>`.
+   * An identifier for the customer in the format `gid://shopify/Customer/<id>`. This value is unique per shop.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](https://shopify.dev/docs/apps/store/data-protection/protected-customer-data).
    *


### PR DESCRIPTION
## Summary

Clarifies that `customer.id` on the checkout UI extensions `Customer` interface is unique per shop, not globally unique.

## Why

The previous JSDoc described `customer.id` as "A globally-unique identifier for the customer," which misled developers building multi-shop apps to assume they could key records on `customer.id` alone.

## Change

In `packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts`, updates the JSDoc for `Customer.id`.

**Before**
> A globally-unique identifier for the customer in the format `gid://shopify/Customer/<id>`.

**After**
> An identifier for the customer in the format `gid://shopify/Customer/<id>`. This value is unique per shop.

## Context

Feedback from Simon Bolduc during a checkout UI extensions docs review. See [shop/issues-learn#1857](https://github.com/shop/issues-learn/issues/1857).

A companion shopify-dev PR updates the Best practices section of the Buyer Identity API docs to prescribe keying records on shop and `customer.id` together for multi-shop apps.

Sibling PRs cover the same change on the `2026-07-rc`, `2026-01`, and `2025-10` branches.