### PR TITLE
ci: declare workflow-level `contents: read` on 4 workflows

### DIFF
--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   remind:
     name: Changeset Reminder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   type-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/internal-snapshot.yml
+++ b/.github/workflows/internal-snapshot.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   internal-snapshot:
     name: Internal Snapshot

--- a/.github/workflows/unstable-snapshot.yml
+++ b/.github/workflows/unstable-snapshot.yml
@@ -8,6 +8,9 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   unstable-snapshot:
     name: Unstable Snapshot


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 4 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `cla.yml`, `shopify-dev-preview-automation.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.