### PR TITLE
[File Picker Intent] add File picker intent type and action to public Intents API types

### DIFF
--- a/.changeset/admin-pick-file-intent.md
+++ b/.changeset/admin-pick-file-intent.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-tester': patch
+---
+
+Add `pick` action and `shopify/File` resource type to the admin Intents API, enabling extensions to open the file picker via `intents.invoke('pick:shopify/File', …)`.

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
@@ -84,10 +84,10 @@ export interface IntentResponseApi {
 }
 
 /**
- * The type of operation to perform: creating a new resource or editing an existing one.
+ * The type of operation to perform: creating a new resource, editing an existing one, or picking existing resources.
  * @publicDocs
  */
-export type IntentAction = 'create' | 'edit';
+export type IntentAction = 'create' | 'edit' | 'pick';
 
 /**
  * The types of Shopify resources that support intent-based creation and editing workflows.
@@ -99,6 +99,7 @@ export type IntentType =
   | 'shopify/Collection'
   | 'shopify/Customer'
   | 'shopify/Discount'
+  | 'shopify/File'
   | 'shopify/Location'
   | 'shopify/Market'
   | 'shopify/Menu'
@@ -140,7 +141,7 @@ export interface IntentQuery extends IntentQueryOptions {
 }
 
 /**
- * The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating or editing resources, such as products, customers, or discounts. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created or updated resource data.
+ * The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating, editing, or picking resources, such as products, customers, or files. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created, updated, or selected resource data.
  *
  * @param intent - Either a string query (for example, `'create:shopify/Product'`) or structured object describing the intent
  * @param options - Optional parameters when using string query format, such as resource IDs for editing or additional context data
@@ -161,6 +162,13 @@ export interface IntentQuery extends IntentQueryOptions {
  *   data: { type: 'amount-off-product' }
  * });
  * const response = await activity.complete;
+ *
+ * // Pick files from the merchant's media library
+ * const activity = await intents.invoke('pick:shopify/File', {
+ *   data: { mediaTypes: ['MediaImage'], multiSelect: true }
+ * });
+ * const response = await activity.complete;
+ * // response.data.ids contains the selected file GIDs
  * ```
  * @publicDocs
  */

--- a/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/intents/intents.ts
@@ -163,7 +163,7 @@ export interface IntentQuery extends IntentQueryOptions {
  * });
  * const response = await activity.complete;
  *
- * // Pick files from the merchant's media library
+ * // Pick files from the store
  * const activity = await intents.invoke('pick:shopify/File', {
  *   data: { mediaTypes: ['MediaImage'], multiSelect: true }
  * });


### PR DESCRIPTION
## Summary
Add public documentation for the new `pick:shopify/File` admin intent (File Picker Intent) to the UI Extensions Intents API types.

## Changes
- Extend `IntentAction` type to include `'pick'` action
- Extend `IntentType` union to include `'shopify/File'` resource
- Update `IntentInvokeApi` JSDoc to document file-picking workflows alongside create/edit patterns
- Add `@example` showing file picker invocation with `mediaTypes` and `multiSelect` options, demonstrating the `.ids` response
- Add changeset bumping `@shopify/ui-extensions` and `@shopify/ui-extensions-tester` as patch

## Testing
- From the repo root: `yarn install`
- Type-check the admin surface — `IntentAction` now includes `'pick'` and `IntentType` includes `'shopify/File'`; existing `create`/`edit` usages are unaffected
- (Optional) Regenerate admin docs to confirm the type lands: `yarn docs:admin 2026-07-rc`, then `grep -c "shopify/File" packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json`. This also pulls in unrelated drift, so it is not committed here (see "Generated files").

## Generated files
Generated documentation JSON (`docs/surfaces/admin/generated/...`) is **intentionally excluded** from this PR. Regenerating it via `yarn docs:admin 2026-07-rc` currently also sweeps in unrelated drift (new extension targets + non-deterministic TypeScript internal-symbol churn) because the committed artifacts are already behind current source. The generated JSON and shopify.dev sync are handled by the normal docs pipeline / the shopify.dev PR.

## Related PRs
- App Bridge types: Shopify/extensibility#1434
- shopify.dev docs: shop/world#805918
- admin-web registration: shop/world#740113

## Context
Part of File Picker Intent epic: shop/issues-workflows#1518 (docs sub-issue #1503).
