### PR TITLE
Update suggestions limit and isLocationFormVisible descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
@@ -57,7 +57,7 @@ export interface AddressAutocompleteSuggestOutput {
   /**
    * An array of address autocomplete suggestions to show to the buyer.
    * Checkout displays up to five address suggestions. Return no more
-   * than five — additional suggestions are ignored.
+   * than five. Additional suggestions are ignored.
    */
   suggestions: AddressAutocompleteSuggestion[];
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
@@ -56,8 +56,8 @@ interface Target {
 export interface AddressAutocompleteSuggestOutput {
   /**
    * An array of address autocomplete suggestions to show to the buyer.
-   *
-   * > Note: Only the first five suggestions will be displayed to the buyer.
+   * Checkout displays up to five address suggestions. Return no more
+   * than five — additional suggestions are ignored.
    */
   suggestions: AddressAutocompleteSuggestion[];
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
@@ -3,9 +3,9 @@ import type {SubscribableSignalLike} from '../../shared';
 /** @publicDocs */
 export interface PickupPointListApi {
   /**
-   * Whether the location search form is currently visible to the buyer.
-   * Use this to conditionally render UI that depends on the buyer actively
-   * searching for pickup points.
+   * Reflects which view was active when the extension loaded. When the
+   * buyer moves to the next view, the extension restarts with the
+   * current value rather than updating in place.
    */
   isLocationFormVisible: SubscribableSignalLike<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -611,7 +611,14 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   attributes: SubscribableSignalLike<Attribute[]>;
 
   /**
-   * All payment options available to the buyer for this checkout, such as credit cards, wallets, and local payment methods. The list depends on the shop's payment configuration and the buyer's region.
+   * All payment options available to the buyer for this checkout, such as
+   * credit cards, wallets, and local payment methods. The list depends on
+   * the shop's payment configuration and the buyer's region.
+   *
+   * The set of payment options can change when the buyer updates their
+   * address or cart, so subscribe to changes rather than reading once
+   * during initialization. Each option exposes `handle` and `type` only.
+   * Provider names, logos, fees, and installment terms aren't available.
    */
   availablePaymentOptions: SubscribableSignalLike<PaymentOption[]>;
 
@@ -726,7 +733,13 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   ) => Promise<{data?: Data; errors?: GraphQLError[]}>;
 
   /**
-   * The payment options the buyer has currently selected. This updates as the buyer changes their payment method. The array can contain multiple entries when the buyer splits payment across methods (for example, a gift card and a credit card).
+   * The payment options the buyer has currently selected. This updates as
+   * the buyer changes their payment method. The array can contain multiple
+   * entries when the buyer splits payment across methods (for example, a
+   * gift card and a credit card).
+   *
+   * Each option exposes `handle` and `type` only. Provider names, logos,
+   * fees, and installment terms aren't available.
    */
   selectedPaymentOptions: SubscribableSignalLike<SelectedPaymentOption[]>;
 


### PR DESCRIPTION
## Summary
Cascade of #4379 to 2026-04.

- **suggestions** (address autocomplete): Reword the 5-suggestion limit as an actionable developer instruction.
- **isLocationFormVisible** (pickup point list): Correct to reflect snapshot-at-load behavior.

## Test plan
- [ ] Verify generated docs show updated descriptions after regen

Made with [Cursor](https://cursor.com)