### PR TITLE
Add JSDoc for component properties (2026-07-rc)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -822,6 +822,8 @@ interface BadgeProps$1 extends GlobalProps {
 	/**
 	 * An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Set to an empty string to display no icon.
 	 *
+	 * Always positioned relative to the text content. Independent positioning isn't supported.
+	 *
 	 * @default ''
 	 */
 	icon?: IconType | AnyString;
@@ -1410,6 +1412,8 @@ export interface LinkBehaviorProps extends InteractionProps, FocusEventProps {
 export interface InteractionProps {
 	/**
 	 * The ID of the component to control when this component is activated. Pair with the `command` property to specify what action to perform on the target component. Learn more about the [`commandFor` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor).
+	 *
+	 * When both `commandFor` and `href` are set, `commandFor` takes precedence. The command runs and the link doesn't navigate.
 	 */
 	commandFor?: string;
 	/**
@@ -1537,6 +1541,8 @@ export interface MultipleInputProps extends BaseInputProps {
 	 * An array of `value` attributes for the currently selected options.
 	 *
 	 * This is a convenience prop for setting the `selected` prop on child options.
+	 *
+	 * Form data captures the selected value strings only. Complex nested content inside choices is for display purposes and isn't included in form submissions.
 	 */
 	values?: string[];
 }
@@ -1805,6 +1811,8 @@ interface CheckboxProps$1 extends GlobalProps, BaseCheckableProps, FieldErrorPro
 	 * If you want to present an error when this field is empty, you can do
 	 * so with the `error` property.
 	 *
+	 * Adds semantic meaning for accessibility. Doesn't trigger automatic validation or display an error. Implement validation logic yourself and use the `error` prop to show results.
+	 *
 	 * @default false
 	 */
 	required?: boolean;
@@ -1906,6 +1914,8 @@ interface ChoiceListProps$1 extends GlobalProps, Pick<BasicFieldProps, "label" |
 	 * - `block`: The choices are displayed on the block axis.
 	 * - `grid`: The choices are displayed in a grid.
 	 *
+	 * The selected content slot is supported only in the default (stacked) variant. `inline` and `grid` ignore it.
+	 *
 	 * @implementation The `block`, `inline` and `grid` variants are more suitable for button looking choices, but it's at the
 	 * discretion of each surface.
 	 *
@@ -1968,6 +1978,8 @@ interface ClickableChipProps$1 extends ChipProps$1, GlobalProps {
 	 * ensure you update app state for this property when the `remove` event fires.
 	 *
 	 * If the chip is not `removable`, it can still be hidden by setting this property.
+	 *
+	 * When using the `removable` variant, keep `hidden` synced with your app state. If `hidden` isn't updated after the chip is removed, the chip can become permanently hidden.
 	 *
 	 * @default false
 	 */
@@ -2051,6 +2063,8 @@ export type ConsentPolicy = "sms-marketing";
 interface ConsentCheckboxProps$1 extends GlobalProps, CheckboxProps$1 {
 	/**
 	 * The policy for which user consent is being collected.
+	 *
+	 * Only `sms-marketing` is supported. Other consent policy types aren't available through this component.
 	 */
 	policy?: ConsentPolicy;
 }
@@ -2059,6 +2073,8 @@ interface PhoneFieldProps$1 extends GlobalProps, BaseTextFieldProps, Pick<FieldD
 	/**
 	 * The type of phone number to collect. Specific styling may be applied to each type to provide extra guidance to users. No additional validation is performed based on the type.
 	 *
+	 * Styling hint for the input keyboard. Doesn't validate the phone number format. Implement validation in your extension and use the `error` prop to show results.
+	 *
 	 * @default ''
 	 */
 	type?: "mobile" | "";
@@ -2066,6 +2082,8 @@ interface PhoneFieldProps$1 extends GlobalProps, BaseTextFieldProps, Pick<FieldD
 interface ConsentPhoneFieldProps$1 extends GlobalProps, PhoneFieldProps$1 {
 	/**
 	 * The policy for which user consent is being collected.
+	 *
+	 * Only `sms-marketing` is supported.
 	 */
 	policy?: ConsentPolicy;
 }
@@ -2119,6 +2137,8 @@ interface DatePickerProps$1 extends GlobalProps, InputProps, FocusEventProps {
 	 *       So `--2024` is equivalent to `--2024-12-31`.
 	 *     - Whitespace is allowed either side of `--`.
 	 *
+	 * Comma-separated list of allowed dates in `YYYY-MM-DD` format.
+	 *
 	 * @default ""
 	 *
 	 * @example
@@ -2145,6 +2165,8 @@ interface DatePickerProps$1 extends GlobalProps, InputProps, FocusEventProps {
 	 *     - If parts of the date are omitted for `end`, they are assumed to be the maximum possible value.
 	 *       So `--2024` is equivalent to `--2024-12-31`.
 	 *     - Whitespace is allowed either side of `--`.
+	 *
+	 * Comma-separated list of disallowed dates in `YYYY-MM-DD` format.
 	 *
 	 * @default ""
 	 *
@@ -2209,6 +2231,8 @@ interface DatePickerProps$1 extends GlobalProps, InputProps, FocusEventProps {
 	 * - If `type="single"`, this is a date in `YYYY-MM-DD` format.
 	 * - If `type="multiple"`, this is a comma-separated list of dates in `YYYY-MM-DD` format.
 	 * - If `type="range"`, this is a range in `YYYY-MM-DD--YYYY-MM-DD` format. The range is inclusive.
+	 *
+	 * Single dates use ISO 8601 format (`YYYY-MM-DD`); ranges use `YYYY-MM-DD--YYYY-MM-DD`. Locale-specific formats aren't supported.
 	 *
 	 * @default ""
 	 */
@@ -2327,6 +2351,9 @@ interface DropZoneProps$1 extends GlobalProps, FileInputProps, BasicFieldProps {
 	 */
 	onDropRejected?: (event: Event) => void;
 }
+/**
+ * Doesn't perform automatic format validation. Implement validation logic yourself and use the `error` prop to display results.
+ */
 interface EmailFieldProps$1 extends GlobalProps, BaseTextFieldProps, MinMaxLengthProps, AutocompleteProps<EmailAutocompleteField> {
 }
 export type EmailAutocompleteField = ExtractStrict<AnyAutocompleteField, "email" | `${AutocompleteAddressGroup} email`>;


### PR DESCRIPTION
## Summary

Adds JSDoc to checkout component property descriptions whose documentation was moved out of `## Limitations` sections in shopify-dev. Pairs with the .mdx cleanup in shopify/world#669910 and the multi-agent plan in shopify/world#660052.

References shopify/issues-learn#1612.

## Properties touched (Agent D scope, D.* checkout components)

All edits to `packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts`.

- D.2 `ClickableChipProps$1.hidden` — sync-with-app-state guidance for the `removable` variant.
- D.4 `InteractionProps.commandFor` — precedence note when both `commandFor` and `href` are set (used by the link component).
- D.6 `BadgeProps$1.icon` — icon position is fixed relative to text content.
- D.7 `CheckboxProps$1.required` — `required` adds semantic meaning, doesn't auto-validate.
- D.8 `ChoiceListProps$1.variant` — selected content slot supported in the default (stacked) variant only.
- D.8 `MultipleInputProps.values` — form data captures selected value strings only.
- D.9 `ConsentCheckboxProps$1.policy` — only `sms-marketing` is supported.
- D.10 `PhoneFieldProps$1.type` — styling hint, doesn't validate phone format (used by consent-phone-field).
- D.10 `ConsentPhoneFieldProps$1.policy` — only `sms-marketing` is supported.
- D.11 `DatePickerProps$1.allow` — comma-separated list in `YYYY-MM-DD` (used by date-field via `Pick<>`).
- D.11 `DatePickerProps$1.disallow` — comma-separated list in `YYYY-MM-DD` (used by date-field via `Pick<>`).
- D.12 `DatePickerProps$1.value` — ISO 8601 format (also covers D.11 date-field `value` via `Pick<>`).
- D.13 `EmailFieldProps$1` interface description — doesn't perform automatic format validation.

## Notes / deviations from the plan

- **D.4 `commandFor`**: Per the plan, edited at the base interface (`InteractionProps`). The note is conditional on `href` being set, so it's accurate for both link (which has `href`) and button (vacuously true).
- **D.11 / D.12 `value`**: Both date-field and date-picker share the `value` prop via `Pick<DatePickerProps$1, "value" | ...>`. The D.12 text (which covers ranges) supersedes the D.11 text (single dates only) since it's broader and accurate for both. Added once on `DatePickerProps$1.value`.
- **D.13 email-field component-level**: `EmailFieldProps$1` had no leading description. Added a JSDoc block above the interface declaration.
- **Style**: Removed em dashes from the plan text (replaced with periods or commas) per the agreed style rules. Kept "only" next to what it modifies.

## Test plan

- [ ] CI passes on this PR
- [ ] Sibling PRs land for `2025-10`, `2026-01`, `2026-04` with byte-identical JSDoc

Generated with [Claude Code](https://claude.com/claude-code)
