### PR TITLE
Fix cart-line-item target description

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
@@ -4,7 +4,7 @@ import {CartLine} from '../order-status/order-status';
 
 export interface CartLineItemApi {
   /**
-   * The cart line the extension is attached to.
+   * The cart line that this extension is attached to. Use this to read the line item's merchandise, quantity, cost, and attributes.
    */
   target: StatefulRemoteSubscribable<CartLine>;
 }


### PR DESCRIPTION
## Summary
- Enriched `CartLineItemApi.target` description in customer-account `cart-line-item.ts` to mention merchandise, quantity, cost, and attributes
- Verified: `commandFor`/`command` properties do not exist on this version — no `InteractionProps` fix needed (no `components-shared.d.ts`, and `shared.ts` has no commandFor patterns)

## Test plan
- [ ] `yarn build` passes
- [ ] Verify descriptions render correctly in generated docs

Made with [Cursor](https://cursor.com)