### PR TITLE
Add JSDoc for API properties (2025-10)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/cart-line/cart-line-item.ts
@@ -7,6 +7,10 @@ export interface CartLineItemApi {
    * The cart line that this extension is attached to. Use this to read the
    * line item's merchandise, quantity, cost, and attributes.
    *
+   * Available only on the corresponding item target. Shipping option item
+   * targets expose shipping option properties; pickup location item targets
+   * expose pickup location properties.
+   *
    * > Note: Until version `2023-04`, this property was a `ReadonlySignalLike<PresentmentCartLine>`.
    */
   target: SubscribableSignalLike<CartLine>;

--- a/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/checkout/checkout.ts
@@ -56,6 +56,9 @@ export interface NoteChangeResultError {
   /**
    * A message that explains the error. This message is useful for debugging.
    * It isn't localized and shouldn't be displayed to the buyer.
+   *
+   * Render your own localized error text rather than displaying this message
+   * to the buyer.
    */
   message: string;
 }
@@ -162,6 +165,9 @@ export interface CartLineChangeResultError {
   /**
    * A message that explains the error. This message is useful for debugging.
    * It isn't localized and shouldn't be displayed to the buyer.
+   *
+   * Render your own localized error text rather than displaying this message
+   * to the buyer.
    */
   message: string;
 }
@@ -419,6 +425,9 @@ export interface GiftCardChangeResultError {
   /**
    * A message that explains the error. This message is useful for debugging.
    * It isn't localized and shouldn't be displayed to the buyer.
+   *
+   * Render your own localized error text rather than displaying this message
+   * to the buyer.
    */
   message: string;
 }
@@ -550,6 +559,9 @@ export interface MetafieldChangeResultError {
   /**
    * A message that explains the error. This message is useful for debugging.
    * It isn't localized and shouldn't be displayed to the buyer.
+   *
+   * Render your own localized error text rather than displaying this message
+   * to the buyer.
    */
   message: string;
 }
@@ -653,6 +665,9 @@ export interface CheckoutApi {
   /**
    * Adds, removes, or updates line items in the cart. The returned promise resolves when the change has been applied by the server, and the [`lines`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-lines#properties-propertydetail-lines) property updates with the new state.
    *
+   * Accepts a single change per call. To make multiple changes, call this
+   * method separately for each one.
+   *
    * > Note: This method returns an error if the [cart instruction](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#properties-propertydetail-instructions) `lines.canAddCartLine` is false, or the buyer is using an accelerated checkout method, such as Apple Pay or Google Pay.
    */
   applyCartLinesChange(change: CartLineChange): Promise<CartLineChangeResult>;
@@ -671,6 +686,10 @@ export interface CheckoutApi {
 
   /**
    * Adds or removes a gift card from the checkout. The returned promise resolves when the change has been applied by the server, and the [`appliedGiftCards`](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/gift-cards#properties-propertydetail-appliedgiftcards) property updates with the new state.
+   *
+   * Unlike other write operations, gift card changes aren't gated by a cart
+   * instruction flag. The method succeeds in all contexts except accelerated
+   * checkout, where it returns an error result.
    *
    * > Caution:
    * > See [security considerations](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#network-access) if your extension retrieves gift card codes through a network call.

--- a/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/order-confirmation/order-confirmation.ts
@@ -15,6 +15,8 @@ export interface OrderConfirmation {
    * A randomly generated alpha-numeric identifier for the order, distinct
    * from `order.id`. The value is `undefined` for orders that were created
    * before this field was introduced. All recent orders have a number.
+   *
+   * Optional. Might not be present for orders created before 2024.
    */
   number?: string;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/pickup/pickup-location-item.ts
@@ -5,11 +5,19 @@ import type {PickupLocationOption} from '../standard/standard';
 export interface PickupLocationItemApi {
   /**
    * The pickup location that this extension is attached to. Use this to read the location's name, address, and other details.
+   *
+   * Available only on the corresponding item target. Shipping option item
+   * targets expose shipping option properties; pickup location item targets
+   * expose pickup location properties.
    */
   target: SubscribableSignalLike<PickupLocationOption>;
 
   /**
    * Whether the buyer has selected the target pickup location. When `true`, the target location is the buyer's active choice. When `false`, the buyer has chosen a different pickup location.
+   *
+   * Available only on the corresponding item target. Shipping option item
+   * targets expose shipping option properties; pickup location item targets
+   * expose pickup location properties.
    */
   isTargetSelected: SubscribableSignalLike<boolean>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shared.ts
@@ -56,6 +56,9 @@ export interface Attribute {
    * The value associated with the attribute key. This is a freeform string
    * that can store any information the buyer or app provides.
    *
+   * Attribute values are always strings. To store structured data, serialize
+   * it to JSON and parse it when reading.
+   *
    * @example 'Please use red wrapping paper'
    */
   value: string;

--- a/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/shipping/shipping-option-item.ts
@@ -5,11 +5,19 @@ import type {ShippingOption} from '../standard/standard';
 export interface ShippingOptionItemApi {
   /**
    * The shipping option that this extension is attached to. Use this to read the option's cost, carrier, delivery estimate, and other details.
+   *
+   * Available only on the corresponding item target. Shipping option item
+   * targets expose shipping option properties; pickup location item targets
+   * expose pickup location properties.
    */
   target: SubscribableSignalLike<ShippingOption>;
 
   /**
    * Whether the buyer has selected the target shipping option. When `true`, the target option is the buyer's active choice. When `false`, the buyer has chosen a different shipping option.
+   *
+   * Available only on the corresponding item target. Shipping option item
+   * targets expose shipping option properties; pickup location item targets
+   * expose pickup location properties.
    */
   isTargetSelected: SubscribableSignalLike<boolean>;
 

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -35,7 +35,8 @@ export interface Storage {
    * The stored data is deserialized from JSON and returned as
    * its original type.
    *
-   * Returns `null` if no stored data exists.
+   * Returns the stored value for the given key, or `null` when no value
+   * exists. Doesn't throw on a missing key.
    */
   read<T = unknown>(key: string): Promise<T | null>;
 
@@ -123,6 +124,9 @@ export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {
    * The published version of the running extension target.
    *
    * For unpublished extensions, the value is `undefined`.
+   *
+   * Don't use this property as a stable identifier in development environments.
+   * It becomes available only after the extension is published.
    *
    * @example 3.0.10
    */
@@ -425,6 +429,9 @@ export interface Localization {
 
   /**
    * The country context of the checkout, carried over from the cart. It updates when the buyer changes their shipping address country. Use this value to display region-specific content such as local support information or regional policies. The value is `undefined` if the buyer's country is unknown.
+   *
+   * Derived from the buyer's shipping address. Returns `undefined` until the
+   * buyer enters a shipping address.
    */
   country: SubscribableSignalLike<Country | undefined>;
 
@@ -599,6 +606,13 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * All payment options available to the buyer for this checkout, such as credit cards, wallets, and local payment methods. The list depends on the shop's payment configuration and the buyer's region.
+   *
+   * Reactive. The set of payment options can change when the buyer updates
+   * their address or cart. Subscribe to changes rather than reading once
+   * during initialization.
+   *
+   * Each option exposes `handle` and `type` only. Provider names, logos, fees,
+   * and installment terms aren't available.
    */
   availablePaymentOptions: SubscribableSignalLike<PaymentOption[]>;
 
@@ -631,6 +645,8 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](https://shopify.dev/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)
    * and the `checkout_token` field in the [REST Admin API `Order` resource](https://shopify.dev/docs/api/admin-rest/unstable/resources/order#resource-object).
+   *
+   * Can be `undefined`. Handle the `undefined` state before using the value.
    */
   checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;
 
@@ -641,6 +657,9 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * The delivery groups for this checkout. Each group contains one or more cart lines and the available delivery options (shipping, pickup point, or pickup location) for those items.
+   *
+   * Empty until the buyer enters enough address information for Shopify to
+   * calculate shipping rates.
    */
   deliveryGroups: SubscribableSignalLike<DeliveryGroup[]>;
 
@@ -730,6 +749,13 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * The payment options the buyer has currently selected. This updates as the buyer changes their payment method. The array can contain multiple entries when the buyer splits payment across methods (for example, a gift card and a credit card).
+   *
+   * Reactive. The set of payment options can change when the buyer updates
+   * their address or cart. Subscribe to changes rather than reading once
+   * during initialization.
+   *
+   * Each option exposes `handle` and `type` only. Provider names, logos, fees,
+   * and installment terms aren't available.
    */
   selectedPaymentOptions: SubscribableSignalLike<SelectedPaymentOption[]>;
 
@@ -823,6 +849,10 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
  * Use session tokens to verify the identity of the buyer and the shop
  * context when making server-side API calls. The token is a signed JWT
  * that contains claims such as the customer ID, shop domain, and expiration.
+ *
+ * The `sub` claim in the decoded token is present only when the buyer is
+ * logged in and the app has permission to read customer accounts. Absent for
+ * anonymous buyers.
  */
 export interface SessionToken {
   /**
@@ -984,11 +1014,17 @@ export interface CartCost {
 
   /**
    * The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been calculated yet, such as when the buyer is still on the information step.
+   *
+   * `undefined` until the buyer selects a shipping method (typically after the
+   * information step).
    */
   totalShippingAmount: SubscribableSignalLike<Money | undefined>;
 
   /**
    * The total tax the buyer can expect to pay, or the total tax already included in product and shipping prices (for tax-inclusive regions). The value is `undefined` if taxes haven't been calculated yet.
+   *
+   * `undefined` when taxes haven't been calculated or aren't available for the
+   * buyer's region.
    */
   totalTaxAmount: SubscribableSignalLike<Money | undefined>;
 
@@ -1373,6 +1409,11 @@ interface InterceptorRequestAllow {
    * This callback is called when all interceptors finish. We recommend
    * setting errors or reasons for blocking at this stage, so that all the errors in
    * the UI show up at once.
+   *
+   * Runs after all intercept results are collected. Use it for local state
+   * updates such as setting an error flag. By the time it runs, the navigation
+   * decision is final, so blocking logic belongs in the intercept handler
+   * itself, not here.
    * @param result InterceptorResult with behavior as either 'allow' or 'block'
    */
   perform?(result: InterceptorResult): void | Promise<void>;
@@ -1400,6 +1441,11 @@ interface InterceptorRequestBlock {
    * This callback is called when all interceptors finish. We recommend
    * setting errors or reasons for blocking at this stage, so that all the errors in
    * the UI show up at once.
+   *
+   * Runs after all intercept results are collected. Use it for local state
+   * updates such as setting an error flag. By the time it runs, the navigation
+   * decision is final, so blocking logic belongs in the intercept handler
+   * itself, not here.
    * @param result InterceptorResult with behavior as either 'allow' or 'block'
    */
   perform?(result: InterceptorResult): void | Promise<void>;
@@ -1599,6 +1645,10 @@ export interface Analytics {
   /**
    * Publishes a custom event to [Web Pixels](https://shopify.dev/docs/apps/marketing).
    * Returns `true` when the event is successfully dispatched.
+   *
+   * The Promise resolves to `true` when the event was dispatched. The boolean
+   * indicates dispatch confirmation only. It doesn't indicate whether any
+   * specific web pixel processed the event.
    */
   publish(name: string, data: Record<string, unknown>): Promise<boolean>;
 
@@ -1911,24 +1961,45 @@ export interface AllowedProcessing {
    * Whether analytics data can be collected based on the visitor's consent,
    * the merchant's privacy configuration, and the visitor's region. Analytics
    * data includes how the shop was used and what interactions occurred.
+   *
+   * Whether analytics data can be collected right now. Combines the buyer's
+   * consent, the merchant's privacy configuration, and the buyer's region into
+   * a single boolean. Check this flag, not `visitorConsent.analytics`, before
+   * calling `shopify.analytics.publish()`.
    */
   analytics: boolean;
   /**
    * Whether marketing data can be collected based on the visitor's consent,
    * the merchant's privacy configuration, and the visitor's region. Marketing
    * data includes attribution and targeted advertising preferences.
+   *
+   * Whether marketing data can be collected right now. Combines the buyer's
+   * consent, the merchant's privacy configuration, and the buyer's region into
+   * a single boolean. Check this flag, not `visitorConsent.marketing`, before
+   * performing marketing-related data collection.
    */
   marketing: boolean;
   /**
    * Whether preference data can be collected based on the visitor's consent,
    * the merchant's privacy configuration, and the visitor's region. Preference
    * data includes language, currency, and sizing choices.
+   *
+   * Whether preference data can be collected right now. Combines the buyer's
+   * consent, the merchant's privacy configuration, and the buyer's region into
+   * a single boolean. Check this flag, not `visitorConsent.preferences`,
+   * before storing or reading buyer preference data.
    */
   preferences: boolean;
   /**
    * Whether data can be shared with third parties based on the visitor's
    * consent, the merchant's privacy configuration, and the visitor's region.
    * This typically applies to behavioral advertising data.
+   *
+   * Whether buyer data can be shared with or sold to third parties right now.
+   * Combines the buyer's consent, the merchant's privacy configuration, and
+   * the buyer's region into a single boolean. Check this flag, not
+   * `visitorConsent.saleOfData`, before sharing or selling buyer data with
+   * third parties.
    */
   saleOfData: boolean;
 }
@@ -1978,6 +2049,9 @@ export interface TrackingConsentMetafieldChange {
   key: string;
   /**
    * The new value to store in the metafield. Set to `null` to delete the metafield.
+   *
+   * Consent metafield values are strings, not booleans. Pass `null` to delete
+   * a tracking consent metafield.
    */
   value: string | null;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/preact/localized-fields.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/localized-fields.ts
@@ -38,6 +38,8 @@ export function useLocalizedFields<
 /**
  * Returns the current localized field or undefined for the specified
  * localized field key and re-renders your component if the value changes.
+ *
+ * Returns `undefined` when no field is configured for the buyer's country.
  * @publicDocs
  */
 export function useLocalizedField<

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -388,11 +388,16 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
   /**
    * Triggers a login prompt if the customer is viewing a pre-authenticated **Order status** page.
    * Use this to require full authentication before displaying sensitive information in your extension.
+   *
+   * Triggers a login prompt for pre-authenticated buyers. Doesn't guarantee
+   * the buyer completes the login. Handle the dismissal case in your code.
    */
   requireLogin: () => Promise<void>;
 
   /**
    * The buyer's current authentication level on the **Order status** page. Use this to determine whether to display sensitive information or prompt the buyer to log in.
+   *
+   * Read-only. The authentication level can't be changed programmatically.
    */
   authenticationState: SubscribableSignalLike<AuthenticationState>;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -27,6 +27,10 @@ export interface Metafield {
 
   /**
    * The data stored in the metafield. The format depends on the `valueType`: a plain string for `'string'`, a numeric value for `'integer'`, or a serialized JSON object for `'json_string'`.
+   *
+   * Returned as a string regardless of the metafield's content type. Parse
+   * with `JSON.parse()` for metafields containing JSON or other structured
+   * data.
    */
   value: string | number;
 
@@ -171,6 +175,10 @@ export interface Market {
   handle: string;
 }
 
+/**
+ * Provides raw localization data only. The `i18n` translation and formatting
+ * helpers from the Localization API aren't available on order status targets.
+ */
 export interface OrderStatusLocalization {
   /**
    * The currency used to display money amounts on the **Order status** page. Use this value
@@ -251,12 +259,18 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
 
   /**
    * The buyer who placed the order, including their customer account, email, phone number, and B2B purchasing company. Use this to personalize the **Order status** page or identify B2B orders.
+   *
+   * Reflects the customer account at the time the order was placed. Doesn't
+   * update if account details change afterward.
    */
   buyerIdentity?: OrderStatusBuyerIdentity;
 
   /**
    * The checkout settings that were active when the buyer placed the order, such as
    * whether order notes and login are enabled.
+   *
+   * Returns the merchant's checkout configuration at the time of checkout.
+   * Doesn't reflect updates made after the order was placed.
    */
   checkoutSettings: SubscribableSignalLike<CheckoutSettings>;
 
@@ -278,6 +292,9 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    * - `CartCodeDiscountAllocation`: A discount the buyer applied by entering a code at checkout.
    * - `CartAutomaticDiscountAllocation`: A discount the merchant configured in Shopify admin to apply automatically.
    * - `CartCustomDiscountAllocation`: A discount created programmatically by a [Shopify Function](/docs/apps/build/functions).
+   *
+   * Returns order-level discounts only. For per-line discount allocations,
+   * read from individual cart lines via the Cart Lines API.
    */
   discountAllocations: SubscribableSignalLike<CartDiscountAllocation[]>;
 
@@ -340,12 +357,18 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    * The shipping address that the buyer provided for the order. This is where physical goods
    * are delivered. The value is `undefined` if the order contains only digital products or
    * if a shipping address wasn't required.
+   *
+   * Reflects the state at the time the order was placed. Doesn't update if the
+   * customer changes their account address afterward.
    */
   shippingAddress?: SubscribableSignalLike<MailingAddress | undefined>;
 
   /**
    * The billing address associated with the buyer's payment method for the order. The value
    * is `undefined` if the order doesn't have a billing address on file.
+   *
+   * Reflects the state at the time the order was placed. Doesn't update if the
+   * customer changes their account address afterward.
    */
   billingAddress?: SubscribableSignalLike<MailingAddress | undefined>;
 
@@ -474,6 +497,9 @@ export interface AppliedGiftCard {
 
   /**
    * The remaining balance of the applied gift card after the order was placed.
+   *
+   * Reflects the remaining amount at the time the order was placed. Doesn't
+   * update if the gift card is used for subsequent purchases.
    */
   balance: Money;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/shared.ts
@@ -232,6 +232,9 @@ export interface Attribute {
   /**
    * The value associated with the attribute key. This contains the buyer-provided or app-set data for the custom attribute.
    *
+   * Attribute values are always strings. If structured data was stored during
+   * checkout, parse it on read with `JSON.parse()`.
+   *
    * @example 'Happy Birthday!'
    */
   value: string;
@@ -565,6 +568,9 @@ export interface CustomerPrivacy {
    * The visitor's geographic location, used to determine whether more granular consent controls should be displayed based on regional privacy regulations.
    *
    * @example `{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.
+   *
+   * Requires level 1 access to protected customer data. `undefined` without
+   * that access. Regional compliance logic can't run without it.
    *
    * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).
    */


### PR DESCRIPTION
## Summary

Adds JSDoc to checkout and customer account API surfaces for properties whose documentation was moved out of `## Limitations` sections in shopify-dev. Pairs with the .mdx cleanup in shopify/world#663262 and the multi-agent plan in shopify/world#660052.

References shopify/issues-learn#1612.

## Properties touched (Agent 1 scope, A.* and B.*)

**Checkout API** (`packages/ui-extensions/src/surfaces/checkout/api/`)
- A.2 `Attribute.value` (shared.ts)
- A.4 `InterceptorRequestAllow.perform` and `InterceptorRequestBlock.perform` (standard.ts)
- A.6 `CartLineChangeResultError.message`, `CheckoutApi.applyCartLinesChange` (checkout.ts)
- A.7 `StandardApi.checkoutToken` (standard.ts)
- A.8 `CartCost.totalShippingAmount`, `CartCost.totalTaxAmount` (standard.ts)
- A.9 `TrackingConsentMetafieldChange.value`, `AllowedProcessing.{analytics,marketing,preferences,saleOfData}` (standard.ts)
- A.10 `StandardApi.deliveryGroups` (standard.ts); `target` and `isTargetSelected` on `CartLineItemApi`, `ShippingOptionItemApi`, `PickupLocationItemApi`
- A.12 `GiftCardChangeResultError.message`, `CheckoutApi.applyGiftCardChange` (checkout.ts)
- A.13 `useLocalizedField` (preact/localized-fields.ts)
- A.14 `NoteChangeResultError.message` (checkout.ts)
- A.15 `OrderConfirmation.number` (order-confirmation.ts)
- A.17 `Analytics.publish` (standard.ts)
- A.18 `Extension.version` (standard.ts)
- A.19 `Localization.country` (standard.ts)
- A.20 `MetafieldChangeResultError.message` (checkout.ts)
- A.21 `SessionToken` interface description (standard.ts) — there's no typed `sub` claim, so the JSDoc lives on the interface itself
- A.24 `Storage.read` (standard.ts)

**Customer account API** (`packages/ui-extensions/src/surfaces/customer-account/api/`)
- B.2 `OrderStatusApi.checkoutSettings` (order-status.ts)
- B.4 `CustomerPrivacy.region` (shared.ts)
- B.5 `OrderStatusApi.shippingAddress`, `OrderStatusApi.billingAddress` (order-status.ts)
- B.6 `Attribute.value` (shared.ts)
- B.7 `OrderStatusApi.buyerIdentity` (order-status.ts)
- B.8 `OrderStatusApi.discountAllocations` (order-status.ts)
- B.9 `AppliedGiftCard.balance` (order-status.ts)
- B.10 `Metafield.value` (order-status.ts)
- B.11 `OrderStatusLocalization` interface description (order-status.ts)

**Follow-up commit** (covers content trimmed from .mdx in review feedback on shopify/world#663262):
- `OrderStatusApi.requireLogin` (order-status.ts) — dismissal-handling guidance
- `OrderStatusApi.authenticationState` (order-status.ts) — read-only framing

## Notes / deviations from the plan

- **A.3 buyer-identity (checkout)**: Reviewer trimmed the level-2 access note from the .mdx intro because it duplicated the `<Requires>` callout. Existing JSDoc on `BuyerIdentity.email` and `BuyerIdentity.phone` in `standard.ts` already includes "Requires level 2 access to protected customer data" plus the `undefined` behavior, so no JSDoc edit is needed here.
- **A.16 payment options superseded upstream**: The `availablePaymentOptions` and `selectedPaymentOptions` JSDoc edits in this PR were superseded by upstream commit `2e27e8ea7 Add payment option limitations to availablePaymentOptions and selectedPaymentOptions` (Stephanie). Same content, reviewer-improved phrasing. The merge resolution in this PR takes the upstream wording, so A.16 is no longer load-bearing here.
- **A.6, A.12, A.14, A.20 error `message`**: The plan's text references "the error code" but these error result types only carry `type: 'error'` and `message: string` — no error code field. Adapted the new sentence to "Render your own localized error text rather than displaying this message to the buyer."
- **A.21 SessionToken `sub` claim**: There's no typed `sub` field in the source — the token is a JWT string. Added the guidance to the `SessionToken` interface description.
- **B.14 storefront global `fetch()`**: The `fetch()` approach uses the standard JS `fetch` with `shopify:storefront/...` URLs and has no typed function in the customer account API source. Skipped JSDoc for this version. The `.mdx` cleanup already covers the guidance.
- **Style**: Removed em dashes from the plan text (replaced with periods, semicolons, or commas) per the agreed style rules. Kept "only" next to what it modifies.

## Test plan

- [x] CI passes on this PR
- [x] Sibling PRs land for `2026-01`, `2026-04`, `2026-07-rc` with byte-identical JSDoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)