### PR TITLE
Add POS staff member session signal

### DIFF
--- a/.changeset/tiny-staff-signal.md
+++ b/.changeset/tiny-staff-signal.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-tester': minor
+---
+
+Add `session.staffMember` for POS UI extensions so extensions can read and subscribe to the currently pinned staff member.

--- a/packages/ui-extensions-tester/src/point-of-sale/factories.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/factories.ts
@@ -19,6 +19,7 @@ import type {
   ConnectivityState,
   Cart,
   Session,
+  StaffMember,
   TransactionCompleteData,
   TransactionCompleteWithReprintData,
   CashTrackingSessionStartData,
@@ -60,6 +61,12 @@ function createSessionCurrentSession(): Session {
     staffMemberId: 1,
     currency: 'USD',
     posVersion: '9.0.0',
+  };
+}
+
+function createStaffMember(): StaffMember {
+  return {
+    id: 1,
   };
 }
 
@@ -119,6 +126,7 @@ function createMockStandardApi<T extends RenderExtensionTarget>(
     toast: {show: () => {}},
     session: {
       currentSession: createSessionCurrentSession(),
+      staffMember: createReadonlySignalLike(createStaffMember()),
       getSessionToken: async () => 'mock-session-token',
       deviceId: 1,
     },
@@ -454,6 +462,7 @@ function createDataTargetMock<T extends ExtensionTarget>(
     i18n: createMockI18n(),
     session: {
       currentSession: createSessionCurrentSession(),
+      staffMember: createReadonlySignalLike(createStaffMember()),
       getSessionToken: async () => 'mock-session-token',
       deviceId: 1,
     },

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -134,7 +134,7 @@ export type {
 
 export type {CountryCode} from './types/country-code';
 
-export type {Session} from './types/session';
+export type {Session, StaffMember} from './types/session';
 export type {Storage} from './types/storage';
 export {StorageError} from './types/storage';
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/session-api/session-api.ts
@@ -1,4 +1,5 @@
-import type {Session} from '../../types/session';
+import type {ReadonlySignalLike} from '../../../../shared';
+import type {Session, StaffMember} from '../../types/session';
 
 /**
  * The `SessionApi` object provides session details and authentication methods.
@@ -9,6 +10,10 @@ export interface SessionApiContent {
    * Provides comprehensive information about the current POS session including shop details, user authentication, location data, staff member information, currency settings, and POS version. This data is static for the duration of the session and updates when users switch locations or staff members change.
    */
   currentSession: Session;
+  /**
+   * Provides read-only access to the staff member currently pinned into POS and allows subscribing to staff member changes. The value is `undefined` when no staff member is pinned in.
+   */
+  staffMember: ReadonlySignalLike<StaffMember | undefined>;
   /**
    * Generates a fresh session token for secure communication with your app's backend service. Returns `undefined` when the authenticated user lacks proper app permissions. The token is a Shopify OpenID Connect ID Token that should be used in `Authorization` headers for backend API calls. This is based on the authenticated user, not the pinned staff member.
    */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/session.ts
@@ -1,6 +1,17 @@
 import type {CurrencyCode} from '../../../shared';
 
 /**
+ * Defines a staff member in POS.
+ * @publicDocs
+ */
+export interface StaffMember {
+  /**
+   * The staff member ID.
+   */
+  id: number;
+}
+
+/**
  * Defines information about the current POS session.
  * @publicDocs
  */
@@ -26,7 +37,9 @@ export interface Session {
   locationId: number;
 
   /**
-   * The staff ID of the staff member currently pinned into the POS. This may differ from the user ID if the pinned staff member is different from the logged-in user.
+   * The staff ID of the staff member pinned into POS when the extension started. This may differ from the user ID if the pinned staff member is different from the logged in user.
+   *
+   * @deprecated Use `session.staffMember` on the Session API instead.
    */
   staffMemberId?: number;
 


### PR DESCRIPTION
### Background

https://github.com/shop/issues-retail/issues/29701

POS UI extensions currently expose `session.currentSession.staffMemberId` as a static value captured when an extension instance starts. Extensions need a reactive session field so they can respond when the pinned-in staff member changes.

### Solution

Add `session.staffMember` to the POS Session API as a `ReadonlySignalLike<StaffMember | undefined>`, matching existing signal-based APIs like `cart.current` and `connectivity.current`.

The `StaffMember` shape is intentionally limited to `{ id }`. This is a reactive replacement for the existing public `currentSession.staffMemberId` field. I opted not to expose `firstName` / `lastName` in this PR because Shopify's internal PII guidance treats names as PII/personal data, including employee or contractor names:

- https://vault.shopify.io/page/4631

Staff display names can be considered separately with API/privacy review if needed.

This keeps `currentSession.staffMemberId` for backwards compatibility and marks it deprecated. The runtime wiring will happen in the companion `Shopify/extensibility` PR.

Changes:

- Add `StaffMember` with `id`
- Add `SessionApiContent.staffMember`
- Export `StaffMember` from the POS API barrel
- Update POS tester factories to include the new signal
- Add a minor changeset

### 🎩

- `yarn build`

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
