### PR TITLE
[POS] Narrow pos.app.ready.data cart surface to readonly

### DIFF
--- a/.changeset/pos-data-target-readonly-cart.md
+++ b/.changeset/pos-data-target-readonly-cart.md
@@ -1,0 +1,7 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Narrow the `pos.app.ready.data` cart API surface to readonly. The background extension target's `shopify.cart` now only exposes the subscribable `current` signal; cart mutation methods (`addLineItem`, `clearCart`, `applyCartDiscount`, `setCustomer`, etc.) are not typed on this target. Cart mutation remains available to interactive render targets via the unchanged `CartApi`.
+
+Internally this splits `CartApiContent` into `ReadonlyCartApiContent` + `MutableCartApiContent` (both re-exported), and introduces `ReadonlyCartApi` for use in `DataTargetApi`.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -3,6 +3,9 @@ export type {
   CartDiscountType,
   CartApiContent,
   LineItemDiscountType,
+  ReadonlyCartApi,
+  ReadonlyCartApiContent,
+  MutableCartApiContent,
 } from './api/cart-api/cart-api';
 
 export type {CartLineItemApi} from './api/cart-line-item-api/cart-line-item-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -19,6 +19,15 @@ export interface CartApi {
 }
 
 /**
+ * Read-only view of the cart for background extension targets
+ * (e.g. `pos.app.ready.data`).
+ * @publicDocs
+ */
+export interface ReadonlyCartApi {
+  cart: ReadonlyCartApiContent;
+}
+
+/**
  * Defines the type of discount applied at the cart level. Specifies whether the discount is percentage-based, fixed amount, or discount code redemption.
  * @publicDocs
  */
@@ -31,15 +40,21 @@ export type CartDiscountType = 'Percentage' | 'FixedAmount' | 'Code';
 export type LineItemDiscountType = 'Percentage' | 'FixedAmount';
 
 /**
- * The `CartApi` object provides access to cart management functionality and real-time cart state monitoring. Access these properties through `shopify.cart` to interact with the current POS cart.
+ * Subscribable cart state without mutation methods.
  * @publicDocs
  */
-export interface CartApiContent {
+export interface ReadonlyCartApiContent {
   /**
    * Provides read-only access to the current cart state and allows subscribing to cart changes. The `value` property provides the current cart state, and `subscribe` allows listening to changes with improved performance and memory management.
    */
   current: ReadonlySignalLike<Cart>;
+}
 
+/**
+ * Cart and line item write operations.
+ * @publicDocs
+ */
+export interface MutableCartApiContent {
   /**
    * Perform a bulk update of the entire cart state including note, discounts, customer, line items, and properties. Returns the updated cart object after the operation completes with enhanced validation and error handling.
    *
@@ -249,3 +264,11 @@ export interface CartApiContent {
    */
   removeLineItemSellingPlan(uuid: string): Promise<void>;
 }
+
+/**
+ * The `CartApi` object provides access to cart management functionality and real-time cart state monitoring. Access these properties through `shopify.cart` to interact with the current POS cart.
+ * @publicDocs
+ */
+export interface CartApiContent
+  extends ReadonlyCartApiContent,
+    MutableCartApiContent {}

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
@@ -1,4 +1,4 @@
-import {CartApi} from '../cart-api/cart-api';
+import {ReadonlyCartApi} from '../cart-api/cart-api';
 import {ConnectivityApi} from '../connectivity-api/connectivity-api';
 import {DeviceApi} from '../device-api/device-api';
 import {ExtensionApi} from '../extension-api/extension-api';
@@ -25,4 +25,4 @@ export type DataTargetApi<T> = {
   ConnectivityApi &
   DeviceApi &
   ProductSearchApi &
-  CartApi;
+  ReadonlyCartApi;


### PR DESCRIPTION
### Summary

Tightens the cart API surface for `pos.app.ready.data` so the background extension target only sees the subscribable `cart.current` signal — not the full set of cart mutators.

<img width="549" height="60" alt="image" src="https://github.com/user-attachments/assets/9afe8705-5832-401c-a56e-9388692fbfb9" />

### Why

`pos.app.ready.data` is documented as a passive observer ("observe POS events without rendering UI"). Its `DataTargetApi` currently mixes in the full `CartApi`, which means a headless background extension has the same write power as an interactive render extension — `addLineItem`, `clearCart`, `applyCartDiscount`, `setCustomer`, etc. That was a miss in the original design.

### What changes

- Split `CartApiContent` into `ReadonlyCartApiContent` (just `current`) and `MutableCartApiContent` (all mutators).
- `CartApiContent` now `extends ReadonlyCartApiContent, MutableCartApiContent` — same shape as before, no surface change for render targets.
- New `ReadonlyCartApi` wrapper interface (`{cart: ReadonlyCartApiContent}`).
- `DataTargetApi` uses `ReadonlyCartApi` instead of `CartApi`.
- Re-export `ReadonlyCartApi`, `ReadonlyCartApiContent`, `MutableCartApiContent` from `surfaces/point-of-sale/api.ts`.

### What does **not** change

- Render targets — unchanged. Still get the full `CartApi`.
- `CartApi` / `CartApiContent` — still exported, still the same member set.
- **Storage** stays mutable on `pos.app.ready.data` — background-extension caching for render-target consumption is a real use case; cart mutation from a passive observer is not.

### Versioning

`patch` bump. `pos.app.ready.data` is on the 2026-07 RC track and isn't GA yet, so this is iterating on an unreleased surface — not a public-API break. No third-party callers in production found via grokt sweep — only Shopify-internal infra and one CDP test.

### Coordinated follow-ups (separate PRs)

1. **`Shopify/extensibility`** — narrow the runtime cart surface in `cartPlugin.expose()` for targets in `POS_BACKGROUND_EXTENSION_TARGETS`. Single-plugin / target-aware approach.
2. **`shop/world`** — rewrite `tooling/extensibility-host-eval/test-scripts/background-extension/apiSurface/cart.js` to assert mutator absence instead of exercising mutators. Bump `@shopify/extensibility-host-*` deps once #1 publishes.

### Validation

- ✅ `yarn build`
- ✅ `tsc --noEmit` for `@shopify/ui-extensions`
- ✅ `ui-extensions-tester` — 69/69 pass
- ✅ ESLint + Prettier on edited files
- ⚠️ Unrelated pre-existing failures on `2026-07-rc` (`react` resolution in `checkout/preact` test suites, lint errors in untracked CJS shim files) — verified to exist on the clean base branch as well.
