### PR TITLE
[Customer account] Add inlineSize to Page in 2026-07-rc

### DIFF
--- a/.changeset/brown-flowers-ask.md
+++ b/.changeset/brown-flowers-ask.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add inlineSize to the customer account Page component

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Page.d.ts
@@ -1,4 +1,4 @@
-import {BaseElementPropsWithChildren, IdProps} from './shared';
+import {BaseElementPropsWithChildren, IdProps, SizeKeyword} from './shared';
 
 export interface PageProps extends IdProps {
   /**
@@ -10,6 +10,15 @@ export interface PageProps extends IdProps {
    * A secondary heading displayed below the main heading for additional context.
    */
   subheading?: string;
+
+  /**
+   * The inline size of the page
+   * - `base` corresponds to a set default inline size
+   * - `large` full width with whitespace
+   *
+   * @default 'base'
+   */
+  inlineSize?: Extract<SizeKeyword, 'base' | 'large'>;
 }
 
 export interface PageElementSlots {


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-customer-accounts-and-login/issues/4197
Related to https://github.com/shop/world/pull/705416
Related to https://github.com/shop/world/pull/714889

Add `inlineSize` to  Customer account `Page` component in 2026-07-rc

### Solution

Add `inlineSize` to Customer account `Page` props

| Before | After |
|-------|-------|
| <img width="1114" height="162" alt="Screenshot 2026-05-12 at 6 12 22 PM" src="https://github.com/user-attachments/assets/3b7d8804-9452-4d24-b290-1e1cc0b3ce60" /> | <img width="611" height="223" alt="Screenshot 2026-05-12 at 6 11 53 PM" src="https://github.com/user-attachments/assets/2c75ad0b-c2b8-4478-8b65-7af07ec64280" /> |

### 🎩

1. Use the snapshot to see that `inlineSize` on `s-page` is typed in extensions

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
