### PR TITLE
docs(admin): add LoadingOptions interface and AppNav type sources for app-home docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data.json
@@ -7569,6 +7569,95 @@
     ]
   },
   {
+    "name": "AppNav",
+    "description": "The app nav component (`<s-app-nav>`) injects navigation items into the Shopify admin sidebar. Use this component to define sidebar navigation for your App Home extension. It does not render visible UI — it configures navigation items on the host side.",
+    "isVisualComponent": false,
+    "category": "Web components",
+    "subCategory": "Navigation",
+    "thumbnail": "/assets/templated-apis-screenshots/admin/components/app-nav.png",
+    "requires": "an [admin.app.home.render](/docs/api/app-home-ui-extension/{API_VERSION}/targets) target.",
+    "definitions": [
+      {
+        "title": "Properties",
+        "description": "Configure the following properties on the app nav component.",
+        "type": "AppNavAttributes",
+        "typeDefinitions": {
+          "AppNavAttributes": {
+            "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+            "name": "AppNavAttributes",
+            "description": "Configure the following properties on the app nav component.",
+            "isPublicDocs": true,
+            "members": [
+              {
+                "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "children",
+                "value": "ComponentChildren",
+                "description": "The navigation items to inject into the Shopify admin sidebar. Provide `<s-link>` children where each link represents a navigation item. This component does not render any visible UI itself.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "A unique identifier for the element.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AppNavAttributes {\n  /**\n   * A unique identifier for the element.\n   */\n  id?: string;\n  /**\n   * The navigation items to inject into the Shopify admin sidebar.\n   * Provide `<s-link>` children where each link represents a navigation item.\n   * This component does not render any visible UI itself.\n   */\n  children?: ComponentChildren;\n}"
+          },
+          "ComponentChildren": {
+            "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ComponentChildren",
+            "value": "any",
+            "description": ""
+          }
+        }
+      },
+      {
+        "title": "Link properties",
+        "description": "Properties for links used as children.",
+        "type": "AppNavLinkAttributes",
+        "typeDefinitions": {
+          "AppNavLinkAttributes": {
+            "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+            "name": "AppNavLinkAttributes",
+            "description": "Attributes for link elements used as children of app nav. Each link defines a navigation destination in your app's menu.",
+            "isPublicDocs": true,
+            "members": [
+              {
+                "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "children",
+                "value": "string",
+                "description": "The visible label text for the navigation item. Keep labels short (1-2 words) and use nouns that describe the destination (such as \"Products\", \"Settings\", or \"Reports\"). Avoid verbs like \"Manage\" or \"View\" to maintain consistency with Shopify admin navigation patterns.",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "href",
+                "value": "string",
+                "description": "The URL path for the navigation item. Must be a relative path within your app, such as `/products` or `/settings`. When clicked, it navigates the app to this route without a full page reload. The path should match a route defined in your app's routing configuration."
+              }
+            ],
+            "value": "export interface AppNavLinkAttributes {\n  /**\n   * The URL path for the navigation item. Must be a relative path within your app, such as `/products` or `/settings`. When clicked, it navigates the app to this route without a full page reload. The path should match a route defined in your app's routing configuration.\n   */\n  href: string;\n  /**\n   * The visible label text for the navigation item. Keep labels short (1-2 words) and use nouns that describe the destination (such as \"Products\", \"Settings\", or \"Reports\"). Avoid verbs like \"Manage\" or \"View\" to maintain consistency with Shopify admin navigation patterns.\n   */\n  children?: string;\n}"
+          }
+        }
+      }
+    ],
+    "related": [
+      {
+        "name": "Link",
+        "subtitle": "Web component",
+        "url": "/docs/api/app-home-ui-extension/{API_VERSION}/web-components/actions/link",
+        "type": "component"
+      }
+    ]
+  },
+  {
     "name": "Avatar",
     "description": "The avatar component displays profile images or initials for users, customers, and businesses in a compact visual format. Use avatar to represent people or entities throughout the interface, with automatic fallback to initials when images aren't available.\n\nAvatars support multiple sizes for different contexts and provide consistent color assignment for initials based on the name provided. For product or content preview images, use [thumbnail](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/thumbnail). For full-size images, use [image](/docs/api/{API_NAME}/{API_VERSION}/web-components/media-and-visuals/image).",
     "category": "Web components",
@@ -10145,7 +10234,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -10898,7 +10987,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$3@16010",
+                "name": "__@internals$3@16405",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -12712,7 +12801,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -13279,7 +13368,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$2@16111",
+                "name": "__@internals$2@16506",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -13578,7 +13667,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -14211,7 +14300,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dirtyStateSymbol@16155",
+                "name": "__@dirtyStateSymbol@16550",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -14220,7 +14309,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$1@16154",
+                "name": "__@internals$1@16549",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -14908,7 +14997,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@getFileInput@16192",
+                "name": "__@getFileInput@16587",
                 "value": "() => HTMLInputElement",
                 "description": "",
                 "isPrivate": true,
@@ -14917,7 +15006,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals@16191",
+                "name": "__@internals@16586",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -14926,7 +15015,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@setFiles@16190",
+                "name": "__@setFiles@16585",
                 "value": "(files: File[]) => void",
                 "description": "",
                 "isPrivate": true,
@@ -15425,7 +15514,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -18879,7 +18968,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@16327",
+                "name": "__@overlayActivator@16722",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -18888,7 +18977,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@16326",
+                "name": "__@overlayHidden@16721",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -18897,7 +18986,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@16328",
+                "name": "__@overlayHideFrameId@16723",
                 "value": "number",
                 "description": "",
                 "isPrivate": true,
@@ -19225,7 +19314,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@abortController@16386",
+                "name": "__@abortController@16781",
                 "value": "AbortController",
                 "description": "",
                 "isPrivate": true,
@@ -19234,7 +19323,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@childrenRerenderObserver@16388",
+                "name": "__@childrenRerenderObserver@16783",
                 "value": "MutationObserver",
                 "description": "",
                 "isPrivate": true,
@@ -19243,7 +19332,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@dialog@16380",
+                "name": "__@dialog@16775",
                 "value": "HTMLDialogElement",
                 "description": "",
                 "isPrivate": true,
@@ -19252,7 +19341,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@dismiss@16381",
+                "name": "__@dismiss@16776",
                 "value": "() => void",
                 "description": "",
                 "isPrivate": true,
@@ -19261,7 +19350,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@focusedElement@16382",
+                "name": "__@focusedElement@16777",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -19270,7 +19359,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@hasOpenChildModal@16376",
+                "name": "__@hasOpenChildModal@16771",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -19279,7 +19368,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@hide@16378",
+                "name": "__@hide@16773",
                 "value": "() => Promise<void>",
                 "description": "",
                 "isPrivate": true,
@@ -19288,7 +19377,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@isOpen@16379",
+                "name": "__@isOpen@16774",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -19297,7 +19386,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@nestedModals@16384",
+                "name": "__@nestedModals@16779",
                 "value": "Map<Modal, boolean>",
                 "description": "",
                 "isPrivate": true,
@@ -19306,7 +19395,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@onBackdropClick@16385",
+                "name": "__@onBackdropClick@16780",
                 "value": "(event: MouseEvent) => void",
                 "description": "",
                 "isPrivate": true,
@@ -19315,7 +19404,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@onChildModalChange@16387",
+                "name": "__@onChildModalChange@16782",
                 "value": "EventListenerOrEventListenerObject",
                 "description": "",
                 "isPrivate": true,
@@ -19324,7 +19413,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@onEscape@16383",
+                "name": "__@onEscape@16778",
                 "value": "(event: KeyboardEvent) => void",
                 "description": "",
                 "isPrivate": true,
@@ -19333,7 +19422,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@16327",
+                "name": "__@overlayActivator@16722",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -19342,7 +19431,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@16326",
+                "name": "__@overlayHidden@16721",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -19351,7 +19440,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@16328",
+                "name": "__@overlayHideFrameId@16723",
                 "value": "number",
                 "description": "",
                 "isPrivate": true,
@@ -19360,7 +19449,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@shadowDomRerenderObserver@16389",
+                "name": "__@shadowDomRerenderObserver@16784",
                 "value": "MutationObserver",
                 "description": "",
                 "isPrivate": true,
@@ -19369,7 +19458,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "MethodDeclaration",
-                "name": "__@show@16377",
+                "name": "__@show@16772",
                 "value": "() => Promise<void>",
                 "description": "",
                 "isPrivate": true,
@@ -19866,7 +19955,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -20342,7 +20431,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -21872,7 +21961,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -22396,7 +22485,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayActivator@16327",
+                "name": "__@overlayActivator@16722",
                 "value": "HTMLElement",
                 "description": "",
                 "isPrivate": true,
@@ -22405,7 +22494,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHidden@16326",
+                "name": "__@overlayHidden@16721",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -22414,7 +22503,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@overlayHideFrameId@16328",
+                "name": "__@overlayHideFrameId@16723",
                 "value": "number",
                 "description": "",
                 "isPrivate": true,
@@ -23116,7 +23205,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -23908,7 +23997,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@hasInitialValueSymbol@16606",
+                "name": "__@hasInitialValueSymbol@17001",
                 "value": "boolean",
                 "description": "",
                 "isPrivate": true,
@@ -23917,7 +24006,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -23926,7 +24015,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@usedFirstOptionSymbol@16605",
+                "name": "__@usedFirstOptionSymbol@17000",
                 "value": "boolean",
                 "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
                 "isPrivate": true,
@@ -25786,7 +25875,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -26244,7 +26333,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@actualTableVariantSymbol@16681",
+                "name": "__@actualTableVariantSymbol@17076",
                 "value": "AddedContext<ActualTableVariant>",
                 "description": "",
                 "isPrivate": true,
@@ -26253,7 +26342,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@tableHeadersSharedDataSymbol@16682",
+                "name": "__@tableHeadersSharedDataSymbol@17077",
                 "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
                 "description": "",
                 "isPrivate": true,
@@ -26747,7 +26836,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "GetAccessor",
-                "name": "__@headerFormatSymbol@16704",
+                "name": "__@headerFormatSymbol@17099",
                 "value": "HeaderFormat",
                 "description": "",
                 "isPrivate": true,
@@ -27979,7 +28068,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -28490,7 +28579,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,
@@ -29511,7 +29600,7 @@
               {
                 "filePath": "src/surfaces/admin/components.ts",
                 "syntaxKind": "PropertyDeclaration",
-                "name": "__@internals$4@15957",
+                "name": "__@internals$4@16352",
                 "value": "ElementInternals",
                 "description": "",
                 "isPrivate": true,

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -182,6 +182,20 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
+          "name": "admin.app.home.render",
+          "value": "RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >",
+          "description": "Renders an admin extension on the app home page."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin.app.intent.render",
+          "value": "RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >",
+          "description": "Renders an admin extension for handling app intents."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
           "name": "admin.app.tools.data",
           "value": "RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >",
           "description": "A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions."
@@ -706,7 +720,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -917,9 +931,17 @@
           "value": "string | URL",
           "description": "The URL that launched the current intent workflow, if your extension was opened through an intent. Use this to determine how your extension was invoked and access any parameters passed in the URL.",
           "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "response",
+          "value": "IntentResponseApi",
+          "description": "Resolves the current intent from within an invoked extension. This property is only present when your extension is running inside an intent workflow.",
+          "isOptional": true
         }
       ],
-      "value": "export interface Intents {\n  /**\n   * The URL that launched the current intent workflow, if your extension was opened through an intent. Use this to determine how your extension was invoked and access any parameters passed in the URL.\n   */\n  launchUrl?: string | URL;\n  /**\n   * Launches an intent workflow for creating or editing Shopify resources. Returns a handle that resolves when the merchant completes, cancels, or encounters an error in the workflow. Use this to initiate resource creation or editing without building custom forms.\n   */\n  invoke?: IntentInvokeApi;\n}"
+      "value": "export interface Intents {\n  /**\n   * Resolves the current intent from within an invoked extension. This property is only present when your extension is running inside an intent workflow.\n   */\n  response?: IntentResponseApi;\n\n  /**\n   * The URL that launched the current intent workflow, if your extension was opened through an intent. Use this to determine how your extension was invoked and access any parameters passed in the URL.\n   */\n  launchUrl?: string | URL;\n  /**\n   * Launches an intent workflow for creating or editing Shopify resources. Returns a handle that resolves when the merchant completes, cancels, or encounters an error in the workflow. Use this to initiate resource creation or editing without building custom forms.\n   */\n  invoke?: IntentInvokeApi;\n}"
     }
   },
   "IntentInvokeApi": {
@@ -930,6 +952,71 @@
       "isPublicDocs": true,
       "members": [],
       "value": "export interface IntentInvokeApi {\n  (query: IntentQuery): Promise<IntentActivity>;\n  (intentURL: string, options?: IntentQueryOptions): Promise<IntentActivity>;\n}"
+    }
+  },
+  "IntentResponseApi": {
+    "src/surfaces/admin/api/intents/intents.ts": {
+      "filePath": "src/surfaces/admin/api/intents/intents.ts",
+      "name": "IntentResponseApi",
+      "description": "The `IntentResponseApi` object provides methods for resolving the current intent from within an invoked extension. This API is only present when your extension is running inside an intent workflow.",
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "closed",
+          "value": "() => Promise<void>",
+          "description": "Resolves the current intent as closed without completing the workflow."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "error",
+          "value": "(message: string, issues?: Issue[]) => Promise<void>",
+          "description": "Resolves the current intent with an error. Use `issues` to provide field-specific validation details when available."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "ok",
+          "value": "(data?: { [key: string]: unknown; }) => Promise<void>",
+          "description": "Resolves the current intent successfully. Pass output data when your intent defines a response schema."
+        }
+      ],
+      "value": "export interface IntentResponseApi {\n  /**\n   * Resolves the current intent successfully. Pass output data when your intent defines a response schema.\n   */\n  ok(data?: SuccessIntentResponse['data']): Promise<void>;\n\n  /**\n   * Resolves the current intent with an error. Use `issues` to provide field-specific validation details when available.\n   */\n  error(message: string, issues?: Issue[]): Promise<void>;\n\n  /**\n   * Resolves the current intent as closed without completing the workflow.\n   */\n  closed(): Promise<void>;\n}"
+    }
+  },
+  "Issue": {
+    "src/surfaces/admin/api/intents/intents.ts": {
+      "filePath": "src/surfaces/admin/api/intents/intents.ts",
+      "name": "Issue",
+      "description": "A structured issue describing a validation or workflow error.",
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "A machine-readable error code for this issue. Use this for programmatic error handling or logging.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A description of what's wrong with this field. Display this to help merchants understand how to fix the error.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string[]",
+          "description": "The path to the field that has an error (for example, `['product', 'title']`). Use this to identify which field caused the validation failure.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface Issue {\n  /** The path to the field that has an error (for example, `['product', 'title']`). Use this to identify which field caused the validation failure. */\n  path?: string[];\n  /** A description of what's wrong with this field. Display this to help merchants understand how to fix the error. */\n  message?: string;\n  /** A machine-readable error code for this issue. Use this for programmatic error handling or logging. */\n  code?: string;\n}"
     }
   },
   "PickerApi": {
@@ -1177,7 +1264,7 @@
       "filePath": "src/shared.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "ApiVersion",
-      "value": "'2023-04' | '2023-07' | '2023-10' | '2024-01' | '2024-04' | '2024-07' | '2024-10' | '2025-01' | '2025-04' | 'unstable' | '2025-07' | '2025-10' | '2026-01' | '2026-04'",
+      "value": "'2023-04' | '2023-07' | '2023-10' | '2024-01' | '2024-04' | '2024-07' | '2024-10' | '2025-01' | '2025-04' | 'unstable' | '2025-07' | '2025-10' | '2026-01' | '2026-04' | '2026-07'",
       "description": "The supported GraphQL Admin API versions. Use this to specify which API version your GraphQL queries should execute against. Each version includes specific features, bug fixes, and breaking changes. The `unstable` version provides access to the latest features but may change without notice."
     }
   },
@@ -2544,7 +2631,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -2889,7 +2976,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@6858",
+          "name": "__@internals$3@7051",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3571,7 +3658,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3674,7 +3761,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@6959",
+          "name": "__@internals$2@7152",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3933,7 +4020,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4095,7 +4182,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@7003",
+          "name": "__@dirtyStateSymbol@7196",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -4103,7 +4190,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@7002",
+          "name": "__@internals$1@7195",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4270,7 +4357,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@7038",
+          "name": "__@setFiles@7231",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true
@@ -4278,7 +4365,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@7040",
+          "name": "__@getFileInput@7233",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true
@@ -4286,7 +4373,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@7039",
+          "name": "__@internals@7232",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4596,7 +4683,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6014,7 +6101,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@7174",
+          "name": "__@overlayHidden@7367",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -6022,7 +6109,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@7175",
+          "name": "__@overlayActivator@7368",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -6030,7 +6117,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@7176",
+          "name": "__@overlayHideFrameId@7369",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -6241,7 +6328,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6492,7 +6579,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7083,7 +7170,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7387,7 +7474,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7635,7 +7722,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@7453",
+          "name": "__@usedFirstOptionSymbol@7646",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true
@@ -7643,7 +7730,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@7454",
+          "name": "__@hasInitialValueSymbol@7647",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -7673,7 +7760,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8237,7 +8324,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8352,7 +8439,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@7529",
+          "name": "__@actualTableVariantSymbol@7722",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true
@@ -8360,7 +8447,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@7530",
+          "name": "__@tableHeadersSharedDataSymbol@7723",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true
@@ -8570,7 +8657,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@7552",
+          "name": "__@headerFormatSymbol@7745",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true
@@ -9150,7 +9237,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9393,7 +9480,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9550,7 +9637,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@7174",
+          "name": "__@overlayHidden@7367",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -9558,7 +9645,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@7175",
+          "name": "__@overlayActivator@7368",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -9566,7 +9653,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@7176",
+          "name": "__@overlayHideFrameId@7369",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -9860,7 +9947,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@6805",
+          "name": "__@internals$4@6998",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -10375,6 +10462,800 @@
         }
       ],
       "value": "declare class Form extends PreactCustomElement implements FormProps {\n  constructor();\n}"
+    }
+  },
+  "AppHomeApi": {
+    "src/surfaces/admin/api/app-home/app-home.ts": {
+      "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+      "name": "AppHomeApi",
+      "description": "The `AppHomeApi` object provides methods for app home extensions. Access the following properties on the `AppHomeApi` object to authenticate users, query the [GraphQL Admin API](/docs/api/admin-graphql), translate content, handle intents, persist data, display toast notifications, control the Admin page-level loading indicator, and access app-level data.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "app",
+          "value": "AppApi",
+          "description": "Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "auth",
+          "value": "Auth",
+          "description": "Provides methods for authenticating calls to your app backend. Use the `idToken()` method to retrieve a signed JWT token that verifies the current user's identity for secure server-side operations."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extension",
+          "value": "{ target: ExtensionTarget; }",
+          "description": "The identifier of the running extension target. Use this to determine which target your extension is rendering in and conditionally adjust functionality or UI based on the extension context."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "i18n",
+          "value": "I18n",
+          "description": "Utilities for translating content according to the current localization of the admin. Use these methods to provide translated strings that match the merchant's language preferences, ensuring your extension is accessible to a global audience."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "intents",
+          "value": "Intents",
+          "description": "Provides information to the receiver of an intent. Use this to access data passed from other extensions or parts of the admin when your extension is launched through intent-based navigation."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "loading",
+          "value": "LoadingApi",
+          "description": "Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "<Data = unknown, Variables = { [key: string]: unknown; }>(query: string, options?: { variables?: Variables; version?: Omit<ApiVersion, \"2023-04\">; }) => Promise<{ data?: Data; errors?: GraphQLError[]; }>",
+          "description": "Executes GraphQL queries against the [GraphQL Admin API](/docs/api/admin-graphql). Use this to fetch shop data, manage resources, or perform mutations. Queries are automatically authenticated with the current user's permissions. Optionally specify GraphQL variables and API version for your query."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storage",
+          "value": "Storage",
+          "description": "Provides methods for persisting data in browser storage that is scoped to your extension. Use this to store user preferences, cache data, maintain state across sessions, or save temporary working data. Storage is persistent across page reloads and isolated per extension."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "toast",
+          "value": "ToastApi",
+          "description": "Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow."
+        }
+      ],
+      "value": "export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardApi<ExtensionTarget> {\n  /**\n   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.\n   */\n  toast: ToastApi;\n\n  /**\n   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.\n   */\n  app: AppApi;\n\n  /**\n   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.\n   */\n  loading: LoadingApi;\n}"
+    }
+  },
+  "AppApi": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "name": "AppApi",
+      "description": "The `AppApi` object provides methods for interacting with app-level data and functionality. Use this API to query information about extensions registered for the current app.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extensions",
+          "value": "() => Promise<ExtensionInfo[]>",
+          "description": "Returns a list of all extensions registered for the current app, including their activation status and target information. Use this to discover what extensions are available and where they are activated."
+        }
+      ],
+      "value": "export interface AppApi {\n  /**\n   * Returns a list of all extensions registered for the current app, including their activation status and target information.\n   * Use this to discover what extensions are available and where they are activated.\n   *\n   * @returns A promise that resolves to an array of extension information objects.\n   */\n  extensions: () => Promise<ExtensionInfo[]>;\n}"
+    }
+  },
+  "ExtensionInfo": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "name": "ExtensionInfo",
+      "description": "Information about an extension registered for the current app.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "activations",
+          "value": "UiExtensionActivation[] | ThemeExtensionBlockActivation[]",
+          "description": "The list of activations for this extension. For UI extensions, this contains target information. For theme extensions, this contains detailed block activation information."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string | null",
+          "description": "The unique handle identifier for this extension, if available.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "status",
+          "value": "ExtensionStatus",
+          "description": "The current status of this extension.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "ExtensionType",
+          "description": "The type of extension.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface ExtensionInfo {\n  /**\n   * The unique handle identifier for this extension, if available.\n   */\n  handle?: string | null;\n\n  /**\n   * The list of activations for this extension. For UI extensions, this contains target information.\n   * For theme extensions, this contains detailed block activation information.\n   */\n  activations: UiExtensionActivation[] | ThemeExtensionBlockActivation[];\n\n  /**\n   * The current status of this extension.\n   */\n  status?: ExtensionStatus;\n\n  /**\n   * The type of extension.\n   */\n  type?: ExtensionType;\n}"
+    }
+  },
+  "UiExtensionActivation": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "name": "UiExtensionActivation",
+      "description": "Represents an activation of a UI extension at a specific target.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "string",
+          "description": "The extension target where this extension is activated."
+        }
+      ],
+      "value": "export interface UiExtensionActivation {\n  /**\n   * The extension target where this extension is activated.\n   */\n  target: string;\n}"
+    }
+  },
+  "ThemeExtensionBlockActivation": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "name": "ThemeExtensionBlockActivation",
+      "description": "Represents a theme extension block activation with its status and nested activations.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "activations",
+          "value": "ThemeBlockActivation[]",
+          "description": "The list of theme-specific activations for this block."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The handle identifier for this theme extension block."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The display name of this theme extension block."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "status",
+          "value": "ExtensionStatus",
+          "description": "The current status of this theme extension block."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "ThemeAppBlockTarget | ThemeAppEmbedTarget",
+          "description": "The target location for this theme extension block or embed."
+        }
+      ],
+      "value": "export interface ThemeExtensionBlockActivation {\n  /**\n   * The target location for this theme extension block or embed.\n   */\n  target: ThemeAppBlockTarget | ThemeAppEmbedTarget;\n\n  /**\n   * The handle identifier for this theme extension block.\n   */\n  handle: string;\n\n  /**\n   * The display name of this theme extension block.\n   */\n  name: string;\n\n  /**\n   * The current status of this theme extension block.\n   */\n  status: ExtensionStatus;\n\n  /**\n   * The list of theme-specific activations for this block.\n   */\n  activations: ThemeBlockActivation[];\n}"
+    }
+  },
+  "ThemeBlockActivation": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "name": "ThemeBlockActivation",
+      "description": "Represents an activation of a theme block at a specific target within a theme.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "string",
+          "description": "The target location within the theme."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app/app.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "themeId",
+          "value": "string",
+          "description": "The ID of the theme where this block is activated."
+        }
+      ],
+      "value": "export interface ThemeBlockActivation {\n  /**\n   * The target location within the theme.\n   */\n  target: string;\n\n  /**\n   * The ID of the theme where this block is activated.\n   */\n  themeId: string;\n}"
+    }
+  },
+  "ExtensionStatus": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ExtensionStatus",
+      "value": "'active' | 'available' | 'unavailable'",
+      "description": "The status of an extension indicating whether it's active, available for activation, or unavailable.",
+      "isPublicDocs": true
+    }
+  },
+  "ThemeAppBlockTarget": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ThemeAppBlockTarget",
+      "value": "'section'",
+      "description": "The target location for theme app blocks within a theme section.",
+      "isPublicDocs": true
+    }
+  },
+  "ThemeAppEmbedTarget": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ThemeAppEmbedTarget",
+      "value": "'head' | 'body' | 'compliance_head'",
+      "description": "The target location for theme app embeds within the document.",
+      "isPublicDocs": true
+    }
+  },
+  "ExtensionType": {
+    "src/surfaces/admin/api/app/app.ts": {
+      "filePath": "src/surfaces/admin/api/app/app.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ExtensionType",
+      "value": "'ui_extension' | 'theme_app_extension'",
+      "description": "The type of extension.",
+      "isPublicDocs": true
+    }
+  },
+  "LoadingApi": {
+    "src/surfaces/admin/api/loading/loading.ts": {
+      "filePath": "src/surfaces/admin/api/loading/loading.ts",
+      "name": "LoadingApi",
+      "description": "Sets the Admin page-level loading indicator for hosted app home extensions.\n\nCall with `true` to start loading. Call with `false`, or without an argument, to stop loading.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "isLoading",
+          "description": "",
+          "value": "boolean",
+          "isOptional": true,
+          "filePath": "src/surfaces/admin/api/loading/loading.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/surfaces/admin/api/loading/loading.ts",
+        "description": "",
+        "name": "void",
+        "value": "void"
+      },
+      "value": "(isLoading?: boolean) => void"
+    }
+  },
+  "ToastApi": {
+    "src/surfaces/admin/api/toast/toast.ts": {
+      "filePath": "src/surfaces/admin/api/toast/toast.ts",
+      "name": "ToastApi",
+      "description": "The `ToastApi` object provides methods for displaying temporary notification messages. Access these methods through `shopify.toast` to show user feedback and status updates.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/toast/toast.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hide",
+          "value": "() => void",
+          "description": "Dismisses any currently visible toast notification. Use this to programmatically hide a toast before its duration expires."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/toast/toast.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "show",
+          "value": "(message: string, options?: ToastOptions) => void",
+          "description": "Displays a toast notification with the specified message. The toast appears as a temporary overlay that automatically dismisses after the specified duration. Use for providing immediate user feedback, confirming actions, or communicating status updates without interrupting the user's workflow."
+        }
+      ],
+      "value": "export interface ToastApi {\n  /**\n   * Displays a toast notification with the specified message. The toast appears as a temporary overlay that automatically dismisses after the specified duration. Use for providing immediate user feedback, confirming actions, or communicating status updates without interrupting the user's workflow.\n   *\n   * @param message - The text content to display in the toast notification.\n   * @param options - Optional configuration for the toast behavior and appearance.\n   */\n  show: (message: string, options?: ToastOptions) => void;\n\n  /**\n   * Dismisses any currently visible toast notification. Use this to programmatically hide a toast before its duration expires.\n   */\n  hide: () => void;\n}"
+    }
+  },
+  "ToastOptions": {
+    "src/surfaces/admin/api/toast/toast.ts": {
+      "filePath": "src/surfaces/admin/api/toast/toast.ts",
+      "name": "ToastOptions",
+      "description": "Options for configuring toast notification behavior and appearance.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/toast/toast.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "action",
+          "value": "string",
+          "description": "The label for an optional action button displayed in the toast. When provided, an action button appears that the user can click.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/toast/toast.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "duration",
+          "value": "number",
+          "description": "The duration in milliseconds to display the toast before automatically dismissing. If not specified, a default duration is used.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/toast/toast.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isError",
+          "value": "boolean",
+          "description": "Whether to display the toast as an error notification. Use for error messages or failed operations.",
+          "isOptional": true,
+          "defaultValue": "false"
+        },
+        {
+          "filePath": "src/surfaces/admin/api/toast/toast.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "onAction",
+          "value": "() => void",
+          "description": "Callback function triggered when the user clicks the action button. Only called if `action` is provided.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/toast/toast.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "onDismiss",
+          "value": "() => void",
+          "description": "Callback function triggered when the toast is dismissed, either automatically after the duration expires or manually by the user.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface ToastOptions {\n  /**\n   * The duration in milliseconds to display the toast before automatically dismissing. If not specified, a default duration is used.\n   */\n  duration?: number;\n\n  /**\n   * Whether to display the toast as an error notification. Use for error messages or failed operations.\n   * @defaultValue false\n   */\n  isError?: boolean;\n\n  /**\n   * The label for an optional action button displayed in the toast. When provided, an action button appears that the user can click.\n   */\n  action?: string;\n\n  /**\n   * Callback function triggered when the user clicks the action button. Only called if `action` is provided.\n   */\n  onAction?: () => void;\n\n  /**\n   * Callback function triggered when the toast is dismissed, either automatically after the duration expires or manually by the user.\n   */\n  onDismiss?: () => void;\n}"
+    }
+  },
+  "FormExtensionComponents": {
+    "src/surfaces/admin/components/FormExtensionComponents.ts": {
+      "filePath": "src/surfaces/admin/components/FormExtensionComponents.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "FormExtensionComponents",
+      "value": "StandardComponents | 'Form'",
+      "description": "The components available for building form-based extensions. Includes all standard components plus the form component for creating structured data collection interfaces with submission handling and validation."
+    }
+  },
+  "Modal": {
+    "src/surfaces/admin/components.ts": {
+      "filePath": "src/surfaces/admin/components.ts",
+      "name": "Modal",
+      "description": "Configure the following properties on the modal component.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "accessibilityLabel",
+          "value": "string",
+          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers."
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "heading",
+          "value": "string",
+          "description": "A title that describes the content of the modal."
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "padding",
+          "value": "\"base\" | \"none\"",
+          "description": "Adjust the padding around the modal content.\n\n`base`: applies padding that is appropriate for the element.\n\n`none`: removes all padding from the element. This can be useful when elements inside the modal need to span to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base' to bring back the desired padding for the rest of the content.",
+          "defaultValue": "'base'"
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "size",
+          "value": "\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
+          "description": "The size of the modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.",
+          "defaultValue": "'base'"
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "showOverlay",
+          "value": "() => void",
+          "description": "A method to programmatically show the overlay."
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "hideOverlay",
+          "value": "() => void",
+          "description": "A method to programmatically hide the overlay."
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "toggleOverlay",
+          "value": "() => void",
+          "description": "A method to programmatically toggle the visibility of the overlay."
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "connectedCallback",
+          "value": "() => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "disconnectedCallback",
+          "value": "() => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@abortController@7427",
+          "value": "AbortController",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@dialog@7421",
+          "value": "HTMLDialogElement",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@focusedElement@7423",
+          "value": "HTMLElement",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@nestedModals@7425",
+          "value": "Map<Modal, boolean>",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@childrenRerenderObserver@7429",
+          "value": "MutationObserver",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@shadowDomRerenderObserver@7430",
+          "value": "MutationObserver",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@onEscape@7424",
+          "value": "(event: KeyboardEvent) => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@onBackdropClick@7426",
+          "value": "(event: MouseEvent) => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@onChildModalChange@7428",
+          "value": "EventListenerOrEventListenerObject",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "GetAccessor",
+          "name": "__@isOpen@7420",
+          "value": "boolean",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "__@dismiss@7422",
+          "value": "() => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "GetAccessor",
+          "name": "__@hasOpenChildModal@7417",
+          "value": "boolean",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "__@show@7418",
+          "value": "() => Promise<void>",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "__@hide@7419",
+          "value": "() => Promise<void>",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@overlayHidden@7367",
+          "value": "boolean",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@overlayActivator@7368",
+          "value": "HTMLElement",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "__@overlayHideFrameId@7369",
+          "value": "number",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "setAttribute",
+          "value": "(name: string, value: string) => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "attributeChangedCallback",
+          "value": "(name: string) => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "adoptedCallback",
+          "value": "() => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "queueRender",
+          "value": "() => void",
+          "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "click",
+          "value": "({ sourceEvent }?: ClickOptions) => void",
+          "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
+          "isPrivate": true
+        }
+      ],
+      "value": "declare class Modal extends PreactOverlayElement implements ModalProps {\n  accessor accessibilityLabel: ModalProps['accessibilityLabel'];\n  accessor heading: ModalProps['heading'];\n  accessor padding: ModalProps['padding'];\n  accessor size: ModalProps['size'];\n  /** @private */\n  [abortController]: AbortController;\n  /** @private */\n  [dialog]: HTMLDialogElement | null;\n  /** @private */\n  [focusedElement]: HTMLElement | null;\n  /** @private */\n  [nestedModals]: Map<Modal, boolean>;\n  /** @private */\n  [childrenRerenderObserver]: MutationObserver;\n  /** @private */\n  [shadowDomRerenderObserver]: MutationObserver;\n  /** @private */\n  [onEscape]: (event: KeyboardEvent) => void;\n  /** @private */\n  [onBackdropClick]: (event: MouseEvent) => void;\n  /** @private */\n  [onChildModalChange]: EventListenerOrEventListenerObject;\n  /** @private */\n  get [isOpen](): boolean;\n  /** @private */\n  [dismiss](): void;\n  /** @private */\n  get [hasOpenChildModal](): boolean;\n  /** @private */\n  [show](): Promise<void>;\n  /** @private */\n  [hide](): Promise<void>;\n  showOverlay(): void;\n  hideOverlay(): void;\n  toggleOverlay(): void;\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n  constructor();\n}"
+    }
+  },
+  "Page": {
+    "src/surfaces/admin/components.ts": {
+      "filePath": "src/surfaces/admin/components.ts",
+      "name": "Page",
+      "description": "Use as the outer wrapper of a page.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "inlineSize",
+          "value": "\"small\" | \"base\" | \"large\"",
+          "description": "The inline size of the page\n- `base` corresponds to a set default inline size\n- `large` full width with whitespace",
+          "defaultValue": "'base'"
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "heading",
+          "value": "string",
+          "description": "The main page heading"
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "connectedCallback",
+          "value": "() => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "disconnectedCallback",
+          "value": "() => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "setAttribute",
+          "value": "(name: string, value: string) => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "attributeChangedCallback",
+          "value": "(name: string) => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "adoptedCallback",
+          "value": "() => void",
+          "description": "",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "queueRender",
+          "value": "() => void",
+          "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "click",
+          "value": "({ sourceEvent }?: ClickOptions) => void",
+          "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
+          "isPrivate": true
+        }
+      ],
+      "value": "declare class Page extends PreactCustomElement implements PageProps {\n  accessor inlineSize: PageProps['inlineSize'];\n  accessor heading: PageProps['heading'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
+    }
+  },
+  "IntentRenderApi": {
+    "src/surfaces/admin/api/intents/intent-render.ts": {
+      "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+      "name": "IntentRenderApi",
+      "description": "The `IntentRenderApi` object provides methods for extensions that render in response to an app intent. Access the intent data to determine what action the merchant requested and use `intents.response` to resolve the intent when complete.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "auth",
+          "value": "Auth",
+          "description": "Provides methods for authenticating calls to your app backend. Use the `idToken()` method to retrieve a signed JWT token that verifies the current user's identity for secure server-side operations."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extension",
+          "value": "{ target: ExtensionTarget; }",
+          "description": "The identifier of the running extension target. Use this to determine which target your extension is rendering in and conditionally adjust functionality or UI based on the extension context."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "i18n",
+          "value": "I18n",
+          "description": "Utilities for translating content according to the current localization of the admin. Use these methods to provide translated strings that match the merchant's language preferences, ensuring your extension is accessible to a global audience."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "intents",
+          "value": "IntentRenderIntents",
+          "description": "Provides methods for resolving the current intent. Always available for intent render extensions since they are always invoked inside an intent workflow."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "picker",
+          "value": "PickerApi",
+          "description": "Opens a custom selection dialog with your app-specific data. Use the [Picker API](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/picker-api) to define the picker's heading, items, headers, and selection behavior. Returns a Promise that resolves to a `Picker` object with a `selected` property for accessing the merchant's selection."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "<Data = unknown, Variables = { [key: string]: unknown; }>(query: string, options?: { variables?: Variables; version?: Omit<ApiVersion, \"2023-04\">; }) => Promise<{ data?: Data; errors?: GraphQLError[]; }>",
+          "description": "Executes GraphQL queries against the [GraphQL Admin API](/docs/api/admin-graphql). Use this to fetch shop data, manage resources, or perform mutations. Queries are automatically authenticated with the current user's permissions. Optionally specify GraphQL variables and API version for your query."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "resourcePicker",
+          "value": "ResourcePickerApi",
+          "description": "Opens the [resource picker](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/resource-picker-api) modal for selecting products, variants, or collections. Returns the selected resources when the user confirms their selection, or undefined if they cancel."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storage",
+          "value": "Storage",
+          "description": "Provides methods for persisting data in browser storage that is scoped to your extension. Use this to store user preferences, cache data, maintain state across sessions, or save temporary working data. Storage is persistent across page reloads and isolated per extension."
+        }
+      ],
+      "value": "export interface IntentRenderApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardRenderingExtensionApi<ExtensionTarget> {\n  /**\n   * Provides methods for resolving the current intent. Always available for intent render extensions since they are always invoked inside an intent workflow.\n   */\n  intents: IntentRenderIntents;\n}"
+    }
+  },
+  "IntentRenderIntents": {
+    "src/surfaces/admin/api/intents/intent-render.ts": {
+      "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+      "name": "IntentRenderIntents",
+      "description": "The intents API available to intent render extensions. Unlike other targets where `response` is optional, intent render extensions always run inside an intent workflow so `response` is guaranteed.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/intents/intent-render.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "response",
+          "value": "IntentResponseApi",
+          "description": "Resolves the current intent from within the invoked extension. Use `ok()` to signal success, `error()` to report failure, or `closed()` to indicate the merchant cancelled."
+        }
+      ],
+      "value": "export interface IntentRenderIntents {\n  /**\n   * Resolves the current intent from within the invoked extension. Use `ok()` to signal success, `error()` to report failure, or `closed()` to indicate the merchant cancelled.\n   */\n  response: IntentResponseApi;\n}"
     }
   },
   "StandardApi": {
@@ -11038,15 +11919,6 @@
       "name": "FunctionSettingsComponents",
       "value": "FormExtensionComponents | 'FunctionSettings'",
       "description": "The components available for building function settings extensions. Includes all form components plus the function settings component required for function settings configuration."
-    }
-  },
-  "FormExtensionComponents": {
-    "src/surfaces/admin/components/FormExtensionComponents.ts": {
-      "filePath": "src/surfaces/admin/components/FormExtensionComponents.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "FormExtensionComponents",
-      "value": "StandardComponents | 'Form'",
-      "description": "The components available for building form-based extensions. Includes all standard components plus the form component for creating structured data collection interfaces with submission handling and validation."
     }
   },
   "FunctionSettings": {
@@ -12160,7 +13032,7 @@
           "filePath": "src/surfaces/admin/api/intents/intents.ts",
           "syntaxKind": "PropertySignature",
           "name": "issues",
-          "value": "{ path?: string[]; message?: string; code?: string; }[]",
+          "value": "Issue[]",
           "description": "Specific validation issues or field errors. Present when validation fails on particular fields, allowing you to show targeted error messages.",
           "isOptional": true
         },
@@ -12173,7 +13045,7 @@
           "isOptional": true
         }
       ],
-      "value": "export interface ErrorIntentResponse {\n  /** Indicates the workflow failed. When `'error'`, the workflow encountered validation errors or other issues that prevented completion. */\n  code?: 'error';\n  /** A general error message describing what went wrong. Use this to display feedback when specific field errors aren't available. */\n  message?: string;\n  /** Specific validation issues or field errors. Present when validation fails on particular fields, allowing you to show targeted error messages. */\n  issues?: {\n    /** The path to the field that has an error (for example, `['product', 'title']`). Use this to identify which field caused the validation failure. */\n    path?: string[];\n    /** A description of what's wrong with this field. Display this to help merchants understand how to fix the error. */\n    message?: string;\n    /** A machine-readable error code for this issue. Use this for programmatic error handling or logging. */\n    code?: string;\n  }[];\n}"
+      "value": "export interface ErrorIntentResponse {\n  /** Indicates the workflow failed. When `'error'`, the workflow encountered validation errors or other issues that prevented completion. */\n  code?: 'error';\n  /** A general error message describing what went wrong. Use this to display feedback when specific field errors aren't available. */\n  message?: string;\n  /** Specific validation issues or field errors. Present when validation fails on particular fields, allowing you to show targeted error messages. */\n  issues?: Issue[];\n}"
     }
   },
   "IntentResponse": {
@@ -12514,88 +13386,6 @@
       ]
     }
   },
-  "Page": {
-    "src/surfaces/admin/components.ts": {
-      "filePath": "src/surfaces/admin/components.ts",
-      "name": "Page",
-      "description": "Use as the outer wrapper of a page.",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "inlineSize",
-          "value": "\"small\" | \"base\" | \"large\"",
-          "description": "The inline size of the page\n- `base` corresponds to a set default inline size\n- `large` full width with whitespace",
-          "defaultValue": "'base'"
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "heading",
-          "value": "string",
-          "description": "The main page heading"
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "connectedCallback",
-          "value": "() => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "disconnectedCallback",
-          "value": "() => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "setAttribute",
-          "value": "(name: string, value: string) => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "attributeChangedCallback",
-          "value": "(name: string) => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "adoptedCallback",
-          "value": "() => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "queueRender",
-          "value": "() => void",
-          "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "click",
-          "value": "({ sourceEvent }?: ClickOptions) => void",
-          "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
-        }
-      ],
-      "value": "declare class Page extends PreactCustomElement implements PageProps {\n  accessor inlineSize: PageProps['inlineSize'];\n  accessor heading: PageProps['heading'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
-    }
-  },
   "IntentQueryOptions": {
     "src/surfaces/admin/api/intents/intents.ts": {
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
@@ -12662,6 +13452,25 @@
         }
       ],
       "value": "export interface IntentQuery extends IntentQueryOptions {\n  /**\n   * The operation to perform: `'create'` for new resources or `'edit'` for existing ones.\n   */\n  action: IntentAction;\n  /**\n   * The type of resource to create or edit (for example, `'shopify/Product'`).\n   */\n  type: IntentType;\n}"
+    }
+  },
+  "LoadingOptions": {
+    "src/surfaces/admin/api/loading/loading.ts": {
+      "filePath": "src/surfaces/admin/api/loading/loading.ts",
+      "name": "LoadingOptions",
+      "description": "Options to configure the Admin page-level loading indicator.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/loading/loading.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isLoading",
+          "value": "boolean",
+          "description": "Pass `true` to show the loading indicator, `false` to hide it.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface LoadingOptions {\n  /**\n   * Pass `true` to show the loading indicator, `false` to hide it.\n   */\n  isLoading?: boolean;\n}"
     }
   },
   "Money": {
@@ -18576,260 +19385,6 @@
       "value": "(value: T) => void"
     }
   },
-  "Modal": {
-    "src/surfaces/admin/components.ts": {
-      "filePath": "src/surfaces/admin/components.ts",
-      "name": "Modal",
-      "description": "Configure the following properties on the modal component.",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "accessibilityLabel",
-          "value": "string",
-          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers."
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "heading",
-          "value": "string",
-          "description": "A title that describes the content of the modal."
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "padding",
-          "value": "\"base\" | \"none\"",
-          "description": "Adjust the padding around the modal content.\n\n`base`: applies padding that is appropriate for the element.\n\n`none`: removes all padding from the element. This can be useful when elements inside the modal need to span to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base' to bring back the desired padding for the rest of the content.",
-          "defaultValue": "'base'"
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "size",
-          "value": "\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
-          "description": "The size of the modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.",
-          "defaultValue": "'base'"
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "showOverlay",
-          "value": "() => void",
-          "description": "A method to programmatically show the overlay."
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "hideOverlay",
-          "value": "() => void",
-          "description": "A method to programmatically hide the overlay."
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "toggleOverlay",
-          "value": "() => void",
-          "description": "A method to programmatically toggle the visibility of the overlay."
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "connectedCallback",
-          "value": "() => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "disconnectedCallback",
-          "value": "() => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@7234",
-          "value": "AbortController",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@7228",
-          "value": "HTMLDialogElement",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@7230",
-          "value": "HTMLElement",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@7232",
-          "value": "Map<Modal, boolean>",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@7236",
-          "value": "MutationObserver",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@7237",
-          "value": "MutationObserver",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@7231",
-          "value": "(event: KeyboardEvent) => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@7233",
-          "value": "(event: MouseEvent) => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@7235",
-          "value": "EventListenerOrEventListenerObject",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@7227",
-          "value": "boolean",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@7229",
-          "value": "() => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@7224",
-          "value": "boolean",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "__@show@7225",
-          "value": "() => Promise<void>",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@7226",
-          "value": "() => Promise<void>",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@7174",
-          "value": "boolean",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@7175",
-          "value": "HTMLElement",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@7176",
-          "value": "number",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "setAttribute",
-          "value": "(name: string, value: string) => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "attributeChangedCallback",
-          "value": "(name: string) => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "adoptedCallback",
-          "value": "() => void",
-          "description": "",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "queueRender",
-          "value": "() => void",
-          "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/admin/components.ts",
-          "syntaxKind": "MethodDeclaration",
-          "name": "click",
-          "value": "({ sourceEvent }?: ClickOptions) => void",
-          "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
-        }
-      ],
-      "value": "declare class Modal extends PreactOverlayElement implements ModalProps {\n  accessor accessibilityLabel: ModalProps['accessibilityLabel'];\n  accessor heading: ModalProps['heading'];\n  accessor padding: ModalProps['padding'];\n  accessor size: ModalProps['size'];\n  /** @private */\n  [abortController]: AbortController;\n  /** @private */\n  [dialog]: HTMLDialogElement | null;\n  /** @private */\n  [focusedElement]: HTMLElement | null;\n  /** @private */\n  [nestedModals]: Map<Modal, boolean>;\n  /** @private */\n  [childrenRerenderObserver]: MutationObserver;\n  /** @private */\n  [shadowDomRerenderObserver]: MutationObserver;\n  /** @private */\n  [onEscape]: (event: KeyboardEvent) => void;\n  /** @private */\n  [onBackdropClick]: (event: MouseEvent) => void;\n  /** @private */\n  [onChildModalChange]: EventListenerOrEventListenerObject;\n  /** @private */\n  get [isOpen](): boolean;\n  /** @private */\n  [dismiss](): void;\n  /** @private */\n  get [hasOpenChildModal](): boolean;\n  /** @private */\n  [show](): Promise<void>;\n  /** @private */\n  [hide](): Promise<void>;\n  showOverlay(): void;\n  hideOverlay(): void;\n  toggleOverlay(): void;\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n  constructor();\n}"
-    }
-  },
   "RequiredMoneyFieldProps": {
     "src/surfaces/admin/components.ts": {
       "filePath": "src/surfaces/admin/components.ts",
@@ -19087,7 +19642,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@7174",
+          "name": "__@overlayHidden@7367",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -19095,7 +19650,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@7175",
+          "name": "__@overlayActivator@7368",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -19103,7 +19658,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@7176",
+          "name": "__@overlayHideFrameId@7369",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -21570,6 +22125,59 @@
       "description": "Template schema for reference entity documentation pages.",
       "isPublicDocs": true,
       "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'Purchase Options Card Configuration API',\n  description:\n    'The Purchase Options Card Configuration API provides access to purchase option selection data for products with [subscription](/docs/apps/build/purchase-options/subscriptions) and [selling plan](/docs/apps/build/purchase-options/subscriptions/selling-plans) configurations. Use this API to build action extensions that interact with selected [purchase options](/docs/apps/build/purchase-options) on product and product variant details pages.',\n  isVisualComponent: false,\n  type: 'API',\n  requires:\n    'the [admin action](/docs/api/admin-extensions/{API_VERSION}/web-components/settings-and-templates/admin-action) component.',\n  defaultExample: {\n    description:\n      'Update a subscription by sending product and selling plan IDs to your backend. This example checks for selling plan presence, posts the update request, and shows a success banner before auto-closing the modal.',\n    codeblock: {\n      title: 'Manage a subscription',\n      tabs: [\n        {\n          title: 'jsx',\n          code: './purchase-options-card/examples/manage-subscription.jsx',\n          language: 'jsx',\n        },\n      ],\n    },\n  },\n  definitions: [\n    {\n      title: 'Properties',\n      description:\n        'The `PurchaseOptionsCardConfigurationApi` object provides access to selected purchase option data. Access the following properties on the `PurchaseOptionsCardConfigurationApi` object to interact with currently selected products and selling plans in the `admin.product-purchase-option.action.render` and `admin.product-variant-purchase-option.action.render` targets.',\n      type: 'PurchaseOptionsCardConfigurationApi',\n    },\n  ],\n  examples: {\n    description: 'Work with purchase options and selling plans',\n    examples: [\n      {\n        description:\n          'Show a confirmation dialog before removing a product from a selling plan. This example demonstrates two-step confirmation with cancel option and success feedback after removal.',\n        codeblock: {\n          title: 'Remove from selling plan',\n          tabs: [\n            {\n              title: 'jsx',\n              code: './purchase-options-card/examples/remove-from-plan.jsx',\n              language: 'jsx',\n            },\n          ],\n        },\n      },\n      {\n        description:\n          'Fetch selling plan name and options using the [GraphQL Admin API](/docs/api/admin-graphql) to validate the configuration. This example queries plan details, stores them in state, displays the information, and auto-closes after two seconds.',\n        codeblock: {\n          title: 'Validate selling plan',\n          tabs: [\n            {\n              title: 'jsx',\n              code: './purchase-options-card/examples/validate-selling-plan.jsx',\n              language: 'jsx',\n            },\n          ],\n        },\n      },\n    ],\n  },\n  category: 'Target APIs',\n  subCategory: 'Contextual APIs',\n  related: [],\n  subSections: [\n    {\n      type: 'Generic',\n      anchorLink: 'best-practices',\n      title: 'Best practices',\n      sectionContent:\n        '- **Handle operations based on selling plan selection:** Items in `api.data.selected` have an optional `sellingPlanId` property. When present, perform subscription-specific operations. When absent, treat it as a one-time purchase.',\n    },\n    {\n      type: 'Generic',\n      anchorLink: 'limitations',\n      title: 'Limitations',\n      sectionContent:\n        '- The action only appears when selling plan groups exist on the product or variant. The action is hidden for products without subscription options, even if your extension is installed.\\n' +\n        '- Items in `api.data.selected` have an optional `sellingPlanId` property. When present, the merchant selected a specific selling plan. When absent, they selected the product/variant without a specific plan.\\n' +\n        \"- Your extension can't modify selling plan configurations. The API is read-only for selling plan data. Use GraphQL mutations to update selling plans if needed.\\n\" +\n        '- Selection data only includes IDs. You must query GraphQL for full product, variant, and selling plan details like billing policy and pricing adjustments. Selling plan group data is also unavailable. Your extension only receives individual selling plan IDs but not the parent selling plan group structure.',\n    },\n  ],\n}"
+    }
+  },
+  "AppNavAttributes": {
+    "src/surfaces/admin/components/AppNav/AppNavTypes.ts": {
+      "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+      "name": "AppNavAttributes",
+      "description": "Configure the following properties on the app nav component.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "children",
+          "value": "ComponentChildren",
+          "description": "The navigation items to inject into the Shopify admin sidebar. Provide `<s-link>` children where each link represents a navigation item. This component does not render any visible UI itself.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A unique identifier for the element.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AppNavAttributes {\n  /**\n   * A unique identifier for the element.\n   */\n  id?: string;\n  /**\n   * The navigation items to inject into the Shopify admin sidebar.\n   * Provide `<s-link>` children where each link represents a navigation item.\n   * This component does not render any visible UI itself.\n   */\n  children?: ComponentChildren;\n}"
+    }
+  },
+  "AppNavLinkAttributes": {
+    "src/surfaces/admin/components/AppNav/AppNavTypes.ts": {
+      "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+      "name": "AppNavLinkAttributes",
+      "description": "Attributes for link elements used as children of app nav. Each link defines a navigation destination in your app's menu.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "children",
+          "value": "string",
+          "description": "The visible label text for the navigation item. Keep labels short (1-2 words) and use nouns that describe the destination (such as \"Products\", \"Settings\", or \"Reports\"). Avoid verbs like \"Manage\" or \"View\" to maintain consistency with Shopify admin navigation patterns.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/components/AppNav/AppNavTypes.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "href",
+          "value": "string",
+          "description": "The URL path for the navigation item. Must be a relative path within your app, such as `/products` or `/settings`. When clicked, it navigates the app to this route without a full page reload. The path should match a route defined in your app's routing configuration."
+        }
+      ],
+      "value": "export interface AppNavLinkAttributes {\n  /**\n   * The URL path for the navigation item. Must be a relative path within your app, such as `/products` or `/settings`. When clicked, it navigates the app to this route without a full page reload. The path should match a route defined in your app's routing configuration.\n   */\n  href: string;\n  /**\n   * The visible label text for the navigation item. Keep labels short (1-2 words) and use nouns that describe the destination (such as \"Products\", \"Settings\", or \"Reports\"). Avoid verbs like \"Manage\" or \"View\" to maintain consistency with Shopify admin navigation patterns.\n   */\n  children?: string;\n}"
     }
   }
 }

--- a/packages/ui-extensions/src/surfaces/admin/api.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api.ts
@@ -1,7 +1,7 @@
 export type {I18n, I18nTranslate} from '../../api';
 export type {StandardApi, Intents} from './api/standard/standard';
 export type {ToastApi, ToastOptions} from './api/toast/toast';
-export type {LoadingApi} from './api/loading/loading';
+export type {LoadingApi, LoadingOptions} from './api/loading/loading';
 export type {
   AppApi,
   ExtensionInfo,

--- a/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
@@ -21,7 +21,7 @@ export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>
   app: AppApi;
 
   /**
-   * Sets the Admin page-level loading indicator. Call `loading({ isLoading: true })` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading({ isLoading: false })`, or call `loading()` without an argument, to hide it when the task completes.
+   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.
    */
   loading: LoadingApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/app-home/app-home.ts
@@ -21,7 +21,7 @@ export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>
   app: AppApi;
 
   /**
-   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.
+   * Sets the Admin page-level loading indicator. Call `loading({ isLoading: true })` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading({ isLoading: false })`, or call `loading()` without an argument, to hide it when the task completes.
    */
   loading: LoadingApi;
 }

--- a/packages/ui-extensions/src/surfaces/admin/api/loading/loading.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/loading/loading.ts
@@ -1,9 +1,21 @@
 /**
- * Sets the Admin page-level loading indicator for hosted app home extensions.
- *
- * Call with `true` to start loading. Call with `false`, or without an argument,
- * to stop loading.
+ * Options to configure the Admin page-level loading indicator.
  *
  * @publicDocs
  */
-export type LoadingApi = (isLoading?: boolean) => void;
+export interface LoadingOptions {
+  /**
+   * Pass `true` to show the loading indicator, `false` to hide it.
+   */
+  isLoading?: boolean;
+}
+
+/**
+ * Sets the Admin page-level loading indicator for hosted app home extensions.
+ *
+ * Pass `{ isLoading: true }` to show the indicator and `{ isLoading: false }`,
+ * or call without arguments, to hide it.
+ *
+ * @publicDocs
+ */
+export type LoadingApi = (options?: LoadingOptions) => void;

--- a/packages/ui-extensions/src/surfaces/admin/api/loading/loading.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/loading/loading.ts
@@ -13,9 +13,9 @@ export interface LoadingOptions {
 /**
  * Sets the Admin page-level loading indicator for hosted app home extensions.
  *
- * Pass `{ isLoading: true }` to show the indicator and `{ isLoading: false }`,
- * or call without arguments, to hide it.
+ * Call with `true` to start loading. Call with `false`, or without an argument,
+ * to stop loading.
  *
  * @publicDocs
  */
-export type LoadingApi = (options?: LoadingOptions) => void;
+export type LoadingApi = (isLoading?: boolean) => void;

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
@@ -15,7 +15,7 @@ const data: AdminReferenceEntityTemplateSchema = {
       title: 'Properties',
       description:
         'Configure the following properties on the app nav component.',
-      type: 'AppNav',
+      type: 'AppNavAttributes',
     },
   ],
   related: [

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
@@ -13,7 +13,8 @@ const data: AdminReferenceEntityTemplateSchema = {
   definitions: [
     {
       title: 'Properties',
-      description: 'Configure the following properties on the app nav component.',
+      description:
+        'Configure the following properties on the app nav component.',
       type: 'AppNav',
     },
   ],

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
@@ -17,6 +17,11 @@ const data: AdminReferenceEntityTemplateSchema = {
         'Configure the following properties on the app nav component.',
       type: 'AppNavAttributes',
     },
+    {
+      title: 'Link properties',
+      description: 'Properties for links used as children.',
+      type: 'AppNavLinkAttributes',
+    },
   ],
   related: [
     {

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNav.ab.doc.ts
@@ -1,0 +1,30 @@
+import {AdminReferenceEntityTemplateSchema} from '../../docs-types';
+
+const data: AdminReferenceEntityTemplateSchema = {
+  name: 'AppNav',
+  description:
+    'The app nav component (`<s-app-nav>`) injects navigation items into the Shopify admin sidebar. Use this component to define sidebar navigation for your App Home extension. It does not render visible UI — it configures navigation items on the host side.',
+  isVisualComponent: false,
+  category: 'Web components',
+  subCategory: 'Navigation',
+  thumbnail: '/assets/templated-apis-screenshots/admin/components/app-nav.png',
+  requires:
+    'an [admin.app.home.render](/docs/api/app-home-ui-extension/{API_VERSION}/targets) target.',
+  definitions: [
+    {
+      title: 'Properties',
+      description: 'Configure the following properties on the app nav component.',
+      type: 'AppNav',
+    },
+  ],
+  related: [
+    {
+      name: 'Link',
+      subtitle: 'Web component',
+      url: '/docs/api/app-home-ui-extension/{API_VERSION}/web-components/actions/link',
+      type: 'component',
+    },
+  ],
+};
+
+export default data;

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
@@ -8,7 +8,7 @@ type ComponentChildren = any;
  *
  * @publicDocs
  */
-export interface AppNav {
+export interface AppNavAttributes {
   /**
    * A unique identifier for the element.
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
@@ -1,0 +1,24 @@
+// ComponentChildren is defined in shared.d.ts — we re-declare it here so this
+// non-generated .ts file can reference it without importing from a .d.ts path,
+// and so the type harvester records the correct type name in generated docs.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ComponentChildren = any;
+
+/**
+ * Configure the following properties on the app nav component.
+ *
+ * @publicDocs
+ */
+export interface AppNav {
+  /**
+   * A unique identifier for the element.
+   */
+  id?: string;
+  /**
+   * The navigation items to inject into the Shopify admin sidebar.
+   * Provide `<s-link>` children where each link represents a navigation item.
+   * One `<s-link>` with `rel="home"` is required and represents the home/root navigation item.
+   * This component does not render any visible UI itself.
+   */
+  children?: ComponentChildren;
+}

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
@@ -1,7 +1,6 @@
 // ComponentChildren is defined in shared.d.ts — we re-declare it here so this
 // non-generated .ts file can reference it without importing from a .d.ts path,
 // and so the type harvester records the correct type name in generated docs.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ComponentChildren = any;
 
 /**
@@ -17,7 +16,6 @@ export interface AppNav {
   /**
    * The navigation items to inject into the Shopify admin sidebar.
    * Provide `<s-link>` children where each link represents a navigation item.
-   * One `<s-link>` with `rel="home"` is required and represents the home/root navigation item.
    * This component does not render any visible UI itself.
    */
   children?: ComponentChildren;

--- a/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/AppNav/AppNavTypes.ts
@@ -20,3 +20,19 @@ export interface AppNavAttributes {
    */
   children?: ComponentChildren;
 }
+
+/**
+ * Attributes for link elements used as children of app nav. Each link defines a navigation destination in your app's menu.
+ *
+ * @publicDocs
+ */
+export interface AppNavLinkAttributes {
+  /**
+   * The URL path for the navigation item. Must be a relative path within your app, such as `/products` or `/settings`. When clicked, it navigates the app to this route without a full page reload. The path should match a route defined in your app's routing configuration.
+   */
+  href: string;
+  /**
+   * The visible label text for the navigation item. Keep labels short (1-2 words) and use nouns that describe the destination (such as "Products", "Settings", or "Reports"). Avoid verbs like "Manage" or "View" to maintain consistency with Shopify admin navigation patterns.
+   */
+  children?: string;
+}


### PR DESCRIPTION
## Summary

Fixes two issues in the app-home-ui-extension docs pipeline.

### Issue [#2537](https://github.com/shop/issues-admin-extensibility/issues/2537) — LoadingOptions interface for docs consistency

**Context:** Tim (docs) noticed that the App Bridge (iframe) loading API has a `LoadingOptions` interface that renders in the docs as an expandable properties table with an `isLoading?: boolean` row. The UI Extension equivalent only had `LoadingApi = (isLoading?: boolean) => void`, which renders as a raw function signature — inconsistent with the App Bridge docs presentation.

The fix is documentation-only: `LoadingOptions` is added as a standalone `@publicDocs` interface so the docs can reference it via `<TypeDefinition typeName="LoadingOptions" />` and render the properties table. **The calling convention is unchanged** — `shopify.loading(true)` / `shopify.loading(false)` stays exactly as-is. `LoadingOptions` is a parallel type for docs presentation, not a change to the function signature.

### Issue [#2539](https://github.com/shop/issues-admin-extensibility/issues/2539) — s-app-nav not appearing in generated docs

**Root cause:** Henry added `AppNav.d.ts` (a generated declaration file synced from admin-web/polaris) and deliberately did not add AppNav to `components.d.ts` — because `components.d.ts` covers all admin targets, but `<s-app-nav>` is only available in the `admin.app.home.render` target.

The problem is that the type harvester (`@shopify/generate-docs`) only processes `.ts` files, not `.d.ts` files. The one exception is `components.d.ts`, which the build script temporarily copies to `components.ts` before running the harvester. `AppNav.d.ts` is never copied, so `AppNav` is invisible to the harvester and never appears in the generated JSON. Additionally, `AppNav.d.ts` is auto-generated — adding `@publicDocs` to it would be wiped on the next sync.

**Fix:**

1. **`AppNavTypes.ts`** — A hand-written (non-generated) `.ts` file that exports a documented `AppNav` interface. Because it's a `.ts` file with `@publicDocs`, the type harvester picks it up and writes it into the app_home `generated_docs_data_v2.json` the next time `yarn docs:admin` runs. The file uses a local `type ComponentChildren = any` alias so TypeScript compiles cleanly, while the harvester's `getTypeNameFromValueDeclaration()` reads the raw source text and records `"ComponentChildren"` as the type value, preserving the correct name in generated docs.

2. **`AppNav.ab.doc.ts`** — Routes AppNav into the correct pipeline. The `.ab.doc.ts` suffix means `tsconfig.ab.docs.json` (app_home pipeline) includes it, and `tsconfig.ext.docs.json` (admin_extensions pipeline) excludes it. AppNav only appears in app-home-ui-extension docs, not in regular admin extension docs.

---

## How to test

### LoadingOptions

1. Run `yarn docs:admin` and inspect `docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json`: a `LoadingOptions` key should appear with an `isLoading?: boolean` member.
2. Confirm `LoadingApi` is still `"value": "(isLoading?: boolean) => void"` — the signature is unchanged.
3. In the paired world PR, the loading-api page should render a properties table under "Inputs" (showing `isLoading`) rather than a raw function signature.

<img width="1603" height="1086" alt="Screenshot 2026-05-12 at 1 48 34 PM" src="https://github.com/user-attachments/assets/e03a9370-b6d7-4fe8-8fb5-b420a591ab47" />

### AppNav in generated docs

1. Run `yarn docs:admin` and inspect `docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json`: an `AppNav` key should appear with `id` and `children` members.
2. Confirm `AppNav` does NOT appear in `docs/surfaces/admin/generated/admin_extensions/*/generated_docs_data_v2.json`.
3. In the paired world PR, the app-nav page should render correctly at `/docs/api/app-home-ui-extension/2026-07-rc/web-components/navigation/app-nav`.

<img width="2032" height="1086" alt="Screenshot 2026-05-12 at 2 44 36 PM" src="https://github.com/user-attachments/assets/2ec14cfd-550d-408d-8ad8-35b60c151b13" />


## Related

- Closes https://github.com/shop/issues-admin-extensibility/issues/2537
- Closes https://github.com/shop/issues-admin-extensibility/issues/2539
- Paired world PR with JSON data and MDX page updates (to follow)