### PR TITLE
Add admin.abandoned-checkout-index.action extension targets

### DIFF
--- a/.changeset/add-abandoned-checkout-index-action-target.md
+++ b/.changeset/add-abandoned-checkout-index-action-target.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-tester': patch
+---
+
+Add `admin.abandoned-checkout-index.action.render` and `admin.abandoned-checkout-index.action.should-render` extension targets for the abandoned checkout index page. This mirrors the action targets already available on other resource index pages (orders, customers, products, draft orders, etc.) and unblocks `admin.abandoned-checkout-index.action.link` admin link extensions.

--- a/packages/ui-extensions-tester/src/admin/factories.ts
+++ b/packages/ui-extensions-tester/src/admin/factories.ts
@@ -352,6 +352,7 @@ const adminMockFactories: AdminMockFactory = {
   'admin.collection-details.action.render': createMockActionApi,
   'admin.collection-index.action.render': createMockActionApi,
   'admin.abandoned-checkout-details.action.render': createMockActionApi,
+  'admin.abandoned-checkout-index.action.render': createMockActionApi,
   'admin.product-variant-details.action.render': createMockActionApi,
   'admin.draft-order-details.action.render': createMockActionApi,
   'admin.draft-order-index.action.render': createMockActionApi,
@@ -405,6 +406,7 @@ const adminMockFactories: AdminMockFactory = {
   'admin.collection-index.action.should-render': createShouldRenderMock,
   'admin.abandoned-checkout-details.action.should-render':
     createShouldRenderMock,
+  'admin.abandoned-checkout-index.action.should-render': createShouldRenderMock,
   'admin.product-variant-details.action.should-render': createShouldRenderMock,
   'admin.draft-order-details.action.should-render': createShouldRenderMock,
   'admin.draft-order-index.action.should-render': createShouldRenderMock,

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -259,6 +259,14 @@ export interface ExtensionTargets {
   >;
 
   /**
+   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.
+   */
+  'admin.abandoned-checkout-index.action.render': RenderExtension<
+    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,
+    ActionExtensionComponents
+  >;
+
+  /**
    * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.
    */
   'admin.product-variant-details.action.render': RenderExtension<
@@ -542,6 +550,14 @@ export interface ExtensionTargets {
    */
   'admin.abandoned-checkout-details.action.should-render': RunnableExtension<
     ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,
+    ShouldRenderOutput
+  >;
+
+  /**
+   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.
+   */
+  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<
+    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,
     ShouldRenderOutput
   >;
 


### PR DESCRIPTION
### Background

Adds `admin.abandoned-checkout-index.action.render` and `admin.abandoned-checkout-index.action.should-render` extension targets for the abandoned checkout index page.

### Solution

- Add the two new entries to `packages/ui-extensions/src/surfaces/admin/extension-targets.ts` next to the existing `-details` siblings.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have updated relevant documentation

## References

- https://github.com/shop/issues-admin-mobile/issues/5059
- https://github.com/shop/world/pull/751905
- https://github.com/Shopify/extensions-templates/pull/413
