### PR TITLE
feat: add admin.app.home.render extension target

### DIFF
--- a/.changeset/add-app-home-render-target.md
+++ b/.changeset/add-app-home-render-target.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add admin.app.home.render extension target

--- a/packages/ui-extensions-tester/src/admin/factories.ts
+++ b/packages/ui-extensions-tester/src/admin/factories.ts
@@ -272,6 +272,7 @@ const adminMockFactories: AdminMockFactory = {
   'admin.app.tools.data': createMockStandardApi,
 
   // App render targets
+  'admin.app.home.render': createMockStandardRenderingApi,
   'admin.app.intent.render': createAppIntentRenderMock,
 
   // Block targets

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -675,6 +675,14 @@ export interface ExtensionTargets {
     IntentRenderApi<'admin.app.intent.render'>,
     FormExtensionComponents
   >;
+
+  /**
+   * Renders an admin extension on the app home page.
+   */
+  'admin.app.home.render': RenderExtension<
+    StandardApi<'admin.app.home.render'>,
+    FormExtensionComponents | 'Modal'
+  >;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -681,7 +681,7 @@ export interface ExtensionTargets {
    */
   'admin.app.home.render': RenderExtension<
     StandardApi<'admin.app.home.render'>,
-    FormExtensionComponents | 'Modal'
+    FormExtensionComponents | 'Modal' | 'Page'
   >;
 }
 


### PR DESCRIPTION
Add admin.app.home.render RenderExtension target for RemoteDom App Home. Part of the hosted-app project migration from iframe to RemoteDom worker.

Closes https://github.com/shop/issues-admin-extensibility/issues/2444