### PR TITLE
Match correctly on optional response

### DIFF
--- a/.changeset/mean-ducks-join.md
+++ b/.changeset/mean-ducks-join.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Match correctly on optional response

--- a/packages/ui-extensions/src/surfaces/admin/api/generated/generated.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/generated/generated.ts
@@ -37,7 +37,7 @@ type MergeGeneratedIntentResponse<BaseIntents, Variants> =
                   callback: (value: GeneratedRequest | null) => void,
                 ) => () => void;
               };
-        } & (Variant extends {response: infer GeneratedResponse}
+        } & (Variant extends {response?: infer GeneratedResponse}
             ? BaseIntents extends {response: infer BaseResponse}
               ? {
                   response: Omit<NonNullable<BaseResponse>, 'ok'> &


### PR DESCRIPTION
We had a last minute fix on `generated.ts` but this wasn't taken account in the generics matcher