### PR TITLE
Remove version dates from CA extensionPoint deprecated tags

### DIFF
--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -262,7 +262,7 @@ export interface OrderStatusApi<Target extends ExtensionTarget> {
    * @example 'customer-account.order-status.block.render'
    * Learn more about [targets](/docs/api/customer-account-ui-extensions/{API_VERSION}/targets) and [target configuration](/docs/api/customer-account-ui-extensions/{API_VERSION}#configuration).
    *
-   * @deprecated Deprecated as of version `2023-07`, use `extension.target` instead.
+   * @deprecated Use `extension.target` instead.
    */
   extensionPoint: Target;
 

--- a/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/standard-api/standard-api.ts
@@ -34,7 +34,7 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
    *
    * @example 'customer-account.order-status.block.render'
    *
-   * @deprecated Deprecated as of version `2023-07`, use `extension.target` instead.
+   * @deprecated Use `extension.target` instead.
    */
   extensionPoint: Target;
 


### PR DESCRIPTION
Cascade of #4424 to 2025-07. Simplify `@deprecated` tags on `extensionPoint` in CA.

Made with [Cursor](https://cursor.com)