### PR TITLE
Fix button/clickable type description: remove invalid reset value (2026-01)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
@@ -43,6 +43,16 @@ declare const tagName = "s-button";
 export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'disabled' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'loading' | 'target' | 'tone' | 'type' | 'variant'> {
     target?: Extract<ButtonProps$1['target'], 'auto' | '_blank'>;
     tone?: Extract<ButtonProps$1['tone'], 'auto' | 'neutral' | 'critical'>;
+    /**
+     * The behavioral type of the button component, which determines what action it performs when activated.
+     *
+     * - `submit`: Submits the nearest containing form.
+     * - `button`: Performs no default action, relying on the `click` event handler for behavior.
+     *
+     * This property is ignored if `href` or `commandFor`/`command` is set.
+     *
+     * @default 'button'
+     */
     type?: Extract<ButtonProps$1['type'], 'submit' | 'button'>;
     variant?: Extract<ButtonProps$1['variant'], 'auto' | 'primary' | 'secondary'>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Clickable.d.ts
@@ -69,6 +69,16 @@ export interface ClickableElementProps extends Pick<ClickableProps$1, 'accessibi
     borderWidth?: MaybeAllValuesShorthandProperty<ReducedBorderSizeKeyword> | '';
     borderRadius?: MaybeAllValuesShorthandProperty<Extract<ClickableProps$1['borderRadius'], 'none' | 'small-100' | 'small' | 'base' | 'large' | 'large-100' | 'max'>>;
     target?: Extract<ClickableProps$1['target'], 'auto' | '_blank'>;
+    /**
+     * The behavioral type of the clickable component, which determines what action it performs when activated.
+     *
+     * - `submit`: Submits the nearest containing form.
+     * - `button`: Performs no default action, relying on the `click` event handler for behavior.
+     *
+     * This property is ignored if `href` or `commandFor`/`command` is set.
+     *
+     * @default 'button'
+     */
     type?: Extract<ClickableProps$1['type'], 'submit' | 'button'>;
 }
 /** @publicDocs */

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -95,9 +95,8 @@ interface ButtonProps {
   /**
    * The behavior of the button.
    *
-   * - `'submit'` - Used to indicate the component acts as a submit button, meaning it submits the closest form.
-   * - `'button'` - Used to indicate the component acts as a button, meaning it has no default action.
-   * - `'reset'` - Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).
+   * - `'submit'`: Submits the nearest containing form.
+   * - `'button'`: Performs no default action, relying on the `click` event handler for behavior.
    *
    * This property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.
    *


### PR DESCRIPTION
Cascaded from 2026-04. Removes invalid reset from Button and Clickable type descriptions per [feedback](https://docs.google.com/document/d/11Ebolt8eiOT5XE0T6geXUTewxtH6Hq3m_oLrDyBriYw/edit?tab=t.0)

Made with [Cursor](https://cursor.com)