### PR TITLE
Add cart line item docs wrapper + fix commandFor + enrich target (2026-01)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -1440,17 +1440,11 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
 /** @publicDocs */
 export interface InteractionProps {
 	/**
-	 * ID of a component that should respond to activations (such as clicks) on this component.
-	 *
-	 * See `command` for how to control the behavior of the target.
-	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor
+	 * The ID of the component to control when this component is activated. Pair with the `command` property to specify what action to perform on the target component. Learn more about the [`commandFor` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor).
 	 */
 	commandFor?: string;
 	/**
-	 * Sets the action the `commandFor` should take when this clickable is activated.
-	 *
-	 * See the documentation of particular components for the actions they support.
+	 * Sets the action the `commandFor` target should take when this component is activated.
 	 *
 	 * - `--auto`: Performs the default action for the target component.
 	 * - `--show`: Displays the target component.
@@ -1458,9 +1452,9 @@ export interface InteractionProps {
 	 * - `--toggle`: Alternates the target component.
 	 * - `--copy`: Copies the target ClipboardItem.
 	 *
-	 * @default '--auto'
+	 * Learn more about the [`command` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command).
 	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command
+	 * @default '--auto'
 	 */
 	command?: "--auto" | "--show" | "--hide" | "--toggle" | "--copy";
 	/**

--- a/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/cart-line/cart-line-item.ts
@@ -3,7 +3,7 @@ import {SubscribableSignalLike} from '../shared';
 
 export interface CartLineItemApi {
   /**
-   * The cart line the extension is attached to.
+   * The cart line that this extension is attached to. Use this to read the line item's merchandise, quantity, cost, and attributes.
    */
   target: SubscribableSignalLike<CartLine>;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/docs.ts
@@ -204,6 +204,7 @@ export interface Docs_OrderStatus_CartLinesApi
   extends Pick<OrderStatusApi<any>, 'lines'> {}
 
 /**
+ * The API object provided to `customer-account.order-status.cart-line-item.render-after` extension targets for interacting with individual cart line items.
  * @publicDocs
  */
 export interface Docs_CartLineItem_CartLinesApi


### PR DESCRIPTION
- Add JSDoc + @publicDocs to Docs_CartLineItem_CartLinesApi
- Fix commandFor/command in components-shared.d.ts (remove @see, old patterns)
- Enrich cart-line-item target description to match checkout

Made with [Cursor](https://cursor.com)