### PR TITLE
No-op - Pinning github actions to commit SHAs

### DIFF
--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - uses: actions/checkout@v3
-      - uses: mskelton/changelog-reminder-action@7039cd14fb784c0a2b37f6e7a6ade2c9148c2245 # v2
+      - uses: mskelton/changelog-reminder-action@7039cd14fb784c0a2b37f6e7a6ade2c9148c2245 # v2.0.0
         with:
           changelogRegex: "\\.changeset"
           message: >

--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -31,7 +31,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - uses: actions/checkout@v3
-      - uses: mskelton/changelog-reminder-action@v2
+      - uses: mskelton/changelog-reminder-action@7039cd14fb784c0a2b37f6e7a6ade2c9148c2245 # v2
         with:
           changelogRegex: "\\.changeset"
           message: >


### PR DESCRIPTION
## Why?

By using `some-org/some-action@v3` you are trusting a mutable tag. If the upstream repo is compromised, a force-pushed `v3` ships malicious code into your workflow on the next run — see [tj-actions/changed-files (March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066) for recent real-world cases that leaked secrets across thousands of downstream workflows.

Pinning to a full 40-char SHA (`uses: tj-actions/changed-files@<sha> # v45.0.3`) makes the reference immutable and helps to mitigate this type of supply chain attacks.


cc @sordaz00 for review.