### PR TITLE
Update suggestions limit and isLocationFormVisible descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
@@ -56,7 +56,7 @@ export interface AddressAutocompleteSuggestOutput {
   /**
    * An array of address autocomplete suggestions to show to the buyer.
    * Checkout displays up to five address suggestions. Return no more
-   * than five — additional suggestions are ignored.
+   * than five. Additional suggestions are ignored.
    */
   suggestions: AddressAutocompleteSuggestion[];
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/address-autocomplete/suggest.ts
@@ -55,8 +55,8 @@ interface Target {
 export interface AddressAutocompleteSuggestOutput {
   /**
    * An array of address autocomplete suggestions to show to the buyer.
-   *
-   * > Note: Only the first five suggestions will be displayed to the buyer.
+   * Checkout displays up to five address suggestions. Return no more
+   * than five — additional suggestions are ignored.
    */
   suggestions: AddressAutocompleteSuggestion[];
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-point-list.ts
@@ -3,7 +3,9 @@ import type {StatefulRemoteSubscribable} from '@remote-ui/async-subscription';
 /** @publicDocs */
 export interface PickupPointListApi {
   /**
-   * Whether the customer location input form is shown to the buyer.
+   * Reflects which view was active when the extension loaded. When the
+   * buyer moves to the next view, the extension restarts with the
+   * current value rather than updating in place.
    */
   isLocationFormVisible: StatefulRemoteSubscribable<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -536,6 +536,11 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * All available payment options.
+   *
+   * The set of payment options can change when the buyer updates their
+   * address or cart, so subscribe to changes rather than reading once
+   * during initialization. Each option exposes `handle` and `type` only.
+   * Provider names, logos, fees, and installment terms aren't available.
    */
   availablePaymentOptions: StatefulRemoteSubscribable<PaymentOption[]>;
 
@@ -661,6 +666,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * Payment options selected by the buyer.
+   *
+   * Each option exposes `handle` and `type` only. Provider names, logos,
+   * fees, and installment terms aren't available.
    */
   selectedPaymentOptions: StatefulRemoteSubscribable<SelectedPaymentOption[]>;
 


### PR DESCRIPTION
## Summary
Cascade of #4379 to 2025-07.

- **suggestions** (address autocomplete): Reword the 5-suggestion limit as an actionable developer instruction.
- **isLocationFormVisible** (pickup point list): Correct to reflect snapshot-at-load behavior.

## Test plan
- [ ] Verify generated docs show updated descriptions after regen

Made with [Cursor](https://cursor.com)