### PR TITLE
Add GitHub Action to track forward-ports from stable branches to RC

### DIFF
--- a/.github/workflows/rc-port-tracker.yml
+++ b/.github/workflows/rc-port-tracker.yml
@@ -1,0 +1,165 @@
+name: RC port tracker
+
+on:
+  pull_request:
+    types: [opened, reopened, closed]
+    branches:
+      - 20[0-9][0-9]-[01][1470]
+      - 20[0-9][0-9]-[01][1470]-rc
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label-stable-pr:
+    name: Label PRs against stable branches
+    if: |
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      !endsWith(github.event.pull_request.base.ref, '-rc') &&
+      !startsWith(github.head_ref, 'changeset-release/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const LABEL = 'needs-rc-port';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            const branches = await github.paginate(github.rest.repos.listBranches, {
+              owner, repo, per_page: 100,
+            });
+            const branchNames = branches.map(b => b.name);
+
+            const stableBranches = branchNames
+              .filter(n => /^\d{4}-(?:01|04|07|10)$/.test(n))
+              .sort();
+            const latestStable = stableBranches[stableBranches.length - 1];
+
+            if (pr.base.ref !== latestStable) return;
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: pr.number, labels: [LABEL],
+            });
+
+            if (context.payload.action !== 'opened') return;
+
+            const rcBranches = branchNames
+              .filter(n => /^\d{4}-(?:01|04|07|10)-rc$/.test(n))
+              .sort();
+            const latestRc = rcBranches[rcBranches.length - 1];
+            const rcLabel = latestRc ? `\`${latestRc}\`` : 'the current RC branch';
+
+            const body = [
+              `This PR targets a stable release branch (\`${pr.base.ref}\`). Once merged, the change typically also needs to be forward-ported to ${rcLabel} so it ships in the next release.`,
+              '',
+              `When you open the forward-port PR, include a line like this in its body so the \`${LABEL}\` label gets removed automatically when that PR merges:`,
+              '',
+              '```',
+              `Forward-port of #${pr.number}`,
+              '```',
+              '',
+              'Accepted formats (comma-separated for multiple):',
+              `- \`#${pr.number}\``,
+              `- \`GH-${pr.number}\``,
+              `- \`${pr.number}\``,
+              `- \`https://github.com/${owner}/${repo}/pull/${pr.number}\``,
+              '',
+              `If a forward-port isn't needed (e.g., the change is stable-only), you can remove the \`${LABEL}\` label manually.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: pr.number, body,
+            });
+
+  process-rc-merge:
+    name: Process forward-port references on RC merge
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      endsWith(github.event.pull_request.base.ref, '-rc')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const LABEL = 'needs-rc-port';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            const refs = new Set();
+            const crossRepo = [];
+
+            const blockRegex = /forward-port\s+of:?\s*(.*?)(?:\n\s*\n|$)/gis;
+            for (const match of body.matchAll(blockRegex)) {
+              const tokens = match[1].split(/[\s,;]+/).filter(Boolean);
+              for (const token of tokens) {
+                if (/^(?:-|\*|and|&)$/i.test(token)) continue;
+
+                const url = token.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/i);
+                if (url) {
+                  const [, urlOwner, urlRepo, num] = url;
+                  if (urlOwner.toLowerCase() === owner.toLowerCase() &&
+                      urlRepo.toLowerCase() === repo.toLowerCase()) {
+                    refs.add(parseInt(num, 10));
+                  } else {
+                    crossRepo.push(token);
+                  }
+                  continue;
+                }
+
+                const num = token.match(/^(?:#|GH-)?(\d+)$/i);
+                if (num) refs.add(parseInt(num[1], 10));
+              }
+            }
+
+            if (crossRepo.length) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number,
+                body: `⚠️ The following forward-port references point to a different repository and were ignored:\n${crossRepo.map(r => `- ${r}`).join('\n')}`,
+              });
+            }
+
+            if (refs.size === 0) return;
+
+            for (const num of refs) {
+              try {
+                const { data: ref } = await github.rest.pulls.get({
+                  owner, repo, pull_number: num,
+                });
+
+                if (/-rc$/.test(ref.base.ref)) {
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: pr.number,
+                    body: `⚠️ Skipping #${num}: it targets \`${ref.base.ref}\`, not a stable branch.`,
+                  });
+                  continue;
+                }
+
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: num, name: LABEL,
+                  });
+                } catch (e) {
+                  if (e.status !== 404) throw e;
+                }
+
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: num,
+                  body: `✓ Forward-ported in #${pr.number}.`,
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: pr.number,
+                    body: `⚠️ Forward-port reference #${num} could not be found.`,
+                  });
+                  continue;
+                }
+                throw e;
+              }
+            }


### PR DESCRIPTION
## Summary

Sometimes folks merge PRs to a stable branch (e.g. `2026-04`) but forget to forward-port to the current RC (`2026-07-rc`). When the RC becomes the next stable, those changes could get silently missing and it is a lot of effort to find them close to the release. We can't catch this by comparing commits either sicne the RC has often diverged enough that the patch is genuinely different.

This adds a GitHub Action that does two things:

- **On PR opened against a stable branch (`20XX-XX`)** → tag with `needs-rc-port` and post a comment with copy-paste reference snippets pointing at the current RC.
- **On PR merged into the RC branch (`20XX-XX-rc`)** → parse the body for `Forward-port of #X` references, remove the label from each referenced PR, and post a `Forward-ported in #Y` confirmation comment back on the original.

Open debt is just `is:pr label:needs-rc-port`. If a change is genuinely stable-only, a maintainer can drop the label by hand.
Once we have the labels, we can build tooling and dashboards to catch missed PRs earlier and ping folks to take care of them.

## Flow

```mermaid
---
config:
  theme: neutral
---
flowchart TD
    A([PR opened against stable branch e.g. 2026-04]) --> B[Bot adds needs-rc-port label]
    B --> C[Bot posts comment with reference templates]
    C --> D[PR merged into stable branch]
    D --> E{Forward-port needed?}
    E -->|yes| F[Author opens forward-port PR<br/>against current RC e.g. 2026-07-rc]
    F --> G[PR body includes: Forward-port of #X]
    G --> H[Forward-port PR merged]
    H --> I[Bot parses body, finds referenced PR]
    I --> J[Bot removes needs-rc-port label]
    J --> K[Bot posts: Forward-ported in #Y]
    E -->|no, stable-only change| L[Maintainer removes label manually]

    style B fill:#fff4cc,stroke:#d4a72c
    style C fill:#fff4cc,stroke:#d4a72c
    style I fill:#fff4cc,stroke:#d4a72c
    style J fill:#fff4cc,stroke:#d4a72c
    style K fill:#fff4cc,stroke:#d4a72c
```

Editable on mermaid.shopify.io: https://mermaid.shopify.io/edit#pako:eNqNk0FP4zAQhf_KKL2AVAOqKpAixIq2FFpAQhWHXaU9OPY4iXDsynaoorb_HccJbHtBPeSU78178ybZRkxzjOKIELJUTCtRZPFSAbgcS4xBYeUMlUsV3gupNyynxsH7pIEA7s-StwXoNSrkQDNaKOvAOppKhNRQxXLAi-wCBleDa3I1XJ0DIXcwSkbaAeXcegPklhhG1tqPlTRFuWpHjwI6DuhaW2eB6bJE5WBTuBwMCjSoGILDci2pQ9sJx0E4aYKVaDIfrFBOH6fq0ElAH7ZTbTbU8DZEEwn5n32LPDTIrka7g2lyX7lcm7CvBXEoelvcpuby7rsCVhnTRF2MD_e_8Yt2ztPg_NiETDWvfUQmK442hqMsWkDvbyd5DJKnZHrs2y3ZQU8BmrWtUWPRhvl9EIXydf-0xr2yk8yCZB4kBkv9ib-dZR7o5_9nOU4c2obev9Vhe0r3u_qJVrIG_w2pDHfwkrz6upx_0PxYBzMoqaqolLWf006yrvbXG_k9pIx7QoghY33rjP7AuMeH9GbADsHxqeDsVHB-Kvj8Oxj1I3-xkhY8irdR-M_8_8dR0Eq6aL__Ata5KYk


## 🎩 
I'm afraid we'll have to merge it to test it. I'm not aware of a way to easily test this without creating a fork etc.

Since this is low risk and impact, I think it's fine to merge, test and adjust.