### PR TITLE
feat: add toast and app api for admin app home

### DIFF
--- a/packages/ui-extensions-tester/src/admin/factories.ts
+++ b/packages/ui-extensions-tester/src/admin/factories.ts
@@ -7,6 +7,7 @@ import type {
   ProductDetailsConfigurationApi,
   Intents,
   ToastApi,
+  AppApi,
 } from '@shopify/ui-extensions/admin';
 import {createReadonlySignalLike} from '../mocks/signals';
 import {createMockI18n} from '../mocks/i18n';
@@ -112,10 +113,17 @@ function createMockToastApi(): ToastApi {
   };
 }
 
+function createMockAppApi(): AppApi {
+  return {
+    extensions: async () => [],
+  };
+}
+
 function createAppHomeMock<T extends ExtensionTarget>(target: T) {
   return {
     ...createMockStandardRenderingApi(target),
     toast: createMockToastApi(),
+    app: createMockAppApi(),
   };
 }
 

--- a/packages/ui-extensions-tester/src/admin/factories.ts
+++ b/packages/ui-extensions-tester/src/admin/factories.ts
@@ -6,6 +6,7 @@ import type {
   BlockExtensionApi,
   ProductDetailsConfigurationApi,
   Intents,
+  ToastApi,
 } from '@shopify/ui-extensions/admin';
 import {createReadonlySignalLike} from '../mocks/signals';
 import {createMockI18n} from '../mocks/i18n';
@@ -101,6 +102,20 @@ function createMockStandardRenderingApi<T extends ExtensionTarget>(target: T) {
     picker: (async () => ({
       selected: Promise.resolve(undefined),
     })) as PickerApi,
+  };
+}
+
+function createMockToastApi(): ToastApi {
+  return {
+    show: () => {},
+    hide: () => {},
+  };
+}
+
+function createAppHomeMock<T extends ExtensionTarget>(target: T) {
+  return {
+    ...createMockStandardRenderingApi(target),
+    toast: createMockToastApi(),
   };
 }
 
@@ -272,7 +287,7 @@ const adminMockFactories: AdminMockFactory = {
   'admin.app.tools.data': createMockStandardApi,
 
   // App render targets
-  'admin.app.home.render': createMockStandardRenderingApi,
+  'admin.app.home.render': createAppHomeMock,
   'admin.app.intent.render': createAppIntentRenderMock,
 
   // Block targets

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,5 +1,7 @@
 export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi, Intents} from './api/standard/standard';
+export type {ToastApi, ToastOptions} from './api/toast/toast';
+export type {AppHomeApi} from './api/app-home/app-home';
 export type {StandardRenderingExtensionApi} from './api/standard/standard-rendering';
 export type {Navigation} from './api/block/block';
 export type {

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,6 +1,17 @@
 export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi, Intents} from './api/standard/standard';
 export type {ToastApi, ToastOptions} from './api/toast/toast';
+export type {
+  AppApi,
+  ExtensionInfo,
+  ExtensionType,
+  ExtensionStatus,
+  UiExtensionActivation,
+  ThemeBlockActivation,
+  ThemeExtensionBlockActivation,
+  ThemeAppBlockTarget,
+  ThemeAppEmbedTarget,
+} from './api/app/app';
 export type {AppHomeApi} from './api/app-home/app-home';
 export type {StandardRenderingExtensionApi} from './api/standard/standard-rendering';
 export type {Navigation} from './api/block/block';

--- a/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
@@ -1,9 +1,10 @@
 import type {StandardApi} from '../standard/standard';
 import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
 import type {ToastApi} from '../toast/toast';
+import type {AppApi} from '../app/app';
 
 /**
- * The `AppHomeApi` object provides methods for app home extensions. Access the following properties on the `AppHomeApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle intents, persist data, and display toast notifications.
+ * The `AppHomeApi` object provides methods for app home extensions. Access the following properties on the `AppHomeApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle intents, persist data, display toast notifications, and access app-level data.
  * @publicDocs
  */
 export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>
@@ -12,4 +13,9 @@ export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>
    * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.
    */
   toast: ToastApi;
+
+  /**
+   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.
+   */
+  app: AppApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
@@ -1,0 +1,15 @@
+import type {StandardApi} from '../standard/standard';
+import type {ExtensionTarget as AnyExtensionTarget} from '../../extension-targets';
+import type {ToastApi} from '../toast/toast';
+
+/**
+ * The `AppHomeApi` object provides methods for app home extensions. Access the following properties on the `AppHomeApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle intents, persist data, and display toast notifications.
+ * @publicDocs
+ */
+export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>
+  extends StandardApi<ExtensionTarget> {
+  /**
+   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.
+   */
+  toast: ToastApi;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/app/app.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/app/app.ts
@@ -1,0 +1,123 @@
+/**
+ * The type of extension.
+ * @publicDocs
+ */
+export type ExtensionType = 'ui_extension' | 'theme_app_extension';
+
+/**
+ * The status of an extension indicating whether it's active, available for activation, or unavailable.
+ * @publicDocs
+ */
+export type ExtensionStatus = 'active' | 'available' | 'unavailable';
+
+/**
+ * The target location for theme app blocks within a theme section.
+ * @publicDocs
+ */
+export type ThemeAppBlockTarget = 'section';
+
+/**
+ * The target location for theme app embeds within the document.
+ * @publicDocs
+ */
+export type ThemeAppEmbedTarget = 'head' | 'body' | 'compliance_head';
+
+/**
+ * Represents an activation of a UI extension at a specific target.
+ * @publicDocs
+ */
+export interface UiExtensionActivation {
+  /**
+   * The extension target where this extension is activated.
+   */
+  target: string;
+}
+
+/**
+ * Represents an activation of a theme block at a specific target within a theme.
+ * @publicDocs
+ */
+export interface ThemeBlockActivation {
+  /**
+   * The target location within the theme.
+   */
+  target: string;
+
+  /**
+   * The ID of the theme where this block is activated.
+   */
+  themeId: string;
+}
+
+/**
+ * Represents a theme extension block activation with its status and nested activations.
+ * @publicDocs
+ */
+export interface ThemeExtensionBlockActivation {
+  /**
+   * The target location for this theme extension block or embed.
+   */
+  target: ThemeAppBlockTarget | ThemeAppEmbedTarget;
+
+  /**
+   * The handle identifier for this theme extension block.
+   */
+  handle: string;
+
+  /**
+   * The display name of this theme extension block.
+   */
+  name: string;
+
+  /**
+   * The current status of this theme extension block.
+   */
+  status: ExtensionStatus;
+
+  /**
+   * The list of theme-specific activations for this block.
+   */
+  activations: ThemeBlockActivation[];
+}
+
+/**
+ * Information about an extension registered for the current app.
+ * @publicDocs
+ */
+export interface ExtensionInfo {
+  /**
+   * The unique handle identifier for this extension, if available.
+   */
+  handle?: string | null;
+
+  /**
+   * The list of activations for this extension. For UI extensions, this contains target information.
+   * For theme extensions, this contains detailed block activation information.
+   */
+  activations: UiExtensionActivation[] | ThemeExtensionBlockActivation[];
+
+  /**
+   * The current status of this extension.
+   */
+  status?: ExtensionStatus;
+
+  /**
+   * The type of extension.
+   */
+  type?: ExtensionType;
+}
+
+/**
+ * The `AppApi` object provides methods for interacting with app-level data and functionality.
+ * Use this API to query information about extensions registered for the current app.
+ * @publicDocs
+ */
+export interface AppApi {
+  /**
+   * Returns a list of all extensions registered for the current app, including their activation status and target information.
+   * Use this to discover what extensions are available and where they are activated.
+   *
+   * @returns A promise that resolves to an array of extension information objects.
+   */
+  extensions: () => Promise<ExtensionInfo[]>;
+}

--- a/packages/ui-extensions/src/surfaces/admin/api/toast/toast.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/toast/toast.ts
@@ -1,0 +1,50 @@
+/**
+ * Options for configuring toast notification behavior and appearance.
+ * @publicDocs
+ */
+export interface ToastOptions {
+  /**
+   * The duration in milliseconds to display the toast before automatically dismissing. If not specified, a default duration is used.
+   */
+  duration?: number;
+
+  /**
+   * Whether to display the toast as an error notification. Use for error messages or failed operations.
+   * @defaultValue false
+   */
+  isError?: boolean;
+
+  /**
+   * The label for an optional action button displayed in the toast. When provided, an action button appears that the user can click.
+   */
+  action?: string;
+
+  /**
+   * Callback function triggered when the user clicks the action button. Only called if `action` is provided.
+   */
+  onAction?: () => void;
+
+  /**
+   * Callback function triggered when the toast is dismissed, either automatically after the duration expires or manually by the user.
+   */
+  onDismiss?: () => void;
+}
+
+/**
+ * The `ToastApi` object provides methods for displaying temporary notification messages. Access these methods through `shopify.toast` to show user feedback and status updates.
+ * @publicDocs
+ */
+export interface ToastApi {
+  /**
+   * Displays a toast notification with the specified message. The toast appears as a temporary overlay that automatically dismisses after the specified duration. Use for providing immediate user feedback, confirming actions, or communicating status updates without interrupting the user's workflow.
+   *
+   * @param message - The text content to display in the toast notification.
+   * @param options - Optional configuration for the toast behavior and appearance.
+   */
+  show: (message: string, options?: ToastOptions) => void;
+
+  /**
+   * Dismisses any currently visible toast notification. Use this to programmatically hide a toast before its duration expires.
+   */
+  hide: () => void;
+}

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -14,6 +14,7 @@ import type {
   CustomerSegmentTemplate,
   StandardApi,
   IntentRenderApi,
+  AppHomeApi,
 } from './api';
 import {
   ShouldRenderApi,
@@ -680,7 +681,7 @@ export interface ExtensionTargets {
    * Renders an admin extension on the app home page.
    */
   'admin.app.home.render': RenderExtension<
-    StandardApi<'admin.app.home.render'>,
+    AppHomeApi<'admin.app.home.render'>,
     FormExtensionComponents | 'Modal' | 'Page'
   >;
 }


### PR DESCRIPTION
### Background

Closes https://github.com/shop/issues-admin-extensibility/issues/2456

admin-web PR: https://app.graphite.com/github/pr/shop/world/656740

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- Grab the latest snapshot version
- Pop it in your app home extension
- Type errors magically vanish 🪄 

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
