### PR TITLE
docs(pos): note per-screen sandbox in Navigation API limitations

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/reference/apis/navigation-api.doc.ts
@@ -46,6 +46,7 @@ const data: ReferenceEntityTemplateSchema = {
       sectionContent: `
 - The Navigation API is only available in action (modal) targets and can't be used in action (menu item), block, or tile targets that don't support multi-screen navigation.
 - Navigation state is limited to serializable data and can't contain functions, complex objects, or circular references.
+- Starting in version 2025-10, each screen runs in its own isolated sandbox. State held in module-level variables, closures, or singleton instances isn't shared between screens — use the \`state\` option in \`navigation.navigate()\` (read back via \`navigation.currentEntry.getState()\`) or the [Storage API](https://shopify.dev/docs/api/pos-ui-extensions/latest/target-apis/platform-apis/storage-api) (\`shopify.storage\`) to pass data between them.
 `,
     },
   ],


### PR DESCRIPTION
## What

Adds a bullet to the Navigation API **Limitations** section noting that, starting in version `2025-10`, each screen runs in its own isolated sandbox — state held in module-level variables, closures, or singleton instances isn't shared between screens.

## Why

Developers using `navigation.navigate()` to move between screens have hit unexpected behavior when assuming module-level state, in-memory caches, or singletons would persist across screens. The current docs don't call this out. This PR adds a developer-friendly note pointing them at the supported way to share data: the `state` option in `navigation.navigate()` or persistent storage.

## Backports

This same note is being applied to the supported retroactive versions:

- [x] `2026-07-rc` — #4437
- [ ] `2026-04` (this PR)
- [ ] `2026-01`
- [ ] `2025-10`

## Preview

```
- Starting in version 2025-10, each screen runs in its own isolated sandbox. State held in module-level variables, closures, or singleton instances isn't shared between screens — use the `state` option in `navigation.navigate()` or persistent storage to pass data between them.
```