### PR TITLE
Update Admin UI extension docs for 2026-07-rc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -182,6 +182,20 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
+          "name": "admin.abandoned-checkout-index.action.render",
+          "value": "RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >",
+          "description": "An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin.abandoned-checkout-index.action.should-render",
+          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >",
+          "description": "A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
           "name": "admin.app.home.render",
           "value": "RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >",
           "description": "Renders an admin extension on the app home page."
@@ -720,7 +734,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2631,7 +2645,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -2976,7 +2990,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2374",
+          "name": "__@internals$3@2409",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3658,7 +3672,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3761,7 +3775,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2475",
+          "name": "__@internals$2@2510",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4020,7 +4034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4182,7 +4196,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2519",
+          "name": "__@dirtyStateSymbol@2554",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -4190,7 +4204,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2518",
+          "name": "__@internals$1@2553",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4357,7 +4371,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2554",
+          "name": "__@setFiles@2589",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true
@@ -4365,7 +4379,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2556",
+          "name": "__@getFileInput@2591",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true
@@ -4373,7 +4387,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2555",
+          "name": "__@internals@2590",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4683,7 +4697,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6101,7 +6115,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -6109,7 +6123,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -6117,7 +6131,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -6328,7 +6342,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6579,7 +6593,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7170,7 +7184,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7474,7 +7488,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7722,7 +7736,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@2969",
+          "name": "__@usedFirstOptionSymbol@3004",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true
@@ -7730,7 +7744,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@2970",
+          "name": "__@hasInitialValueSymbol@3005",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -7760,7 +7774,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8324,7 +8338,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8439,7 +8453,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@3045",
+          "name": "__@actualTableVariantSymbol@3080",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true
@@ -8447,7 +8461,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@3046",
+          "name": "__@tableHeadersSharedDataSymbol@3081",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true
@@ -8657,7 +8671,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@3068",
+          "name": "__@headerFormatSymbol@3103",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true
@@ -9237,7 +9251,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9480,7 +9494,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9637,7 +9651,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -9645,7 +9659,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -9653,7 +9667,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -9947,7 +9961,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -10493,8 +10507,8 @@
           "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
           "syntaxKind": "PropertySignature",
           "name": "intents",
-          "value": "Intents",
-          "description": "Provides information to the receiver of an intent. Use this to access data passed from other extensions or parts of the admin when your extension is launched through intent-based navigation."
+          "value": "AppHomeIntents",
+          "description": "Receives [link intents](/docs/apps/build/sidekick/build-app-data) dispatched to the app home target and resolves them when complete. Subscribe to `intents.request` to be notified each time the admin navigates the merchant to your app via a link intent, and call `intents.response.ok()` / `error()` / `closed()` to resolve the active intent.\n\nWhen you run `dev`, the CLI generates typed variants for every intent declared in `shopify.extension.toml`. Use the `WithGeneratedIntents` helper type to narrow `request.value` and `response.ok` to the generated payloads in your app code."
         },
         {
           "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
@@ -10523,9 +10537,16 @@
           "name": "toast",
           "value": "ToastApi",
           "description": "Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "tools",
+          "value": "Tools",
+          "description": "Registers runtime handlers for app tools declared in your extension configuration. Use this to expose app data lookups and app actions to [Sidekick](/docs/apps/build/sidekick/build-app-data), including link intents that drive the navigate modality from the app home target.\n\nWhen you run `dev`, the CLI generates typed `register` overloads for every tool declared in `shopify.extension.toml`. Use the `WithGeneratedTools` helper type to narrow this property to the generated overloads in your app code."
         }
       ],
-      "value": "export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardApi<ExtensionTarget> {\n  /**\n   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.\n   */\n  toast: ToastApi;\n\n  /**\n   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.\n   */\n  app: AppApi;\n\n  /**\n   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.\n   */\n  loading: LoadingApi;\n}"
+      "value": "export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardApi<ExtensionTarget> {\n  /**\n   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.\n   */\n  toast: ToastApi;\n\n  /**\n   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.\n   */\n  app: AppApi;\n\n  /**\n   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.\n   */\n  loading: LoadingApi;\n\n  /**\n   * Receives [link intents](/docs/apps/build/sidekick/build-app-data) dispatched to the app home target and resolves them when complete. Subscribe to `intents.request` to be notified each time the admin navigates the merchant to your app via a link intent, and call `intents.response.ok()` / `error()` / `closed()` to resolve the active intent.\n   *\n   * When you run `dev`, the CLI generates typed variants for every intent declared in `shopify.extension.toml`. Use the `WithGeneratedIntents` helper type to narrow `request.value` and `response.ok` to the generated payloads in your app code.\n   */\n  intents: AppHomeIntents;\n\n  /**\n   * Registers runtime handlers for app tools declared in your extension configuration. Use this to expose app data lookups and app actions to [Sidekick](/docs/apps/build/sidekick/build-app-data), including link intents that drive the navigate modality from the app home target.\n   *\n   * When you run `dev`, the CLI generates typed `register` overloads for every tool declared in `shopify.extension.toml`. Use the `WithGeneratedTools` helper type to narrow this property to the generated overloads in your app code.\n   */\n  tools: Tools;\n}"
     }
   },
   "AppApi": {
@@ -10717,6 +10738,92 @@
       "isPublicDocs": true
     }
   },
+  "AppHomeIntents": {
+    "src/surfaces/admin/api/app-home/app-home.ts": {
+      "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+      "name": "AppHomeIntents",
+      "description": "The intents API available to app home extensions. It exposes a signal-like `request` that streams link intents into the long-running extension. Inspect `request.value` for information about the active intent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "invoke",
+          "value": "IntentInvokeApi",
+          "description": "Launches an intent workflow for creating or editing Shopify resources.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "request",
+          "value": "AppHomeIntentRequest",
+          "description": "The current link intent delivered to the extension. Subscribe to receive new intents over the lifetime of the extension."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "response",
+          "value": "IntentResponseApi",
+          "description": "Resolves the current intent. Available only while `request.value` is non-null; the runtime swaps in a fresh handle for each new intent.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AppHomeIntents {\n  /**\n   * The current link intent delivered to the extension. Subscribe to receive\n   * new intents over the lifetime of the extension.\n   */\n  request: AppHomeIntentRequest;\n  /**\n   * Resolves the current intent. Available only while `request.value` is\n   * non-null; the runtime swaps in a fresh handle for each new intent.\n   */\n  response?: IntentResponseApi;\n  /**\n   * Launches an intent workflow for creating or editing Shopify resources.\n   */\n  invoke?: IntentInvokeApi;\n}"
+    }
+  },
+  "AppHomeIntentRequest": {
+    "src/surfaces/admin/api/app-home/app-home.ts": {
+      "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+      "name": "AppHomeIntentRequest",
+      "description": "The current link intent delivered to an app home extension. The admin pushes a new value into `request` whenever a link intent is dispatched to your app, and resets it to `null` when no intent is active.\n\nThe shape is signal-like (`value` + `subscribe`) so the running extension can observe a stream of intents over its lifetime, mirroring the behaviour the CLI's generated typings already expect via `WithGeneratedIntents`.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subscribe",
+          "value": "(callback: (value: IntentQueryOptions) => void) => () => void",
+          "description": "Subscribes to changes in the active intent. The callback is invoked with the new value whenever the admin dispatches a new intent or clears it. Returns a function that unsubscribes the callback."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "IntentQueryOptions | null",
+          "description": "The intent that's currently being delivered to the extension, or `null` when no intent is active."
+        }
+      ],
+      "value": "export interface AppHomeIntentRequest {\n  /**\n   * The intent that's currently being delivered to the extension, or `null`\n   * when no intent is active.\n   */\n  readonly value: IntentQueryOptions | null;\n  /**\n   * Subscribes to changes in the active intent. The callback is invoked with\n   * the new value whenever the admin dispatches a new intent or clears it.\n   * Returns a function that unsubscribes the callback.\n   */\n  subscribe: (\n    callback: (value: IntentQueryOptions | null) => void,\n  ) => () => void;\n}"
+    }
+  },
+  "IntentQueryOptions": {
+    "src/surfaces/admin/api/intents/intents.ts": {
+      "filePath": "src/surfaces/admin/api/intents/intents.ts",
+      "name": "IntentQueryOptions",
+      "description": "Additional parameters for intent invocation when using the string query format. Use these options to provide resource IDs for editing or pass required context data for resource creation.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "{ [key: string]: unknown; }",
+          "description": "Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface IntentQueryOptions {\n  /**\n   * The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.\n   */\n  value?: string;\n  /**\n   * Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.\n   */\n  data?: {[key: string]: unknown};\n}"
+    }
+  },
   "LoadingApi": {
     "src/surfaces/admin/api/loading/loading.ts": {
       "filePath": "src/surfaces/admin/api/loading/loading.ts",
@@ -10818,6 +10925,61 @@
       "value": "export interface ToastOptions {\n  /**\n   * The duration in milliseconds to display the toast before automatically dismissing. If not specified, a default duration is used.\n   */\n  duration?: number;\n\n  /**\n   * Whether to display the toast as an error notification. Use for error messages or failed operations.\n   * @defaultValue false\n   */\n  isError?: boolean;\n\n  /**\n   * The label for an optional action button displayed in the toast. When provided, an action button appears that the user can click.\n   */\n  action?: string;\n\n  /**\n   * Callback function triggered when the user clicks the action button. Only called if `action` is provided.\n   */\n  onAction?: () => void;\n\n  /**\n   * Callback function triggered when the toast is dismissed, either automatically after the duration expires or manually by the user.\n   */\n  onDismiss?: () => void;\n}"
     }
   },
+  "Tools": {
+    "src/surfaces/admin/api/tools/tools.ts": {
+      "filePath": "src/surfaces/admin/api/tools/tools.ts",
+      "name": "Tools",
+      "description": "The `Tools` object provides methods for registering and removing runtime handlers for app tools declared in your extension configuration. Use this API to expose app data lookups and app actions that [Sidekick](/docs/apps/build/sidekick/build-app-data) can invoke on behalf of merchants.\n\nThe base `register` signature accepts any tool name and a generic handler. When you run `dev`, the CLI generates a typed `register` overload for every tool declared in `shopify.extension.toml`, narrowing both the accepted name and the handler's `input`/return types. Use the `WithGeneratedTools` helper to merge the generated typings into your target's API.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "clear",
+          "value": "() => void",
+          "description": "Unregisters every tool handler currently registered by your extension."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "register",
+          "value": "(name: string, handler: ToolHandler) => () => void",
+          "description": "Registers a tool handler for your app. If a handler with the same name is already registered, it is replaced. Returns a cleanup function that unregisters the handler."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "unregister",
+          "value": "(name: string) => void",
+          "description": "Unregisters a previously registered tool handler. Calling this for a tool that isn't registered is a no-op."
+        }
+      ],
+      "value": "export interface Tools {\n  /**\n   * Registers a tool handler for your app. If a handler with the same name is\n   * already registered, it is replaced. Returns a cleanup function that\n   * unregisters the handler.\n   *\n   * @param name - The tool name as declared in your extension configuration.\n   * @param handler - The function invoked when the tool is called.\n   * @returns A function that unregisters the handler when invoked.\n   */\n  register: (name: string, handler: ToolHandler) => () => void;\n\n  /**\n   * Unregisters a previously registered tool handler. Calling this for a tool\n   * that isn't registered is a no-op.\n   *\n   * @param name - The tool name to unregister.\n   */\n  unregister: (name: string) => void;\n\n  /**\n   * Unregisters every tool handler currently registered by your extension.\n   */\n  clear: () => void;\n}"
+    }
+  },
+  "ToolHandler": {
+    "src/surfaces/admin/api/tools/tools.ts": {
+      "filePath": "src/surfaces/admin/api/tools/tools.ts",
+      "name": "ToolHandler",
+      "description": "A handler function invoked by the platform when a registered tool is called. The handler receives an `input` object that matches the tool's declared input JSON schema and must return (synchronously or asynchronously) an object that matches the declared output JSON schema.\n\nGenerated tool typings narrow the `input` and return value of this handler for each registered tool name. This base signature is the generic fallback used before code generation has run, or for tools that aren't yet declared in your extension configuration.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "input",
+          "description": "",
+          "value": "Record<string, any>",
+          "filePath": "src/surfaces/admin/api/tools/tools.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/surfaces/admin/api/tools/tools.ts",
+        "description": "",
+        "name": "Record<string, any> | Promise<Record<string, any>>",
+        "value": "Record<string, any> | Promise<Record<string, any>>"
+      },
+      "value": "(\n  input: Record<string, any>,\n) => Record<string, any> | Promise<Record<string, any>>"
+    }
+  },
   "FormExtensionComponents": {
     "src/surfaces/admin/components/FormExtensionComponents.ts": {
       "filePath": "src/surfaces/admin/components/FormExtensionComponents.ts",
@@ -10904,7 +11066,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2750",
+          "name": "__@abortController@2785",
           "value": "AbortController",
           "description": "",
           "isPrivate": true
@@ -10912,7 +11074,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2744",
+          "name": "__@dialog@2779",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true
@@ -10920,7 +11082,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2746",
+          "name": "__@focusedElement@2781",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -10928,7 +11090,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2748",
+          "name": "__@nestedModals@2783",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true
@@ -10936,7 +11098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2752",
+          "name": "__@childrenRerenderObserver@2787",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -10944,7 +11106,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2753",
+          "name": "__@shadowDomRerenderObserver@2788",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -10952,7 +11114,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2747",
+          "name": "__@onEscape@2782",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true
@@ -10960,7 +11122,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2749",
+          "name": "__@onBackdropClick@2784",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true
@@ -10968,7 +11130,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2751",
+          "name": "__@onChildModalChange@2786",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true
@@ -10976,7 +11138,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2743",
+          "name": "__@isOpen@2778",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -10984,7 +11146,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2745",
+          "name": "__@dismiss@2780",
           "value": "() => void",
           "description": "",
           "isPrivate": true
@@ -10992,7 +11154,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2740",
+          "name": "__@hasOpenChildModal@2775",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -11000,7 +11162,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2741",
+          "name": "__@show@2776",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -11008,7 +11170,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2742",
+          "name": "__@hide@2777",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -11016,7 +11178,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -11024,7 +11186,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -11032,7 +11194,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -13374,33 +13536,6 @@
           "description": "Products sorted by search relevance based on query terms. Use this when the collection is filtered by search."
         }
       ]
-    }
-  },
-  "IntentQueryOptions": {
-    "src/surfaces/admin/api/intents/intents.ts": {
-      "filePath": "src/surfaces/admin/api/intents/intents.ts",
-      "name": "IntentQueryOptions",
-      "description": "Additional parameters for intent invocation when using the string query format. Use these options to provide resource IDs for editing or pass required context data for resource creation.",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/admin/api/intents/intents.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "data",
-          "value": "{ [key: string]: unknown; }",
-          "description": "Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/admin/api/intents/intents.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string",
-          "description": "The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.",
-          "isOptional": true
-        }
-      ],
-      "value": "export interface IntentQueryOptions {\n  /**\n   * The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.\n   */\n  value?: string;\n  /**\n   * Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.\n   */\n  data?: {[key: string]: unknown};\n}"
     }
   },
   "IntentQuery": {
@@ -19642,7 +19777,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -19650,7 +19785,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -19658,7 +19793,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true

--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/targets.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/targets.json
@@ -1686,6 +1686,68 @@
       "ActionExtensionApi"
     ]
   },
+  "admin.abandoned-checkout-index.action.render": {
+    "components": [
+      "AdminAction",
+      "Avatar",
+      "Badge",
+      "Banner",
+      "Box",
+      "Button",
+      "ButtonGroup",
+      "Checkbox",
+      "Chip",
+      "Choice",
+      "ChoiceList",
+      "Clickable",
+      "ClickableChip",
+      "ColorField",
+      "ColorPicker",
+      "DateField",
+      "DatePicker",
+      "Divider",
+      "DropZone",
+      "EmailField",
+      "Grid",
+      "GridItem",
+      "Heading",
+      "Icon",
+      "Image",
+      "Link",
+      "ListItem",
+      "Menu",
+      "MoneyField",
+      "NumberField",
+      "Option",
+      "OptionGroup",
+      "OrderedList",
+      "Paragraph",
+      "PasswordField",
+      "QueryContainer",
+      "SearchField",
+      "Section",
+      "Select",
+      "Spinner",
+      "Stack",
+      "Switch",
+      "Table",
+      "TableBody",
+      "TableCell",
+      "TableHeader",
+      "TableHeaderRow",
+      "TableRow",
+      "Text",
+      "TextArea",
+      "TextField",
+      "Thumbnail",
+      "Tooltip",
+      "URLField",
+      "UnorderedList"
+    ],
+    "apis": [
+      "ActionExtensionApi"
+    ]
+  },
   "admin.product-variant-details.action.render": {
     "components": [
       "AdminAction",
@@ -3143,6 +3205,12 @@
       "ShouldRenderApi"
     ]
   },
+  "admin.abandoned-checkout-index.action.should-render": {
+    "components": [],
+    "apis": [
+      "ShouldRenderApi"
+    ]
+  },
   "admin.product-variant-details.action.should-render": {
     "components": [],
     "apis": [
@@ -3257,6 +3325,7 @@
   "ActionExtensionApi": {
     "targets": [
       "admin.abandoned-checkout-details.action.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.catalog-details.action.render",
       "admin.collection-details.action.render",
       "admin.collection-index.action.render",
@@ -3334,6 +3403,7 @@
   "ShouldRenderApi": {
     "targets": [
       "admin.abandoned-checkout-details.action.should-render",
+      "admin.abandoned-checkout-index.action.should-render",
       "admin.catalog-details.action.should-render",
       "admin.collection-details.action.should-render",
       "admin.collection-index.action.should-render",
@@ -3390,6 +3460,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3443,6 +3514,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3496,6 +3568,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3549,6 +3622,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3602,6 +3676,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3655,6 +3730,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3708,6 +3784,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3761,6 +3838,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3814,6 +3892,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3867,6 +3946,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3920,6 +4000,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -3973,6 +4054,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4026,6 +4108,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4079,6 +4162,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4132,6 +4216,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4185,6 +4270,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4238,6 +4324,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4291,6 +4378,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4344,6 +4432,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4419,6 +4508,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4472,6 +4562,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4525,6 +4616,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4578,6 +4670,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4631,6 +4724,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4684,6 +4778,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4737,6 +4832,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4790,6 +4886,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4843,6 +4940,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4896,6 +4994,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -4949,6 +5048,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5002,6 +5102,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5055,6 +5156,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5108,6 +5210,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5161,6 +5264,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5214,6 +5318,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5267,6 +5372,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5320,6 +5426,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5373,6 +5480,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5426,6 +5534,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5479,6 +5588,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5532,6 +5642,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5585,6 +5696,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5638,6 +5750,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5691,6 +5804,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5744,6 +5858,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5797,6 +5912,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5850,6 +5966,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5903,6 +6020,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -5956,6 +6074,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -6009,6 +6128,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -6062,6 +6182,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -6115,6 +6236,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -6168,6 +6290,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -6221,6 +6344,7 @@
     "targets": [
       "admin.abandoned-checkout-details.action.render",
       "admin.abandoned-checkout-details.block.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.app.home.render",
       "admin.app.intent.render",
       "admin.catalog-details.action.render",
@@ -6280,6 +6404,7 @@
   "AdminAction": {
     "targets": [
       "admin.abandoned-checkout-details.action.render",
+      "admin.abandoned-checkout-index.action.render",
       "admin.catalog-details.action.render",
       "admin.collection-details.action.render",
       "admin.collection-index.action.render",

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -182,6 +182,20 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
+          "name": "admin.abandoned-checkout-index.action.render",
+          "value": "RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >",
+          "description": "An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin.abandoned-checkout-index.action.should-render",
+          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >",
+          "description": "A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
           "name": "admin.app.home.render",
           "value": "RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >",
           "description": "Renders an admin extension on the app home page."
@@ -720,7 +734,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2631,7 +2645,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -2976,7 +2990,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2374",
+          "name": "__@internals$3@2409",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3658,7 +3672,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3761,7 +3775,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2475",
+          "name": "__@internals$2@2510",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4020,7 +4034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4182,7 +4196,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2519",
+          "name": "__@dirtyStateSymbol@2554",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -4190,7 +4204,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2518",
+          "name": "__@internals$1@2553",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4357,7 +4371,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2554",
+          "name": "__@setFiles@2589",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true
@@ -4365,7 +4379,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2556",
+          "name": "__@getFileInput@2591",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true
@@ -4373,7 +4387,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2555",
+          "name": "__@internals@2590",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4683,7 +4697,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6101,7 +6115,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -6109,7 +6123,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -6117,7 +6131,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -6328,7 +6342,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6579,7 +6593,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7170,7 +7184,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7474,7 +7488,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7722,7 +7736,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@2969",
+          "name": "__@usedFirstOptionSymbol@3004",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true
@@ -7730,7 +7744,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@2970",
+          "name": "__@hasInitialValueSymbol@3005",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -7760,7 +7774,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8324,7 +8338,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8439,7 +8453,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@3045",
+          "name": "__@actualTableVariantSymbol@3080",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true
@@ -8447,7 +8461,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@3046",
+          "name": "__@tableHeadersSharedDataSymbol@3081",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true
@@ -8657,7 +8671,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@3068",
+          "name": "__@headerFormatSymbol@3103",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true
@@ -9237,7 +9251,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9480,7 +9494,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9637,7 +9651,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -9645,7 +9659,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -9653,7 +9667,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -9947,7 +9961,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -10493,8 +10507,8 @@
           "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
           "syntaxKind": "PropertySignature",
           "name": "intents",
-          "value": "Intents",
-          "description": "Provides information to the receiver of an intent. Use this to access data passed from other extensions or parts of the admin when your extension is launched through intent-based navigation."
+          "value": "AppHomeIntents",
+          "description": "Receives [link intents](/docs/apps/build/sidekick/build-app-data) dispatched to the app home target and resolves them when complete. Subscribe to `intents.request` to be notified each time the admin navigates the merchant to your app via a link intent, and call `intents.response.ok()` / `error()` / `closed()` to resolve the active intent.\n\nWhen you run `dev`, the CLI generates typed variants for every intent declared in `shopify.extension.toml`. Use the `WithGeneratedIntents` helper type to narrow `request.value` and `response.ok` to the generated payloads in your app code."
         },
         {
           "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
@@ -10523,9 +10537,16 @@
           "name": "toast",
           "value": "ToastApi",
           "description": "Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "tools",
+          "value": "Tools",
+          "description": "Registers runtime handlers for app tools declared in your extension configuration. Use this to expose app data lookups and app actions to [Sidekick](/docs/apps/build/sidekick/build-app-data), including link intents that drive the navigate modality from the app home target.\n\nWhen you run `dev`, the CLI generates typed `register` overloads for every tool declared in `shopify.extension.toml`. Use the `WithGeneratedTools` helper type to narrow this property to the generated overloads in your app code."
         }
       ],
-      "value": "export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardApi<ExtensionTarget> {\n  /**\n   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.\n   */\n  toast: ToastApi;\n\n  /**\n   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.\n   */\n  app: AppApi;\n\n  /**\n   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.\n   */\n  loading: LoadingApi;\n}"
+      "value": "export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardApi<ExtensionTarget> {\n  /**\n   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.\n   */\n  toast: ToastApi;\n\n  /**\n   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.\n   */\n  app: AppApi;\n\n  /**\n   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.\n   */\n  loading: LoadingApi;\n\n  /**\n   * Receives [link intents](/docs/apps/build/sidekick/build-app-data) dispatched to the app home target and resolves them when complete. Subscribe to `intents.request` to be notified each time the admin navigates the merchant to your app via a link intent, and call `intents.response.ok()` / `error()` / `closed()` to resolve the active intent.\n   *\n   * When you run `dev`, the CLI generates typed variants for every intent declared in `shopify.extension.toml`. Use the `WithGeneratedIntents` helper type to narrow `request.value` and `response.ok` to the generated payloads in your app code.\n   */\n  intents: AppHomeIntents;\n\n  /**\n   * Registers runtime handlers for app tools declared in your extension configuration. Use this to expose app data lookups and app actions to [Sidekick](/docs/apps/build/sidekick/build-app-data), including link intents that drive the navigate modality from the app home target.\n   *\n   * When you run `dev`, the CLI generates typed `register` overloads for every tool declared in `shopify.extension.toml`. Use the `WithGeneratedTools` helper type to narrow this property to the generated overloads in your app code.\n   */\n  tools: Tools;\n}"
     }
   },
   "AppApi": {
@@ -10717,6 +10738,92 @@
       "isPublicDocs": true
     }
   },
+  "AppHomeIntents": {
+    "src/surfaces/admin/api/app-home/app-home.ts": {
+      "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+      "name": "AppHomeIntents",
+      "description": "The intents API available to app home extensions. It exposes a signal-like `request` that streams link intents into the long-running extension. Inspect `request.value` for information about the active intent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "invoke",
+          "value": "IntentInvokeApi",
+          "description": "Launches an intent workflow for creating or editing Shopify resources.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "request",
+          "value": "AppHomeIntentRequest",
+          "description": "The current link intent delivered to the extension. Subscribe to receive new intents over the lifetime of the extension."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "response",
+          "value": "IntentResponseApi",
+          "description": "Resolves the current intent. Available only while `request.value` is non-null; the runtime swaps in a fresh handle for each new intent.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AppHomeIntents {\n  /**\n   * The current link intent delivered to the extension. Subscribe to receive\n   * new intents over the lifetime of the extension.\n   */\n  request: AppHomeIntentRequest;\n  /**\n   * Resolves the current intent. Available only while `request.value` is\n   * non-null; the runtime swaps in a fresh handle for each new intent.\n   */\n  response?: IntentResponseApi;\n  /**\n   * Launches an intent workflow for creating or editing Shopify resources.\n   */\n  invoke?: IntentInvokeApi;\n}"
+    }
+  },
+  "AppHomeIntentRequest": {
+    "src/surfaces/admin/api/app-home/app-home.ts": {
+      "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+      "name": "AppHomeIntentRequest",
+      "description": "The current link intent delivered to an app home extension. The admin pushes a new value into `request` whenever a link intent is dispatched to your app, and resets it to `null` when no intent is active.\n\nThe shape is signal-like (`value` + `subscribe`) so the running extension can observe a stream of intents over its lifetime, mirroring the behaviour the CLI's generated typings already expect via `WithGeneratedIntents`.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subscribe",
+          "value": "(callback: (value: IntentQueryOptions) => void) => () => void",
+          "description": "Subscribes to changes in the active intent. The callback is invoked with the new value whenever the admin dispatches a new intent or clears it. Returns a function that unsubscribes the callback."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "IntentQueryOptions | null",
+          "description": "The intent that's currently being delivered to the extension, or `null` when no intent is active."
+        }
+      ],
+      "value": "export interface AppHomeIntentRequest {\n  /**\n   * The intent that's currently being delivered to the extension, or `null`\n   * when no intent is active.\n   */\n  readonly value: IntentQueryOptions | null;\n  /**\n   * Subscribes to changes in the active intent. The callback is invoked with\n   * the new value whenever the admin dispatches a new intent or clears it.\n   * Returns a function that unsubscribes the callback.\n   */\n  subscribe: (\n    callback: (value: IntentQueryOptions | null) => void,\n  ) => () => void;\n}"
+    }
+  },
+  "IntentQueryOptions": {
+    "src/surfaces/admin/api/intents/intents.ts": {
+      "filePath": "src/surfaces/admin/api/intents/intents.ts",
+      "name": "IntentQueryOptions",
+      "description": "Additional parameters for intent invocation when using the string query format. Use these options to provide resource IDs for editing or pass required context data for resource creation.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "{ [key: string]: unknown; }",
+          "description": "Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface IntentQueryOptions {\n  /**\n   * The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.\n   */\n  value?: string;\n  /**\n   * Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.\n   */\n  data?: {[key: string]: unknown};\n}"
+    }
+  },
   "LoadingApi": {
     "src/surfaces/admin/api/loading/loading.ts": {
       "filePath": "src/surfaces/admin/api/loading/loading.ts",
@@ -10818,6 +10925,61 @@
       "value": "export interface ToastOptions {\n  /**\n   * The duration in milliseconds to display the toast before automatically dismissing. If not specified, a default duration is used.\n   */\n  duration?: number;\n\n  /**\n   * Whether to display the toast as an error notification. Use for error messages or failed operations.\n   * @defaultValue false\n   */\n  isError?: boolean;\n\n  /**\n   * The label for an optional action button displayed in the toast. When provided, an action button appears that the user can click.\n   */\n  action?: string;\n\n  /**\n   * Callback function triggered when the user clicks the action button. Only called if `action` is provided.\n   */\n  onAction?: () => void;\n\n  /**\n   * Callback function triggered when the toast is dismissed, either automatically after the duration expires or manually by the user.\n   */\n  onDismiss?: () => void;\n}"
     }
   },
+  "Tools": {
+    "src/surfaces/admin/api/tools/tools.ts": {
+      "filePath": "src/surfaces/admin/api/tools/tools.ts",
+      "name": "Tools",
+      "description": "The `Tools` object provides methods for registering and removing runtime handlers for app tools declared in your extension configuration. Use this API to expose app data lookups and app actions that [Sidekick](/docs/apps/build/sidekick/build-app-data) can invoke on behalf of merchants.\n\nThe base `register` signature accepts any tool name and a generic handler. When you run `dev`, the CLI generates a typed `register` overload for every tool declared in `shopify.extension.toml`, narrowing both the accepted name and the handler's `input`/return types. Use the `WithGeneratedTools` helper to merge the generated typings into your target's API.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "clear",
+          "value": "() => void",
+          "description": "Unregisters every tool handler currently registered by your extension."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "register",
+          "value": "(name: string, handler: ToolHandler) => () => void",
+          "description": "Registers a tool handler for your app. If a handler with the same name is already registered, it is replaced. Returns a cleanup function that unregisters the handler."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "unregister",
+          "value": "(name: string) => void",
+          "description": "Unregisters a previously registered tool handler. Calling this for a tool that isn't registered is a no-op."
+        }
+      ],
+      "value": "export interface Tools {\n  /**\n   * Registers a tool handler for your app. If a handler with the same name is\n   * already registered, it is replaced. Returns a cleanup function that\n   * unregisters the handler.\n   *\n   * @param name - The tool name as declared in your extension configuration.\n   * @param handler - The function invoked when the tool is called.\n   * @returns A function that unregisters the handler when invoked.\n   */\n  register: (name: string, handler: ToolHandler) => () => void;\n\n  /**\n   * Unregisters a previously registered tool handler. Calling this for a tool\n   * that isn't registered is a no-op.\n   *\n   * @param name - The tool name to unregister.\n   */\n  unregister: (name: string) => void;\n\n  /**\n   * Unregisters every tool handler currently registered by your extension.\n   */\n  clear: () => void;\n}"
+    }
+  },
+  "ToolHandler": {
+    "src/surfaces/admin/api/tools/tools.ts": {
+      "filePath": "src/surfaces/admin/api/tools/tools.ts",
+      "name": "ToolHandler",
+      "description": "A handler function invoked by the platform when a registered tool is called. The handler receives an `input` object that matches the tool's declared input JSON schema and must return (synchronously or asynchronously) an object that matches the declared output JSON schema.\n\nGenerated tool typings narrow the `input` and return value of this handler for each registered tool name. This base signature is the generic fallback used before code generation has run, or for tools that aren't yet declared in your extension configuration.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "input",
+          "description": "",
+          "value": "Record<string, any>",
+          "filePath": "src/surfaces/admin/api/tools/tools.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/surfaces/admin/api/tools/tools.ts",
+        "description": "",
+        "name": "Record<string, any> | Promise<Record<string, any>>",
+        "value": "Record<string, any> | Promise<Record<string, any>>"
+      },
+      "value": "(\n  input: Record<string, any>,\n) => Record<string, any> | Promise<Record<string, any>>"
+    }
+  },
   "FormExtensionComponents": {
     "src/surfaces/admin/components/FormExtensionComponents.ts": {
       "filePath": "src/surfaces/admin/components/FormExtensionComponents.ts",
@@ -10904,7 +11066,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2750",
+          "name": "__@abortController@2785",
           "value": "AbortController",
           "description": "",
           "isPrivate": true
@@ -10912,7 +11074,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2744",
+          "name": "__@dialog@2779",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true
@@ -10920,7 +11082,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2746",
+          "name": "__@focusedElement@2781",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -10928,7 +11090,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2748",
+          "name": "__@nestedModals@2783",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true
@@ -10936,7 +11098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2752",
+          "name": "__@childrenRerenderObserver@2787",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -10944,7 +11106,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2753",
+          "name": "__@shadowDomRerenderObserver@2788",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -10952,7 +11114,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2747",
+          "name": "__@onEscape@2782",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true
@@ -10960,7 +11122,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2749",
+          "name": "__@onBackdropClick@2784",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true
@@ -10968,7 +11130,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2751",
+          "name": "__@onChildModalChange@2786",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true
@@ -10976,7 +11138,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2743",
+          "name": "__@isOpen@2778",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -10984,7 +11146,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2745",
+          "name": "__@dismiss@2780",
           "value": "() => void",
           "description": "",
           "isPrivate": true
@@ -10992,7 +11154,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2740",
+          "name": "__@hasOpenChildModal@2775",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -11000,7 +11162,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2741",
+          "name": "__@show@2776",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -11008,7 +11170,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2742",
+          "name": "__@hide@2777",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -11016,7 +11178,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -11024,7 +11186,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -11032,7 +11194,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -13374,33 +13536,6 @@
           "description": "Products sorted by search relevance based on query terms. Use this when the collection is filtered by search."
         }
       ]
-    }
-  },
-  "IntentQueryOptions": {
-    "src/surfaces/admin/api/intents/intents.ts": {
-      "filePath": "src/surfaces/admin/api/intents/intents.ts",
-      "name": "IntentQueryOptions",
-      "description": "Additional parameters for intent invocation when using the string query format. Use these options to provide resource IDs for editing or pass required context data for resource creation.",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/admin/api/intents/intents.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "data",
-          "value": "{ [key: string]: unknown; }",
-          "description": "Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/admin/api/intents/intents.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string",
-          "description": "The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.",
-          "isOptional": true
-        }
-      ],
-      "value": "export interface IntentQueryOptions {\n  /**\n   * The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.\n   */\n  value?: string;\n  /**\n   * Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.\n   */\n  data?: {[key: string]: unknown};\n}"
     }
   },
   "IntentQuery": {
@@ -19642,7 +19777,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -19650,7 +19785,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -19658,7 +19793,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
@@ -182,6 +182,20 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
+          "name": "admin.abandoned-checkout-index.action.render",
+          "value": "RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >",
+          "description": "An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin.abandoned-checkout-index.action.should-render",
+          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >",
+          "description": "A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data."
+        },
+        {
+          "filePath": "src/surfaces/admin/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
           "name": "admin.app.home.render",
           "value": "RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >",
           "description": "Renders an admin extension on the app home page."
@@ -720,7 +734,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2631,7 +2645,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -2976,7 +2990,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2374",
+          "name": "__@internals$3@2409",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3658,7 +3672,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3761,7 +3775,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2475",
+          "name": "__@internals$2@2510",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4020,7 +4034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4182,7 +4196,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2519",
+          "name": "__@dirtyStateSymbol@2554",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -4190,7 +4204,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2518",
+          "name": "__@internals$1@2553",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4357,7 +4371,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2554",
+          "name": "__@setFiles@2589",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true
@@ -4365,7 +4379,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2556",
+          "name": "__@getFileInput@2591",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true
@@ -4373,7 +4387,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2555",
+          "name": "__@internals@2590",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4683,7 +4697,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6101,7 +6115,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -6109,7 +6123,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -6117,7 +6131,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -6328,7 +6342,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6579,7 +6593,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7170,7 +7184,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7474,7 +7488,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7722,7 +7736,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@2969",
+          "name": "__@usedFirstOptionSymbol@3004",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true
@@ -7730,7 +7744,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@2970",
+          "name": "__@hasInitialValueSymbol@3005",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -7760,7 +7774,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8324,7 +8338,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8439,7 +8453,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@3045",
+          "name": "__@actualTableVariantSymbol@3080",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true
@@ -8447,7 +8461,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@3046",
+          "name": "__@tableHeadersSharedDataSymbol@3081",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true
@@ -8657,7 +8671,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@3068",
+          "name": "__@headerFormatSymbol@3103",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true
@@ -9237,7 +9251,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9480,7 +9494,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9637,7 +9651,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -9645,7 +9659,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -9653,7 +9667,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -9947,7 +9961,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2321",
+          "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -10493,8 +10507,8 @@
           "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
           "syntaxKind": "PropertySignature",
           "name": "intents",
-          "value": "Intents",
-          "description": "Provides information to the receiver of an intent. Use this to access data passed from other extensions or parts of the admin when your extension is launched through intent-based navigation."
+          "value": "AppHomeIntents",
+          "description": "Receives [link intents](/docs/apps/build/sidekick/build-app-data) dispatched to the app home target and resolves them when complete. Subscribe to `intents.request` to be notified each time the admin navigates the merchant to your app via a link intent, and call `intents.response.ok()` / `error()` / `closed()` to resolve the active intent.\n\nWhen you run `dev`, the CLI generates typed variants for every intent declared in `shopify.extension.toml`. Use the `WithGeneratedIntents` helper type to narrow `request.value` and `response.ok` to the generated payloads in your app code."
         },
         {
           "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
@@ -10523,9 +10537,16 @@
           "name": "toast",
           "value": "ToastApi",
           "description": "Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "tools",
+          "value": "Tools",
+          "description": "Registers runtime handlers for app tools declared in your extension configuration. Use this to expose app data lookups and app actions to [Sidekick](/docs/apps/build/sidekick/build-app-data), including link intents that drive the navigate modality from the app home target.\n\nWhen you run `dev`, the CLI generates typed `register` overloads for every tool declared in `shopify.extension.toml`. Use the `WithGeneratedTools` helper type to narrow this property to the generated overloads in your app code."
         }
       ],
-      "value": "export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardApi<ExtensionTarget> {\n  /**\n   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.\n   */\n  toast: ToastApi;\n\n  /**\n   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.\n   */\n  app: AppApi;\n\n  /**\n   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.\n   */\n  loading: LoadingApi;\n}"
+      "value": "export interface AppHomeApi<ExtensionTarget extends AnyExtensionTarget>\n  extends StandardApi<ExtensionTarget> {\n  /**\n   * Displays brief, non-blocking notification messages at the bottom of the page. Use the Toast API to confirm successful actions, report errors, or provide contextual feedback without interrupting the merchant's workflow.\n   */\n  toast: ToastApi;\n\n  /**\n   * Provides access to app-level data and functionality. Use this API to query information about extensions registered for the current app, including their activation status and target information.\n   */\n  app: AppApi;\n\n  /**\n   * Sets the Admin page-level loading indicator. Call `loading(true)` to show the loading indicator while your app home extension performs an asynchronous task. Call `loading(false)`, or call `loading()` without an argument, to hide it when the task completes.\n   */\n  loading: LoadingApi;\n\n  /**\n   * Receives [link intents](/docs/apps/build/sidekick/build-app-data) dispatched to the app home target and resolves them when complete. Subscribe to `intents.request` to be notified each time the admin navigates the merchant to your app via a link intent, and call `intents.response.ok()` / `error()` / `closed()` to resolve the active intent.\n   *\n   * When you run `dev`, the CLI generates typed variants for every intent declared in `shopify.extension.toml`. Use the `WithGeneratedIntents` helper type to narrow `request.value` and `response.ok` to the generated payloads in your app code.\n   */\n  intents: AppHomeIntents;\n\n  /**\n   * Registers runtime handlers for app tools declared in your extension configuration. Use this to expose app data lookups and app actions to [Sidekick](/docs/apps/build/sidekick/build-app-data), including link intents that drive the navigate modality from the app home target.\n   *\n   * When you run `dev`, the CLI generates typed `register` overloads for every tool declared in `shopify.extension.toml`. Use the `WithGeneratedTools` helper type to narrow this property to the generated overloads in your app code.\n   */\n  tools: Tools;\n}"
     }
   },
   "AppApi": {
@@ -10717,6 +10738,92 @@
       "isPublicDocs": true
     }
   },
+  "AppHomeIntents": {
+    "src/surfaces/admin/api/app-home/app-home.ts": {
+      "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+      "name": "AppHomeIntents",
+      "description": "The intents API available to app home extensions. It exposes a signal-like `request` that streams link intents into the long-running extension. Inspect `request.value` for information about the active intent.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "invoke",
+          "value": "IntentInvokeApi",
+          "description": "Launches an intent workflow for creating or editing Shopify resources.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "request",
+          "value": "AppHomeIntentRequest",
+          "description": "The current link intent delivered to the extension. Subscribe to receive new intents over the lifetime of the extension."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "response",
+          "value": "IntentResponseApi",
+          "description": "Resolves the current intent. Available only while `request.value` is non-null; the runtime swaps in a fresh handle for each new intent.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AppHomeIntents {\n  /**\n   * The current link intent delivered to the extension. Subscribe to receive\n   * new intents over the lifetime of the extension.\n   */\n  request: AppHomeIntentRequest;\n  /**\n   * Resolves the current intent. Available only while `request.value` is\n   * non-null; the runtime swaps in a fresh handle for each new intent.\n   */\n  response?: IntentResponseApi;\n  /**\n   * Launches an intent workflow for creating or editing Shopify resources.\n   */\n  invoke?: IntentInvokeApi;\n}"
+    }
+  },
+  "AppHomeIntentRequest": {
+    "src/surfaces/admin/api/app-home/app-home.ts": {
+      "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+      "name": "AppHomeIntentRequest",
+      "description": "The current link intent delivered to an app home extension. The admin pushes a new value into `request` whenever a link intent is dispatched to your app, and resets it to `null` when no intent is active.\n\nThe shape is signal-like (`value` + `subscribe`) so the running extension can observe a stream of intents over its lifetime, mirroring the behaviour the CLI's generated typings already expect via `WithGeneratedIntents`.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subscribe",
+          "value": "(callback: (value: IntentQueryOptions) => void) => () => void",
+          "description": "Subscribes to changes in the active intent. The callback is invoked with the new value whenever the admin dispatches a new intent or clears it. Returns a function that unsubscribes the callback."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/app-home/app-home.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "IntentQueryOptions | null",
+          "description": "The intent that's currently being delivered to the extension, or `null` when no intent is active."
+        }
+      ],
+      "value": "export interface AppHomeIntentRequest {\n  /**\n   * The intent that's currently being delivered to the extension, or `null`\n   * when no intent is active.\n   */\n  readonly value: IntentQueryOptions | null;\n  /**\n   * Subscribes to changes in the active intent. The callback is invoked with\n   * the new value whenever the admin dispatches a new intent or clears it.\n   * Returns a function that unsubscribes the callback.\n   */\n  subscribe: (\n    callback: (value: IntentQueryOptions | null) => void,\n  ) => () => void;\n}"
+    }
+  },
+  "IntentQueryOptions": {
+    "src/surfaces/admin/api/intents/intents.ts": {
+      "filePath": "src/surfaces/admin/api/intents/intents.ts",
+      "name": "IntentQueryOptions",
+      "description": "Additional parameters for intent invocation when using the string query format. Use these options to provide resource IDs for editing or pass required context data for resource creation.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "{ [key: string]: unknown; }",
+          "description": "Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/admin/api/intents/intents.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface IntentQueryOptions {\n  /**\n   * The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.\n   */\n  value?: string;\n  /**\n   * Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.\n   */\n  data?: {[key: string]: unknown};\n}"
+    }
+  },
   "LoadingApi": {
     "src/surfaces/admin/api/loading/loading.ts": {
       "filePath": "src/surfaces/admin/api/loading/loading.ts",
@@ -10818,6 +10925,61 @@
       "value": "export interface ToastOptions {\n  /**\n   * The duration in milliseconds to display the toast before automatically dismissing. If not specified, a default duration is used.\n   */\n  duration?: number;\n\n  /**\n   * Whether to display the toast as an error notification. Use for error messages or failed operations.\n   * @defaultValue false\n   */\n  isError?: boolean;\n\n  /**\n   * The label for an optional action button displayed in the toast. When provided, an action button appears that the user can click.\n   */\n  action?: string;\n\n  /**\n   * Callback function triggered when the user clicks the action button. Only called if `action` is provided.\n   */\n  onAction?: () => void;\n\n  /**\n   * Callback function triggered when the toast is dismissed, either automatically after the duration expires or manually by the user.\n   */\n  onDismiss?: () => void;\n}"
     }
   },
+  "Tools": {
+    "src/surfaces/admin/api/tools/tools.ts": {
+      "filePath": "src/surfaces/admin/api/tools/tools.ts",
+      "name": "Tools",
+      "description": "The `Tools` object provides methods for registering and removing runtime handlers for app tools declared in your extension configuration. Use this API to expose app data lookups and app actions that [Sidekick](/docs/apps/build/sidekick/build-app-data) can invoke on behalf of merchants.\n\nThe base `register` signature accepts any tool name and a generic handler. When you run `dev`, the CLI generates a typed `register` overload for every tool declared in `shopify.extension.toml`, narrowing both the accepted name and the handler's `input`/return types. Use the `WithGeneratedTools` helper to merge the generated typings into your target's API.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "clear",
+          "value": "() => void",
+          "description": "Unregisters every tool handler currently registered by your extension."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "register",
+          "value": "(name: string, handler: ToolHandler) => () => void",
+          "description": "Registers a tool handler for your app. If a handler with the same name is already registered, it is replaced. Returns a cleanup function that unregisters the handler."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/tools/tools.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "unregister",
+          "value": "(name: string) => void",
+          "description": "Unregisters a previously registered tool handler. Calling this for a tool that isn't registered is a no-op."
+        }
+      ],
+      "value": "export interface Tools {\n  /**\n   * Registers a tool handler for your app. If a handler with the same name is\n   * already registered, it is replaced. Returns a cleanup function that\n   * unregisters the handler.\n   *\n   * @param name - The tool name as declared in your extension configuration.\n   * @param handler - The function invoked when the tool is called.\n   * @returns A function that unregisters the handler when invoked.\n   */\n  register: (name: string, handler: ToolHandler) => () => void;\n\n  /**\n   * Unregisters a previously registered tool handler. Calling this for a tool\n   * that isn't registered is a no-op.\n   *\n   * @param name - The tool name to unregister.\n   */\n  unregister: (name: string) => void;\n\n  /**\n   * Unregisters every tool handler currently registered by your extension.\n   */\n  clear: () => void;\n}"
+    }
+  },
+  "ToolHandler": {
+    "src/surfaces/admin/api/tools/tools.ts": {
+      "filePath": "src/surfaces/admin/api/tools/tools.ts",
+      "name": "ToolHandler",
+      "description": "A handler function invoked by the platform when a registered tool is called. The handler receives an `input` object that matches the tool's declared input JSON schema and must return (synchronously or asynchronously) an object that matches the declared output JSON schema.\n\nGenerated tool typings narrow the `input` and return value of this handler for each registered tool name. This base signature is the generic fallback used before code generation has run, or for tools that aren't yet declared in your extension configuration.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "input",
+          "description": "",
+          "value": "Record<string, any>",
+          "filePath": "src/surfaces/admin/api/tools/tools.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/surfaces/admin/api/tools/tools.ts",
+        "description": "",
+        "name": "Record<string, any> | Promise<Record<string, any>>",
+        "value": "Record<string, any> | Promise<Record<string, any>>"
+      },
+      "value": "(\n  input: Record<string, any>,\n) => Record<string, any> | Promise<Record<string, any>>"
+    }
+  },
   "FormExtensionComponents": {
     "src/surfaces/admin/components/FormExtensionComponents.ts": {
       "filePath": "src/surfaces/admin/components/FormExtensionComponents.ts",
@@ -10904,7 +11066,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2750",
+          "name": "__@abortController@2785",
           "value": "AbortController",
           "description": "",
           "isPrivate": true
@@ -10912,7 +11074,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2744",
+          "name": "__@dialog@2779",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true
@@ -10920,7 +11082,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2746",
+          "name": "__@focusedElement@2781",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -10928,7 +11090,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2748",
+          "name": "__@nestedModals@2783",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true
@@ -10936,7 +11098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2752",
+          "name": "__@childrenRerenderObserver@2787",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -10944,7 +11106,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2753",
+          "name": "__@shadowDomRerenderObserver@2788",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -10952,7 +11114,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2747",
+          "name": "__@onEscape@2782",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true
@@ -10960,7 +11122,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2749",
+          "name": "__@onBackdropClick@2784",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true
@@ -10968,7 +11130,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2751",
+          "name": "__@onChildModalChange@2786",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true
@@ -10976,7 +11138,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2743",
+          "name": "__@isOpen@2778",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -10984,7 +11146,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2745",
+          "name": "__@dismiss@2780",
           "value": "() => void",
           "description": "",
           "isPrivate": true
@@ -10992,7 +11154,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2740",
+          "name": "__@hasOpenChildModal@2775",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -11000,7 +11162,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2741",
+          "name": "__@show@2776",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -11008,7 +11170,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2742",
+          "name": "__@hide@2777",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -11016,7 +11178,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -11024,7 +11186,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -11032,7 +11194,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -13374,33 +13536,6 @@
           "description": "Products sorted by search relevance based on query terms. Use this when the collection is filtered by search."
         }
       ]
-    }
-  },
-  "IntentQueryOptions": {
-    "src/surfaces/admin/api/intents/intents.ts": {
-      "filePath": "src/surfaces/admin/api/intents/intents.ts",
-      "name": "IntentQueryOptions",
-      "description": "Additional parameters for intent invocation when using the string query format. Use these options to provide resource IDs for editing or pass required context data for resource creation.",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/admin/api/intents/intents.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "data",
-          "value": "{ [key: string]: unknown; }",
-          "description": "Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/admin/api/intents/intents.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string",
-          "description": "The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.",
-          "isOptional": true
-        }
-      ],
-      "value": "export interface IntentQueryOptions {\n  /**\n   * The resource identifier for edit operations (for example, `'gid://shopify/Product/123'`). Required when editing existing resources. Omit this for create operations.\n   */\n  value?: string;\n  /**\n   * Additional context data required by specific intent types. For example, discount creation requires a discount type, variant creation requires a parent product ID, and [metaobject](/docs/apps/build/custom-data/metaobjects) creation requires a definition type.\n   */\n  data?: {[key: string]: unknown};\n}"
     }
   },
   "IntentQuery": {
@@ -19642,7 +19777,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2690",
+          "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -19650,7 +19785,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2691",
+          "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -19658,7 +19793,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2692",
+          "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
           "isPrivate": true


### PR DESCRIPTION
Forward-port of #4495

## Summary
- Forward-port the Admin UI extension generated docs update to `2026-07-rc`.
- Regenerate Admin extension, App Home, and App Home UI extension docs for `2026-07-rc`.
- Confirm generated docs use relative `/docs/...` links instead of absolute `https://shopify.dev/...` links.

## Verification
- `yarn install --frozen-lockfile`
- `yarn docs:admin 2026-07-rc`
- `yarn build`
- `yarn type-check`
- `yarn test`
- `python3` check confirmed zero `https://shopify.dev` links in generated Admin docs v2 JSON files

## Known issue
- `yarn lint` fails on unchanged package entry files:
  - `packages/ui-extensions/checkout/preact.js`
  - `packages/ui-extensions/customer-account/preact.js`
