### PR TITLE
Resolve merge conflict markers in DateField and DatePicker (2025-10)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DateField.d.ts
@@ -46,21 +46,6 @@ export interface DateFieldEvents extends Pick<DateFieldProps$1, 'onBlur' | 'onCh
 /** @publicDocs */
 export interface DateFieldElementEvents {
     /**
-<<<<<<< HEAD
-     * A callback fired when the element loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
-     */
-    blur?: CallbackEventListener<typeof tagName>;
-    /**
-     * Callback when the user has **finished editing** a field, for example, once they have blurred the field.
-     */
-    change?: CallbackEventListener<typeof tagName>;
-    /**
-     * A callback fired when the element receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
-     */
-    focus?: CallbackEventListener<typeof tagName>;
-    /**
-     * Callback when the user makes any changes in the field.
-=======
      * A callback fired when the date field value changes.
      *
      * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).
@@ -70,7 +55,6 @@ export interface DateFieldElementEvents {
      * A callback fired when the user inputs data into the date field.
      *
      * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).
->>>>>>> 8763c703b (Improve Forms component descriptions to match admin quality)
      */
     input?: CallbackEventListener<typeof tagName>;
     /**

--- a/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/DatePicker.d.ts
@@ -41,25 +41,13 @@ export interface DatePickerEvents extends Pick<DatePickerProps$1, 'onBlur' | 'on
 /** @publicDocs */
 export interface DatePickerElementEvents {
     /**
-<<<<<<< HEAD
-     * A callback fired when the element loses focus. Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).
-=======
      * A callback fired when the calendar view changes, such as when navigating between months.
->>>>>>> 8763c703b (Improve Forms component descriptions to match admin quality)
      */
     viewChange?: CallbackEventListener<typeof tagName>;
     /**
-<<<<<<< HEAD
-     * Callback when the user has **finished editing** a field, for example, once they have blurred the field.
-     */
-    change?: CallbackEventListener<typeof tagName>;
-    /**
-     * A callback fired when the element receives focus. Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
-=======
      * A callback fired when the date picker receives focus.
      *
      * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).
->>>>>>> 8763c703b (Improve Forms component descriptions to match admin quality)
      */
     focus?: CallbackEventListener<typeof tagName>;
     /**


### PR DESCRIPTION
Resolves unresolved merge conflict markers from cherry-pick that were left in the 2025-10 base branch. Keeps the improved Forms component descriptions.

Made with [Cursor](https://cursor.com)