### PR TITLE
ci: gate Deploy changesets job to push events only (2026-04)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
 
   changesets:
     name: Deploy
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Backport of #4471 to `2026-04` (current stable).

The `changesets` job in `.github/workflows/deploy.yml` is missing an event-type guard. The workflow runs on both `push` (release branches) and `issue_comment.created` (for `/snapit`). The `snapit` job correctly guards itself with `event_name == 'issue_comment'`, but `changesets` has no `if:` and would fire on every `issue_comment.created` event from any GitHub user if the trigger were ever active on the default branch.

Today this is non-exploitable on this branch because `issue_comment` events route through the default branch (`unstable`), whose `deploy.yml` does not carry the trigger. The fix here is structural defense-in-depth so the misconfig does not propagate forward when the workflow is updated.

## Fix

Symmetric one-line guard mirroring the `snapit` job's pattern:

```yaml
  changesets:
    name: Deploy
    if: ${{ github.event_name == 'push' }}
    runs-on: ubuntu-latest
```

After this change, `issue_comment.created` events fire only the `snapit` job; `push` events to release branches fire only the `changesets` job. Reported via bug bounty (parent PR: #4471).