### PR TITLE
Resolve merge conflict markers in DateField and DatePicker (2026-01)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
@@ -46,17 +46,6 @@ export interface DateFieldEvents extends Pick<DateFieldProps$1, 'onBlur' | 'onCh
 /** @publicDocs */
 export interface DateFieldElementEvents {
     /**
-<<<<<<< HEAD
-     * A callback fired when the element loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
-     */
-    blur?: CallbackEventListener<typeof tagName>;
-    /**
-     * Callback when the user has **finished editing** a field, for example, once they have blurred the field.
-     */
-    change?: CallbackEventListener<typeof tagName>;
-    /**
-     * A callback fired when the element receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
-=======
      * A callback fired when the date field loses focus.
      *
      * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
@@ -72,7 +61,6 @@ export interface DateFieldElementEvents {
      * A callback fired when the date field receives focus.
      *
      * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
->>>>>>> eb0f07393 (Improve Forms component descriptions to match admin quality)
      */
     focus?: CallbackEventListener<typeof tagName>;
     /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
@@ -41,17 +41,6 @@ export interface DatePickerEvents extends Pick<DatePickerProps$1, 'onBlur' | 'on
 /** @publicDocs */
 export interface DatePickerElementEvents {
     /**
-<<<<<<< HEAD
-     * A callback fired when the element loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
-     */
-    blur?: CallbackEventListener<typeof tagName>;
-    /**
-     * Callback when the user has **finished editing** a field, for example, once they have blurred the field.
-     */
-    change?: CallbackEventListener<typeof tagName>;
-    /**
-     * A callback fired when the element receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
-=======
      * A callback fired when the date picker loses focus.
      *
      * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
@@ -67,7 +56,6 @@ export interface DatePickerElementEvents {
      * A callback fired when the date picker receives focus.
      *
      * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
->>>>>>> eb0f07393 (Improve Forms component descriptions to match admin quality)
      */
     focus?: CallbackEventListener<typeof tagName>;
     /**


### PR DESCRIPTION
Resolves unresolved merge conflict markers from cherry-pick eb0f07393 that were left in the 2026-01 base branch. Keeps the improved Forms component descriptions.

Made with [Cursor](https://cursor.com)