### PR TITLE
Remove version-dated callouts from API descriptions

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -439,11 +439,14 @@ export interface Localization {
   country: SubscribableSignalLike<Country | undefined>;
 
   /**
-   * The [market](https://shopify.dev/docs/apps/build/markets) context of the checkout, carried over from the cart context. Markets group countries and regions with shared pricing, languages, and domains. It updates when the buyer changes the country of their shipping address. The value is `undefined` if the market is unknown.
+   * The [market](https://shopify.dev/docs/apps/build/markets) context of
+   * the checkout, carried over from the cart context. Markets group
+   * countries and regions with shared pricing, languages, and domains. It
+   * updates when the buyer changes the country of their shipping address.
+   * The value is `undefined` if the market is unknown.
    *
-   * > Caution: Deprecated as of version `2025-04`. Merchants now manage which extensions load for each market, so extensions no longer need to check this value.
-   *
-   * @deprecated Deprecated as of version `2025-04`
+   * @deprecated Merchants now manage which extensions load for each
+   * market, so extensions no longer need to check this value.
    */
   market: SubscribableSignalLike<Market | undefined>;
 }
@@ -587,8 +590,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * For example, if you intend to add a discount code via the `applyDiscountCodeChange` method,
    * check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.
    *
-   * > Caution: As of version `2024-07`, UI extension code must check for instructions before calling select APIs in case those APIs aren't available.
-   *  See the [update guide](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples) for more information.
+   * > Caution: Check instructions before calling select APIs, as some
+   * > may not be available. See the [update guide](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples)
+   * > for more information.
    *
    */
   instructions: SubscribableSignalLike<CartInstructions>;
@@ -683,7 +687,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * @see https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/extension-targets-overview
    * @see https://shopify.dev/docs/apps/app-extensions/configuration#targets
    *
-   * @deprecated Deprecated as of version `2023-07`, use `extension.target` instead.
+   * @deprecated Use `extension.target` instead.
    */
   extensionPoint: Target;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -439,11 +439,11 @@ export interface Localization {
   country: SubscribableSignalLike<Country | undefined>;
 
   /**
-   * The [market](https://shopify.dev/docs/apps/build/markets) context of
-   * the checkout, carried over from the cart context. Markets group
-   * countries and regions with shared pricing, languages, and domains. It
-   * updates when the buyer changes the country of their shipping address.
-   * The value is `undefined` if the market is unknown.
+   * The [market](/docs/apps/build/markets) context of the checkout,
+   * carried over from the cart context. Markets group countries and
+   * regions with shared pricing, languages, and domains. The market
+   * context updates when the buyer changes the country of their
+   * shipping address. The value is `undefined` if the market is unknown.
    *
    * @deprecated Merchants now manage which extensions load for each
    * market, so extensions no longer need to check this value.
@@ -590,8 +590,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    * For example, if you intend to add a discount code via the `applyDiscountCodeChange` method,
    * check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.
    *
-   * > Caution: Check instructions before calling select APIs, as some
-   * > may not be available. See the [update guide](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples)
+   * > Caution: Check cart instructions before calling select APIs, as
+   * > some may not be available. See the
+   * > [Cart Instructions API](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples)
    * > for more information.
    *
    */
@@ -784,8 +785,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * Key-value storage that persists across page loads within the current checkout
-   * session. Data is shared across all activated extension targets of this
-   * extension.
+   * session. Data is shared across all activated targets associated with
+   * this extension.
    *
    * > Caution: Data persistence isn't guaranteed and storage is cleared when the
    * buyer starts a new checkout.


### PR DESCRIPTION
## Summary
Strip "as of version YYYY-MM" from deprecation notices and caution blocks in checkout `standard.ts`. These are migration artifacts — the behavior is now standard and the dates are irrelevant to current developers.

- **`market`**: Removed redundant Caution block; `@deprecated` now explains *why* instead of *when*
- **`instructions`**: Removed version date from Caution; states the requirement directly
- **`extensionPoint`**: `@deprecated` now says what to use instead of when it was deprecated

Closes: https://github.com/shop/issues-learn/issues/2001

## Test plan
- [ ] Verify generated docs no longer show version-dated callouts
- [ ] Cascade to 2026-04, 2026-01, 2025-10, 2025-07

Made with [Cursor](https://cursor.com)