### PR TITLE
2026 07 rc target mapping

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -367,6 +367,20 @@ const COMPOSITE_API_DECOMPOSITION = {
     'MetafieldsApi',
     'NoteApi',
   ],
+  AddressAutocompleteStandardApi: [
+    'AddressesApi',
+    'AnalyticsApi',
+    'AttributesApi',
+    'CheckoutTokenApi',
+    'ExtensionApi',
+    'LocalizationApi',
+    'MetafieldsApi',
+    'SessionTokenApi',
+    'SettingsApi',
+    'ShopApi',
+    'StorageApi',
+    'StorefrontApi',
+  ],
 };
 
 function parseApis(apiString) {

--- a/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/checkout/build-docs-targets-json.mjs
@@ -11,11 +11,10 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Find the generated_docs_data.json file to determine output location
+// Output targets.json next to generated_docs_data_v2.json (wherever it lives).
 function findGeneratedDocsPath() {
   const generatedDir = path.join(__dirname, 'generated');
 
-  // Look for generated_docs_data.json recursively
   function findFile(dir) {
     const files = fs.readdirSync(dir);
     for (const file of files) {
@@ -24,7 +23,7 @@ function findGeneratedDocsPath() {
       if (stat.isDirectory()) {
         const result = findFile(fullPath);
         if (result) return result;
-      } else if (file === 'generated_docs_data.json') {
+      } else if (file === 'generated_docs_data_v2.json') {
         return path.dirname(fullPath);
       }
     }
@@ -32,31 +31,13 @@ function findGeneratedDocsPath() {
   }
 
   const docsPath = findFile(generatedDir);
-  return docsPath || generatedDir; // Fallback to generated root if not found
-}
-
-// Accept an API version argument (e.g. 2026-04-rc) to output targets.json into
-// a versioned directory matching the customer-account pattern.
-// Falls back to the directory containing generated_docs_data.json if not provided.
-const apiVersion = process.argv[2];
-
-function resolveOutputPath() {
-  if (apiVersion) {
-    return path.join(
-      __dirname,
-      'generated',
-      'checkout_ui_extensions',
-      apiVersion,
-      'targets.json',
-    );
-  }
-  return path.join(findGeneratedDocsPath(), 'targets.json');
+  return docsPath || generatedDir;
 }
 
 // Configuration for checkout surface
 const config = {
   basePath: path.join(__dirname, '../../../src/surfaces/checkout'),
-  outputPath: resolveOutputPath(),
+  outputPath: path.join(findGeneratedDocsPath(), 'targets.json'),
   componentTypesPath: null,
   hasComponentTypes: false,
 };
@@ -349,9 +330,44 @@ function getNestedApis(apiName) {
   }
 }
 
-// No composite API decomposition — StandardApi, CheckoutApi, and OrderConfirmationApi
-// are plain interfaces and are rendered as-is in the targets.json.
-const COMPOSITE_API_DECOMPOSITION = {};
+// APIs that are composites — list their documented constituent APIs instead of themselves
+const COMPOSITE_API_DECOMPOSITION = {
+  StandardApi: [
+    'AddressesApi',
+    'AnalyticsApi',
+    'AttributesApi',
+    'BuyerIdentityApi',
+    'BuyerJourneyApi',
+    'CartInstructionsApi',
+    'CartLinesApi',
+    'CheckoutTokenApi',
+    'CostApi',
+    'CustomerPrivacyApi',
+    'DeliveryApi',
+    'DiscountsApi',
+    'ExtensionApi',
+    'GiftCardsApi',
+    'LocalizationApi',
+    'LocalizedFieldsApi',
+    'MetafieldsApi',
+    'NoteApi',
+    'PaymentsApi',
+    'SessionTokenApi',
+    'SettingsApi',
+    'ShopApi',
+    'StorageApi',
+    'StorefrontApi',
+  ],
+  CheckoutApi: [
+    'AddressesApi',
+    'AttributesApi',
+    'CartLinesApi',
+    'DiscountsApi',
+    'GiftCardsApi',
+    'MetafieldsApi',
+    'NoteApi',
+  ],
+};
 
 function parseApis(apiString) {
   const apisSet = new Set();

--- a/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
+++ b/packages/ui-extensions/docs/surfaces/customer-account/build-docs-targets-json.mjs
@@ -11,11 +11,10 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Find the generated_docs_data.json file to determine output location
+// Output targets.json next to generated_docs_data_v2.json (wherever it lives).
 function findGeneratedDocsPath() {
   const generatedDir = path.join(__dirname, 'generated');
 
-  // Look for generated_docs_data.json recursively
   function findFile(dir) {
     const files = fs.readdirSync(dir);
     for (const file of files) {
@@ -24,7 +23,7 @@ function findGeneratedDocsPath() {
       if (stat.isDirectory()) {
         const result = findFile(fullPath);
         if (result) return result;
-      } else if (file === 'generated_docs_data.json' || file === 'generated_docs_data_v2.json') {
+      } else if (file === 'generated_docs_data_v2.json') {
         return path.dirname(fullPath);
       }
     }
@@ -32,29 +31,13 @@ function findGeneratedDocsPath() {
   }
 
   const docsPath = findFile(generatedDir);
-  return docsPath || generatedDir; // Fallback to generated root if not found
-}
-
-// Accept an API version argument (e.g. 2025-07) to output targets.json into a versioned directory.
-const apiVersion = process.argv[2];
-
-function resolveOutputPath() {
-  if (apiVersion) {
-    return path.join(
-      __dirname,
-      'generated',
-      'customer_account_ui_extensions',
-      apiVersion,
-      'targets.json',
-    );
-  }
-  return path.join(findGeneratedDocsPath(), 'targets.json');
+  return docsPath || generatedDir;
 }
 
 // Configuration for customer-account surface
 const config = {
   basePath: path.join(__dirname, '../../../src/surfaces/customer-account'),
-  outputPath: resolveOutputPath(),
+  outputPath: path.join(findGeneratedDocsPath(), 'targets.json'),
   componentTypesPath: 'components',
   hasComponentTypes: true,
 };
@@ -438,9 +421,42 @@ function getNestedApis(apiName) {
 // StandardApi and OrderStatusApi are plain interfaces (not type intersections), so the
 // decomposition must be explicit, matching the Docs_Standard_*Api / Docs_OrderStatus_*Api
 // interfaces defined in src/surfaces/customer-account/api/docs.ts.
-// No composite API decomposition — StandardApi and OrderStatusApi are plain interfaces
-// and are rendered as-is in the targets.json.
-const COMPOSITE_API_DECOMPOSITION = {};
+// APIs that are composites — list their documented constituent APIs instead of themselves
+const COMPOSITE_API_DECOMPOSITION = {
+  StandardApi: [
+    'AnalyticsApi',
+    'AuthenticatedAccountApi',
+    'CustomerAccountApi',
+    'CustomerPrivacyApi',
+    'ExtensionApi',
+    'IntentsApi',
+    'LocalizationApi',
+    'NavigationApi',
+    'SessionTokenApi',
+    'SettingsApi',
+    'StorageApi',
+    'StorefrontApi',
+    'ToastApi',
+    'VersionApi',
+  ],
+  OrderStatusApi: [
+    'AddressesApi',
+    'AttributesApi',
+    'AuthenticationStateApi',
+    'BuyerIdentityApi',
+    'CartLinesApi',
+    'CheckoutSettingsApi',
+    'CostApi',
+    'DiscountsApi',
+    'GiftCardsApi',
+    'MetafieldsApi',
+    'NoteApi',
+    'OrderApi',
+    'OrderStatusLocalizationApi',
+    'RequireLoginApi',
+    'ShopApi',
+  ],
+};
 
 function parseApis(apiString) {
   const apisSet = new Set();
@@ -662,7 +678,12 @@ try {
   // These components have doc pages but are not exported from the TypeScript source,
   // so the script cannot discover them automatically. Add them manually with all targets.
   const allTargetNames = Object.keys(targetsJson).sort();
-  const UNDISCOVERABLE_COMPONENTS = ['Chat', 'ConsentCheckbox', 'ConsentPhoneField', 'StyleHelper'];
+  const UNDISCOVERABLE_COMPONENTS = [
+    'Chat',
+    'ConsentCheckbox',
+    'ConsentPhoneField',
+    'StyleHelper',
+  ];
   for (const component of UNDISCOVERABLE_COMPONENTS) {
     if (!combinedJson[component]) {
       combinedJson[component] = {targets: allTargetNames};


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)
when creating docs for customer account and checkout we need to map between the code targets and the doc targets 

### Solution

update the mapping in the doc generation script.
also put the output of targets in the correct location.

### 🎩

- ...

### Checklist

- [ x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
