### PR TITLE
docs: clarify Divider, ClipboardItem, and Avatar prop limitations (2026-07-rc)

### DIFF
--- a/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components-shared.d.ts
@@ -2005,6 +2005,8 @@ interface ClipboardItemProps$1 extends GlobalProps {
 	/**
 	 * Plain text to be written to the clipboard.
 	 *
+	 * Rich text, HTML, and binary content aren't supported.
+	 *
 	 * @default ''
 	 */
 	text?: string;
@@ -2304,7 +2306,7 @@ interface DividerProps$1 extends GlobalProps {
 	 * The orientation of the divider, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).
 	 *
 	 * - `inline`: A horizontal divider that separates content stacked vertically.
-	 * - `block`: A vertical divider that separates content arranged horizontally.
+	 * - `block`: A vertical divider that separates content arranged horizontally. Requires a parent with a defined height to render visibly.
 	 *
 	 * @default 'inline'
 	 */

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Avatar.d.ts
@@ -18,6 +18,8 @@ export type CallbackEventListener<
 export interface AvatarElementProps extends IdProps {
   /**
    * The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials, such as "JD" for John Doe.
+   *
+   * Characters beyond the first two might be truncated. Special characters, emojis, and non-Latin scripts might not render as expected.
    */
   initials?: string;
 


### PR DESCRIPTION
Companion to shopify-dev cleanup [shop/world#723308](https://github.com/shop/world/pull/723308), which removes `## Limitations` content from .mdx pages following the framework merged in #669910.

Three of those bullets are property-level behavior that belongs on the auto-generated property table, not in a separate doc section. Adding the JSDoc here ensures the regen automation (`areas-platforms-shopify-dev-checkout-ui-extensions-apis-regen-automation.yml`) carries the constraints into shopify-dev when it next runs against this branch.

Sister PRs (one per active version): #4462, #4463, #4464, #4465. Manual checkout-web override (so the alt docs build path doesn't revert these): [shop/world#723563](https://github.com/shop/world/pull/723563).