### PR TITLE
Add s-app-nav component for admin.app.home.render target

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,4 +1,6 @@
 name: ui-extensions
+minimum_dependency_age:
+  enforce: false
 
 up:
   - node:

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
@@ -1,0 +1,145 @@
+/** VERSION: 1.25.0 **/
+/* eslint-disable import/extensions */
+
+/* eslint-disable @typescript-eslint/no-namespace */
+
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
+/// <reference lib="DOM" />
+import type {ComponentChildren} from './shared.d.ts';
+
+/**
+ * The properties for the app nav component. This component renders a navigation menu for the app in the Shopify admin.
+ * @publicDocs
+ */
+export interface AppNavProps {}
+
+declare const tagName = 's-app-nav';
+
+/**
+ * The JSX props for the app nav component. These properties provide optional `id` for element identification in JSX rendering.
+ * @publicDocs
+ */
+export interface AppNavJSXProps {
+  /**
+   * A unique identifier for the element.
+   */
+  id?: string;
+}
+
+/**
+ * The CSS styles as a string, used for styling web components within their shadow DOM.
+ * @publicDocs
+ */
+export type Styles = string;
+/**
+ * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
+ * @publicDocs
+ */
+export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
+  /**
+   * The render function that returns Preact/JSX elements to display in the component's shadow root.
+   */
+  ShadowRoot: (element: any) => ComponentChildren;
+  /**
+   * The optional CSS styles to inject into the component's shadow DOM.
+   */
+  styles?: Styles;
+};
+/**
+ * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
+ * @publicDocs
+ */
+export interface ActivationEventEsque {
+  /**
+   * Whether the Shift key was pressed during the activation event.
+   */
+  shiftKey: boolean;
+  /**
+   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
+   */
+  metaKey: boolean;
+  /**
+   * Whether the Control key was pressed during the activation event.
+   */
+  ctrlKey: boolean;
+  /**
+   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
+   */
+  button: number;
+}
+/**
+ * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
+ * @publicDocs
+ */
+export interface ClickOptions {
+  /**
+   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
+   */
+  sourceEvent?: ActivationEventEsque;
+}
+/**
+ * Base class for creating custom elements with Preact.
+ * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
+ * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
+ */
+declare const BaseClass: typeof globalThis.HTMLElement;
+declare abstract class PreactCustomElement extends BaseClass {
+  /** @private */
+  static get observedAttributes(): string[];
+  constructor({
+    styles,
+    ShadowRoot: renderFunction,
+    delegatesFocus,
+    ...options
+  }: RenderImpl);
+
+  /** @private */
+  setAttribute(name: string, value: string): void;
+  /** @private */
+  attributeChangedCallback(name: string): void;
+  /** @private */
+  connectedCallback(): void;
+  /** @private */
+  disconnectedCallback(): void;
+  /** @private */
+  adoptedCallback(): void;
+  /**
+   * Queue a run of the render function.
+   * You shouldn't need to call this manually - it should be handled by changes to @property values.
+   * @private
+   */
+  queueRender(): void;
+  /**
+   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
+   *
+   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
+   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
+   * @private
+   * @param options
+   */
+  click({sourceEvent}?: ClickOptions): void;
+}
+
+/**
+ * The app nav custom element class that renders a navigation menu for the app in the Shopify admin. On desktop, the navigation appears in the left sidebar. On Shopify mobile, it appears in a dropdown from the title bar. Use link child elements to define navigation items and designate a home route with `rel="home"`.
+ */
+declare class AppNav extends PreactCustomElement implements AppNavProps {
+  constructor();
+}
+declare global {
+  interface HTMLElementTagNameMap {
+    [tagName]: AppNav;
+  }
+}
+declare module 'preact' {
+  namespace createElement.JSX {
+    interface IntrinsicElements {
+      [tagName]: AppNavJSXProps & {
+        children?: preact.ComponentChildren;
+      };
+    }
+  }
+}
+
+export {AppNav};
+export type {AppNavJSXProps};

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav.d.ts
@@ -1,129 +1,28 @@
-/** VERSION: 1.25.0 **/
+/** VERSION: 1.67.0 **/
 /* eslint-disable import/extensions */
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ComponentChildren} from './shared.d.ts';
+import type {
+  AppNavProps$1,
+  PreactCustomElement,
+  RenderImpl,
+} from './shared.d.ts';
 
-/**
- * The properties for the app nav component. This component renders a navigation menu for the app in the Shopify admin.
- * @publicDocs
- */
 export interface AppNavProps {}
 
 declare const tagName = 's-app-nav';
+export interface AppNavJSXProps
+  extends Partial<AppNavProps>,
+    Pick<AppNavProps$1, 'id'> {}
 
-/**
- * The JSX props for the app nav component. These properties provide optional `id` for element identification in JSX rendering.
- * @publicDocs
- */
-export interface AppNavJSXProps {
-  /**
-   * A unique identifier for the element.
-   */
-  id?: string;
+declare class PolarisCustomElement extends PreactCustomElement {
+  constructor(renderImpl: Omit<RenderImpl, 'globalShadowCSS'>);
 }
 
-/**
- * The CSS styles as a string, used for styling web components within their shadow DOM.
- * @publicDocs
- */
-export type Styles = string;
-/**
- * The implementation configuration for rendering a Preact component into a shadow root. Defines the render function that returns JSX elements and optional CSS styles to apply to the component's shadow DOM.
- * @publicDocs
- */
-export type RenderImpl = Omit<ShadowRootInit, 'mode'> & {
-  /**
-   * The render function that returns Preact/JSX elements to display in the component's shadow root.
-   */
-  ShadowRoot: (element: any) => ComponentChildren;
-  /**
-   * The optional CSS styles to inject into the component's shadow DOM.
-   */
-  styles?: Styles;
-};
-/**
- * The properties of an activation event (such as a click or keyboard press) that describe which modifier keys and mouse buttons were involved. This is used to determine intended behavior like opening links in new tabs when Command/Control is pressed.
- * @publicDocs
- */
-export interface ActivationEventEsque {
-  /**
-   * Whether the Shift key was pressed during the activation event.
-   */
-  shiftKey: boolean;
-  /**
-   * Whether the Meta key (Command on Mac, Windows key on Windows) was pressed during the activation event.
-   */
-  metaKey: boolean;
-  /**
-   * Whether the Control key was pressed during the activation event.
-   */
-  ctrlKey: boolean;
-  /**
-   * The mouse button that was pressed during the activation event. `0` for primary button (left click), `1` for auxiliary button (middle click), `2` for secondary button (right click).
-   */
-  button: number;
-}
-/**
- * The options for controlling how a synthetic click behaves. Allows passing modifier key states and button information from an original event to influence link behavior such as opening in new tabs or background tabs.
- * @publicDocs
- */
-export interface ClickOptions {
-  /**
-   * The activation event (such as a click or keyboard event) whose modifier key state and button information should influence the synthetic click behavior. For example, passing an event with `metaKey: true` will cause links to open in a new tab.
-   */
-  sourceEvent?: ActivationEventEsque;
-}
-/**
- * Base class for creating custom elements with Preact.
- * While this class could be used in both Node and the browser, the constructor will only be used in the browser.
- * So we give it a type of HTMLElement to avoid typing issues later where it's used, which will only happen in the browser.
- */
-declare const BaseClass: typeof globalThis.HTMLElement;
-declare abstract class PreactCustomElement extends BaseClass {
-  /** @private */
-  static get observedAttributes(): string[];
-  constructor({
-    styles,
-    ShadowRoot: renderFunction,
-    delegatesFocus,
-    ...options
-  }: RenderImpl);
-
-  /** @private */
-  setAttribute(name: string, value: string): void;
-  /** @private */
-  attributeChangedCallback(name: string): void;
-  /** @private */
-  connectedCallback(): void;
-  /** @private */
-  disconnectedCallback(): void;
-  /** @private */
-  adoptedCallback(): void;
-  /**
-   * Queue a run of the render function.
-   * You shouldn't need to call this manually - it should be handled by changes to @property values.
-   * @private
-   */
-  queueRender(): void;
-  /**
-   * Like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.
-   *
-   * For example, if the `sourceEvent` was a middle click, or has particular keys held down,
-   * components will attempt to produce the desired behavior on links, such as opening the page in the background tab.
-   * @private
-   * @param options
-   */
-  click({sourceEvent}?: ClickOptions): void;
-}
-
-/**
- * The app nav custom element class that renders a navigation menu for the app in the Shopify admin. On desktop, the navigation appears in the left sidebar. On Shopify mobile, it appears in a dropdown from the title bar. Use link child elements to define navigation items and designate a home route with `rel="home"`.
- */
-declare class AppNav extends PreactCustomElement implements AppNavProps {
+declare class AppNav extends PolarisCustomElement implements AppNavProps {
   constructor();
 }
 declare global {

--- a/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
@@ -72,7 +72,16 @@ interface AdminPrintActionProps$1 extends GlobalProps {
    */
   src?: string;
 }
-interface AppNavProps$1 extends GlobalProps {}
+interface AppNavProps$1 extends GlobalProps {
+  /**
+   * The navigation items to inject into the external host navigation.
+   * One child Link is required and represents the home/root navigation item.
+   *
+   * @implementation This does not render UI
+   * @implementation This item is not rendered as a clickable link but configures the home route.
+   */
+  children?: ComponentChildren;
+}
 /**
  * @publicDocs
  */

--- a/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/shared.d.ts
@@ -72,6 +72,7 @@ interface AdminPrintActionProps$1 extends GlobalProps {
    */
   src?: string;
 }
+interface AppNavProps$1 extends GlobalProps {}
 /**
  * @publicDocs
  */

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -681,7 +681,7 @@ export interface ExtensionTargets {
    * Renders an admin extension on the app home page.
    */
   'admin.app.home.render': RenderExtension<
-    StandardApi<'admin.app.home.render'>,
+    AppHomeApi<'admin.app.home.render'>,
     FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'
   >;
 }

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -681,8 +681,8 @@ export interface ExtensionTargets {
    * Renders an admin extension on the app home page.
    */
   'admin.app.home.render': RenderExtension<
-    AppHomeApi<'admin.app.home.render'>,
-    FormExtensionComponents | 'Modal' | 'Page'
+    StandardApi<'admin.app.home.render'>,
+    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'
   >;
 }
 


### PR DESCRIPTION
Closes https://github.com/shop/issues-admin-extensibility/issues/2469

Pair with https://github.com/shop/world/pull/661920

## Summary

Adds the `AppNav` (`s-app-nav`) component to `@shopify/ui-extensions`, scoped exclusively to the `admin.app.home.render` target.

`AppNav.d.ts` is **generated** from the web component definition in [`libraries/javascript/polaris/admin-ui-components`](https://github.com/shop/world/tree/main/libraries/javascript/polaris/admin-ui-components/src/ui-extensions-components/AppNav) — not hand-written. See the admin-web PR for the full definition pipeline.

---

## Changes

- **`components/AppNav.d.ts`** — Generated type declaration for the `s-app-nav` custom element. Declares `tagName = "s-app-nav"`, `AppNavProps`, `AppNavJSXProps`, and extends `HTMLElementTagNameMap` for DOM type safety.
- **`components/shared.d.ts`** — Adds `AppNavProps$1` with `children?: ComponentChildren` (the `s-link` nav items)
- **`extension-targets.ts`** — Adds `AppNav` to the `admin.app.home.render` component union

---

## How it works

`AppNav` is a navigation container with no visible UI of its own. An extension renders `<s-app-nav>` with `<s-link>` children to define sidebar nav items:

```jsx
// In an admin.app.home.render extension:
<s-app-nav>
  <s-link href="/">Home</s-link>
  <s-link href="/orders">Orders</s-link>
  <s-link href="/settings" rel="home">Settings</s-link>
</s-app-nav>
```

On the host side (admin-web), `AppNav.tsx` reads the children via `useReactSubtree` and forwards them to `navMenuPlugin` (`instance.pluginApi.navMenu.set()`), which populates the Polaris admin sidebar. Supports `label`, `url`, and `rel` attributes per link.

Mirrors the [`s-app-nav`](https://shopify.dev/docs/api/app-home/app-bridge-web-components/app-nav) App Bridge web component API.

---

## Testing

### Snapshot

```
"@shopify/ui-extensions": "0.0.0-snapshot-20260429004430"
```

Apply to both `areas/clients/admin-web/package.json` (admin-web) and `extensions/app-home/package.json` (test app).

### Manual tophat

See the [full tophat instructions in the admin-web PR](https://github.com/shop/world/pull/661920) — covers setup, test app wiring, and the 4 verification flows.

---

## New skills

- https://github.com/shopify-playground/optimus/tree/teletraan/extensibility/skills/ui-extensions/SKILL.md
- https://github.com/shopify-playground/optimus/blob/teletraan/extensibility/skills/polaris/SKILL.md
