### PR TITLE
ci: gate Deploy changesets job to push events only (unstable)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   changesets:
     name: Deploy
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Defensive fix on `unstable` (default branch). Parallel to #4471.

Today `unstable`'s `deploy.yml` does not carry the `issue_comment` trigger, so the `changesets` job is not reachable from comments here. However, the missing `if:` is the same structural shape as the issue reported on the release branches via bug bounty, and the moment the `issue_comment` trigger ever propagates to `unstable` (e.g. to make `/snapit` functional, which is what #3783's lineage is working toward), the job becomes reachable from every comment in the repo without this guard.

Adding the guard here pre-emptively means:

1. Future propagation of the `issue_comment` trigger to `unstable` is safe.
2. Newly cut release branches inherit the guard automatically (rather than re-introducing the misconfig that #4471 et al. are fixing on the existing release branches).

## Fix

Symmetric one-line guard mirroring the `snapit` job's pattern on release branches:

```yaml
  changesets:
    name: Deploy
    if: ${{ github.event_name == 'push' }}
    runs-on: ubuntu-latest
```

Behavior on `unstable` today is unchanged — the workflow still only dispatches on `push` to the branches listed in `on.push.branches`, and the job still runs in that context. Reported via bug bounty (parent PR: #4471).