### PR TITLE
ci: gate Deploy changesets job to push events only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
 
   changesets:
     name: Deploy
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

The `changesets` job in `.github/workflows/deploy.yml` is missing an event-type guard. The workflow runs on both `push` (release branches) and `issue_comment.created` (for `/snapit`). The `snapit` job correctly guards itself with `event_name == 'issue_comment'`, but `changesets` has no `if:` and fires on every `issue_comment.created` event comments from anyone on any issue or PR.

Introduced in #3783 when the `issue_comment` trigger was added; the new job was guarded but the existing `changesets` job was not backfilled with the inverse guard.

## Fix

Symmetric one-line guard mirroring the `snapit` job's pattern:

```yaml
  changesets:
    name: Deploy
    if: ${{ github.event_name == 'push' }}
    runs-on: ubuntu-latest
```

After this change, `issue_comment.created` events fire only the `snapit` job; `push` events to release branches fire only the `changesets` job. Reported via bug bounty.