### PR TITLE
make rc job run on base change

### DIFF
--- a/.github/workflows/rc-port-tracker.yml
+++ b/.github/workflows/rc-port-tracker.yml
@@ -2,7 +2,7 @@ name: RC port tracker
 
 on:
   pull_request:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, closed, edited]
     branches:
       - 20[0-9][0-9]-[01][1470]
       - 20[0-9][0-9]-[01][1470]-rc
@@ -15,7 +15,11 @@ jobs:
   label-stable-pr:
     name: Label PRs against stable branches
     if: |
-      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'reopened' ||
+        (github.event.action == 'edited' && github.event.changes.base != null)
+      ) &&
       !endsWith(github.event.pull_request.base.ref, '-rc') &&
       !startsWith(github.head_ref, 'changeset-release/')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Job currently doesn't run when the base changes. I think people often open PRs first against the default branch and then change the base to be the stable branch.

I want to ensure the workflow runs for those too. It currently doesn't.

I believe we need to merge this before we can test it.
Once merged we'll have to do the same against the stable branch. 😭 