### PR TITLE
Remove self-referential Storefront API link from query description (2026-01)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -734,7 +734,6 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
   /**
    * The method used to query the Storefront GraphQL API with a prefetched token.
    *
-   * Refer to [Storefront API access examples](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/storefront-api) for more information.
    */
   query: <Data = unknown, Variables = Record<string, unknown>>(
     query: string,


### PR DESCRIPTION
## Summary

Removes the self-referential "Refer to Storefront API access examples for more information" link from the `query` property description in `StandardApi`. The link points to the same page the reader is already on, which is confusing and unhelpful.

Fixes https://github.com/shop/issues-learn/issues/2084

## Test plan

- [ ] Verify the generated docs no longer include the self-referential link on the Storefront API page


Made with [Cursor](https://cursor.com)