### PR TITLE
Add cash rounding adjustment to POS transaction payloads

### DIFF
--- a/.changeset/cash-rounding-transaction-complete.md
+++ b/.changeset/cash-rounding-transaction-complete.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Add optional `cashRoundingAdjustment` money data to POS transaction-complete payload types.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events/transaction-complete-event.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events/transaction-complete-event.ts
@@ -61,6 +61,10 @@ interface BaseTransactionCompleteEvent extends Event {
    * The tip amount added to this transaction as a `Money` object. This represents the gratuity the customer chose to add on top of the grand total, typically for service-based businesses or hospitality transactions. Tipping can be enabled through POS settings and may be added as a percentage or fixed amount. Returns `undefined` when no tip was added or when tipping is not enabled for the transaction.
    */
   readonly tipAmount?: Money;
+  /**
+   * The cash rounding adjustment applied to this transaction as a `Money` object. Returns `undefined` when no cash rounding adjustment was applied.
+   */
+  readonly cashRoundingAdjustment?: Money;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
@@ -62,4 +62,8 @@ export interface BaseTransactionComplete {
    * The tip amount added to this transaction as a `Money` object. This represents the gratuity the customer chose to add on top of the grand total, typically for service-based businesses or hospitality transactions. Tipping can be enabled through POS settings and may be added as a percentage or fixed amount. Returns `undefined` when no tip was added or when tipping is not enabled for the transaction.
    */
   tipAmount?: Money;
+  /**
+   * The cash rounding adjustment applied to this transaction as a `Money` object. Returns `undefined` when no cash rounding adjustment was applied.
+   */
+  cashRoundingAdjustment?: Money;
 }


### PR DESCRIPTION
Partially resolves: https://github.com/shop/issues-retail/issues/29604

## Summary
Cash rounding adjustment data is not present on that transaction payload that's needed by some partners building POS UI extensions for fiscal compliance (such as Storelink). 

- Add optional cashRoundingAdjustment to BaseTransactionComplete for legacy POS transaction-complete payloads
- Add readonly cashRoundingAdjustment to TransactionCompleteEvent for the new transactioncomplete listener API
- Add a patch changeset for @shopify/ui-extensions

The data for this field is already available in POS app. A follow-up PR will be made in `pos-mobile` to populate this field. 

## Testing
- git diff --check

Related: shop/issues-retail#29604