### PR TITLE
[2025-07] Fix broken anchor links after checkout API heading rename

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts
@@ -89,7 +89,7 @@ export interface AddressAutocompleteStandardApi<
   /**
    * The details about the location, language, and currency of the customer. For utilities to easily
    * format and translate content based on these details, you can use the
-   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
+   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#properties-propertydetail-i18n)
    * object instead.
    */
   localization: Localization;

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -532,9 +532,9 @@ export interface CheckoutApi {
   /**
    * Performs an update on an attribute attached to the cart and checkout. If
    * successful, this mutation results in an update to the value retrieved
-   * through the [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/attributes#standardapi-propertydetail-attributes) property.
+   * through the [`attributes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/attributes#properties-propertydetail-attributes) property.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#properties-propertydetail-instructions) `attributes.canUpdateAttributes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyAttributeChange(change: AttributeChange): Promise<AttributeChangeResult>;
 
@@ -542,22 +542,22 @@ export interface CheckoutApi {
    * Performs an update on the merchandise line items. It resolves when the new
    * line items have been negotiated and results in an update to the value
    * retrieved through the
-   * [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-lines#standardapi-propertydetail-lines)
+   * [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-lines#properties-propertydetail-lines)
    * property.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#properties-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyCartLinesChange(change: CartLineChange): Promise<CartLineChangeResult>;
 
   /**
    * Performs an update on the discount codes.
    * It resolves when the new discount codes have been negotiated and results in an update
-   * to the value retrieved through the [`discountCodes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/discounts#standardapi-propertydetail-discountcodes) property.
+   * to the value retrieved through the [`discountCodes`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/discounts#properties-propertydetail-discountcodes) property.
    *
    * > Caution:
    * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves discount codes through a network call.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#properties-propertydetail-instructions) `discounts.canUpdateDiscountCodes` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyDiscountCodeChange(
     change: DiscountCodeChange,
@@ -566,7 +566,7 @@ export interface CheckoutApi {
   /**
    * Performs an update on the gift cards.
    * It resolves when gift card change have been negotiated and results in an update
-   * to the value retrieved through the [`appliedGiftCards`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/gift-cards#standardapi-propertydetail-appliedgiftcards) property.
+   * to the value retrieved through the [`appliedGiftCards`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/gift-cards#properties-propertydetail-appliedgiftcards) property.
    *
    * > Caution:
    * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#network-access) if your extension retrieves gift card codes through a network call.
@@ -578,18 +578,18 @@ export interface CheckoutApi {
   /**
    * Performs an update on a piece of metadata attached to the checkout. If
    * successful, this mutation results in an update to the value retrieved
-   * through the [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/metafields#standardapi-propertydetail-metafields) property.
+   * through the [`metafields`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/metafields#properties-propertydetail-metafields) property.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#properties-propertydetail-instructions) `metafields.canSetCartMetafields` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyMetafieldChange(change: MetafieldChange): Promise<MetafieldChangeResult>;
 
   /**
    * Performs an update on the note attached to the cart and checkout. If
    * successful, this mutation results in an update to the value retrieved
-   * through the [`note`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/note#standardapi-propertydetail-note) property.
+   * through the [`note`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/note#properties-propertydetail-note) property.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#properties-propertydetail-instructions) `notes.canUpdateNote` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    */
   applyNoteChange(change: NoteChange): Promise<NoteChangeResult>;
 
@@ -604,7 +604,7 @@ export interface CheckoutApi {
    * any prompts. If successful, this mutation results in an update to the value
    * retrieved through the `shippingAddress` property.
    *
-   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#standardapi-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
+   * > Note: This method will return an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions#properties-propertydetail-instructions) `delivery.canSelectCustomAddress` is false, or the buyer is using an accelerated checkout method, such as Apple Pay, Google Pay, or Meta Pay.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -623,7 +623,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The details about the location, language, and currency of the customer. For utilities to easily
    * format and translate content based on these details, you can use the
-   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-i18n)
+   * [`i18n`](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#properties-propertydetail-i18n)
    * object instead.
    */
   localization: Localization;
@@ -1450,7 +1450,7 @@ export interface PaymentTermsTemplate {
    */
   id: string;
   /**
-   * The name of the payment terms translated to the buyer's current language. Refer to [localization.language](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#standardapi-propertydetail-localization).
+   * The name of the payment terms translated to the buyer's current language. Refer to [localization.language](https://shopify.dev/docs/api/checkout-ui-extensions/apis/localization#properties-propertydetail-localization).
    */
   name: string;
   /**


### PR DESCRIPTION
## ⚠️ DO NOT MERGE UNTIL v2 GO-LIVE (Tuesday 2026-04-28)

The TypeScript source is shared between v1 and v2 docs generation. Merging these anchor updates before v2 goes live will break the same links on currently-live v1 pages. Hold until the checkout team confirms v2 go-live.

## What this changes

Updates JSDoc anchor link fragments in checkout UI extension source files to match the renamed v2 API page headings (StandardApi → Properties, CheckoutApi → Methods, etc.). Follows the mapping in shop/issues-learn#1622.

## Fragment mapping applied

| Old | New |
|-----|-----|
| \`#standardapi\` (and \`#standardapi-propertydetail-*\`) | \`#properties\` (and \`#properties-propertydetail-*\`) |
| \`#checkoutapi\` | \`#methods\` |
| \`#orderconfirmationapi\` | \`#order-confirmation-properties\` |
| \`#orderstatusapi\` | \`#order-status-properties\` |
| \`#cartlineitemapi\` | \`#cart-line-item-properties\` |
| \`#shippingoptionlistapi\` | \`#shipping-option-list-properties\` |
| \`#pickuppointlistapi\` | \`#pickup-point-list-properties\` |
| \`#pickuplocationlistapi\` | \`#pickup-location-list-properties\` |
| \`#pickuplocationitemapi\` | \`#pickup-location-item-properties\` |

## Files changed on this branch

- \`packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/standard.ts\` (1 link)
- \`packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts\` (12 links)
- \`packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts\` (2 links)

## Verification

Post-rewrite grep across \`packages/ui-extensions/src\` returns zero hits for any old anchor fragment.

## Related

- Issue: shop/issues-learn#1622 (P0)
- Parent issue: shop/issues-learn#1075
- Heading rename PR: shop/world#589679
- Sibling PRs for 2025-10, 2026-01, 2026-04, 2026-07-rc, and checkout-web will land in the same coordinated merge window.

## Merge checklist

- [ ] v2 go-live confirmed (Tuesday 2026-04-28)
- [ ] Other ui-extensions version PRs ready to merge in parallel
- [ ] checkout-web backport PR ready
- [ ] shopify-dev regen plan ready to run Monday PM