### PR TITLE
Fix cart-line-item target description and commandFor/command patterns

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -1413,7 +1413,7 @@ export interface InteractionProps {
 	 */
 	commandFor?: string;
 	/**
-	 * Sets the action the [`command`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated. Available options:
+	 * Sets the action the `commandFor` target should take when this component is activated. Available options:
 	 *
 	 * - `'--auto'`: Performs the default action appropriate for the target component.
 	 * - `'--show'`: Displays the target component if it's currently hidden.
@@ -1421,7 +1421,7 @@ export interface InteractionProps {
 	 * - `'--toggle'`: Alternates the target component between visible and hidden states.
 	 * - `'--copy'`: Copies the target clipboard item.
 	 *
-	 * The supported actions vary by target component type.
+	 * The supported actions vary by target component type. Learn more about the [`command` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
 	 *
 	 * @default '--auto'
 	 */

--- a/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
@@ -6,7 +6,7 @@ import {SubscribableSignalLike} from '../shared';
  */
 export interface CartLineItemApi {
   /**
-   * The cart line the extension is attached to.
+   * The cart line that this extension is attached to. Use this to read the line item's merchandise, quantity, cost, and attributes.
    */
   target: SubscribableSignalLike<CartLine>;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -1380,27 +1380,21 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
 /** @publicDocs */
 export interface InteractionProps {
   /**
-   * ID of a component that should respond to activations (e.g. clicks) on this component.
-   *
-   * See `command` for how to control the behavior of the target.
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor
+   * The ID of the component to control when this component is activated. Pair with the `command` property to specify what action to perform on the target component. Learn more about the [`commandFor` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor).
    */
   commandFor?: string;
   /**
-   * Sets the action the `commandFor` should take when this clickable is activated.
+   * Sets the action the `commandFor` target should take when this component is activated. Available options:
    *
-   * See the documentation of particular components for the actions they support.
+   * - `'--auto'`: Performs the default action appropriate for the target component.
+   * - `'--show'`: Displays the target component if it's currently hidden.
+   * - `'--hide'`: Conceals the target component from view.
+   * - `'--toggle'`: Alternates the target component between visible and hidden states.
+   * - `'--copy'`: Copies the target clipboard item.
    *
-   * - `--auto`: a default action for the target component.
-   * - `--show`: shows the target component.
-   * - `--hide`: hides the target component.
-   * - `--toggle`: toggles the target component.
-   * - `--copy`: copies the target ClipboardItem.
+   * The supported actions vary by target component type. Learn more about the [`command` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
    *
    * @default '--auto'
-   *
-   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
    */
   command?: '--auto' | '--show' | '--hide' | '--toggle' | '--copy';
   /**


### PR DESCRIPTION
## Summary
- Enriched `CartLineItemApi.target` description in customer-account `cart-line-item.ts` to mention merchandise, quantity, cost, and attributes
- Updated POS `InteractionProps`: rewrote `commandFor`/`command` descriptions, converted `@see` tags to inline links, improved option descriptions
- Fixed checkout `command` description to reference `commandFor` target instead of self-referential `command` link

## Test plan
- [ ] `yarn build` passes
- [ ] Verify descriptions render correctly in generated docs

Made with [Cursor](https://cursor.com)