### PR TITLE
add app home ui extension data as a copy of admin extension data

### DIFF
--- a/.github/workflows/shopify-dev-preview-automation.yml
+++ b/.github/workflows/shopify-dev-preview-automation.yml
@@ -116,6 +116,7 @@ jobs:
           # Only match these specific JSON files
           VALID_FILENAMES=(
             "generated_docs_data.json"
+            "generated_docs_data_v2.json"
             "generated_static_pages.json"
             "generated_category_pages.json"
             "targets.json"

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -555,11 +555,27 @@ try {
     adminExtensionsOutput,
     generatedDocsDataV2File,
   );
+
+  const appHomeUiExtensionsOutput = path.join(
+    rootPath,
+    docsGeneratedRelativePath,
+    'app_home_ui_extensions',
+    EXTENSIONS_API_VERSION,
+  );
+  if (existsSync(generatedDocsDataV2Path)) {
+    await fs.mkdir(appHomeUiExtensionsOutput, {recursive: true});
+    await fs.copyFile(
+      generatedDocsDataV2Path,
+      path.join(appHomeUiExtensionsOutput, generatedDocsDataV2File),
+    );
+  }
+
   console.log('\nGenerated docs at:');
   console.log('  Admin extensions:', adminExtensionsOutput);
   console.log('  targets.json:', targetsJsonPath);
   console.log('  generated_docs_data_v2.json:', generatedDocsDataV2Path);
   console.log('  App Home:', appHomeOutput);
+  console.log('  App Home UI extensions:', appHomeUiExtensionsOutput);
 
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
@@ -572,24 +588,26 @@ try {
     SHOPIFY_DEV_EXTENSIONS_FOLDER !== EXTENSIONS_API_VERSION &&
     shopifyDevExists
   ) {
-    const adminExtSource = path.join(
-      shopifyDevDBPath,
-      'admin_extensions',
-      EXTENSIONS_API_VERSION,
-    );
-    const adminExtDest = path.join(
-      shopifyDevDBPath,
-      'admin_extensions',
-      SHOPIFY_DEV_EXTENSIONS_FOLDER,
-    );
-    if (existsSync(adminExtSource)) {
-      if (existsSync(adminExtDest)) {
-        await fs.rm(adminExtDest, {recursive: true});
-      }
-      await fs.rename(adminExtSource, adminExtDest);
-      console.log(
-        `  Renamed admin_extensions/${EXTENSIONS_API_VERSION} → admin_extensions/${SHOPIFY_DEV_EXTENSIONS_FOLDER} in shopify-dev`,
+    for (const folder of ['admin_extensions', 'app_home_ui_extensions']) {
+      const source = path.join(
+        shopifyDevDBPath,
+        folder,
+        EXTENSIONS_API_VERSION,
       );
+      const dest = path.join(
+        shopifyDevDBPath,
+        folder,
+        SHOPIFY_DEV_EXTENSIONS_FOLDER,
+      );
+      if (existsSync(source)) {
+        if (existsSync(dest)) {
+          await fs.rm(dest, {recursive: true});
+        }
+        await fs.rename(source, dest);
+        console.log(
+          `  Renamed ${folder}/${EXTENSIONS_API_VERSION} → ${folder}/${SHOPIFY_DEV_EXTENSIONS_FOLDER} in shopify-dev`,
+        );
+      }
     }
   }
 

--- a/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
+++ b/packages/ui-extensions/docs/surfaces/admin/build-docs.mjs
@@ -556,17 +556,17 @@ try {
     generatedDocsDataV2File,
   );
 
-  const appHomeUiExtensionsOutput = path.join(
+  const appHomeUiExtensionOutput = path.join(
     rootPath,
     docsGeneratedRelativePath,
-    'app_home_ui_extensions',
+    'app_home_ui_extension',
     EXTENSIONS_API_VERSION,
   );
   if (existsSync(generatedDocsDataV2Path)) {
-    await fs.mkdir(appHomeUiExtensionsOutput, {recursive: true});
+    await fs.mkdir(appHomeUiExtensionOutput, {recursive: true});
     await fs.copyFile(
       generatedDocsDataV2Path,
-      path.join(appHomeUiExtensionsOutput, generatedDocsDataV2File),
+      path.join(appHomeUiExtensionOutput, generatedDocsDataV2File),
     );
   }
 
@@ -575,7 +575,7 @@ try {
   console.log('  targets.json:', targetsJsonPath);
   console.log('  generated_docs_data_v2.json:', generatedDocsDataV2Path);
   console.log('  App Home:', appHomeOutput);
-  console.log('  App Home UI extensions:', appHomeUiExtensionsOutput);
+  console.log('  App Home UI extensions:', appHomeUiExtensionOutput);
 
   await copyGeneratedToShopifyDev({
     generatedDocsPath,
@@ -588,7 +588,7 @@ try {
     SHOPIFY_DEV_EXTENSIONS_FOLDER !== EXTENSIONS_API_VERSION &&
     shopifyDevExists
   ) {
-    for (const folder of ['admin_extensions', 'app_home_ui_extensions']) {
+    for (const folder of ['admin_extensions', 'app_home_ui_extension']) {
       const source = path.join(
         shopifyDevDBPath,
         folder,


### PR DESCRIPTION
### Background

closes: https://github.com/shop/issues-learn/issues/2134

data for app home ui extension doesn't get generated yet

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

generates data for app home ui extension. This is a copy of admin extension data but that will be copied over to shopify-dev when the script is run. 

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
