### PR TITLE
ci: auto-fix lint when creating Version Packages PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           title: Version Packages (${{ github.ref_name }})
+          version: yarn changeset version && yarn lint --fix
           publish: yarn run deploy ${{ !endsWith(github.ref_name, '-rc') && format('--tag {0}', github.ref_name) || '' }} # no tag for RC branches.
           createGithubReleases: false
         env:


### PR DESCRIPTION
## Problem

The [rc branch CI was failing](https://github.com/Shopify/ui-extensions/actions/runs/24849734591/job/72749432207) on the `lint` check for the **Version Packages (rc)** PR.

When the `changesets/action` creates or updates a Version Packages branch it runs `changeset version` by default, which bumps `package.json` files and auto-generates `CHANGELOG.md` entries. These generated files can introduce lint violations, causing the CI `lint` job to fail on the resulting branch/PR.

## Fix

Add a custom `version` script to the `changesets/action` step:

```yaml
version: yarn changeset version && yarn lint --fix
```

This runs `yarn lint --fix` immediately after version bumping, so any auto-fixable lint issues are corrected before the commit is made to the Version Packages branch — keeping it lint-clean and unblocking CI.

## Impact

- No change to the publish path (only the `version` step is affected)
- Applies to all branches using this workflow (stable + rc)
- Only fixable issues are auto-corrected; non-fixable violations would still surface as CI failures (which is the right behaviour)