### PR TITLE
Fix checkbox changeset from minor to patch

### DIFF
--- a/.changeset/checkbox-rich-label.md
+++ b/.changeset/checkbox-rich-label.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/ui-extensions': minor
+'@shopify/ui-extensions': patch
 ---
 
 The `label` prop on the checkout and customer-account `s-checkbox` component now accepts a label as a slot in addition to a plain string, label slots can include only plain text and s-links.


### PR DESCRIPTION
The checkbox label slot changeset from #4395 was incorrectly set to `minor`. We can't ship minor versions on release branches, so this changes it to `patch`.