### PR TITLE
Expose POS background scanner sources and scan events

### DIFF
--- a/.changeset/pos-background-scanner-data.md
+++ b/.changeset/pos-background-scanner-data.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-tester': patch
+---
+
+Expose read-only POS scanner data and scanner sources on the `pos.app.ready.data` target.

--- a/.changeset/pos-background-scanner-data.md
+++ b/.changeset/pos-background-scanner-data.md
@@ -3,4 +3,4 @@
 '@shopify/ui-extensions-tester': patch
 ---
 
-Expose read-only POS scanner data and scanner sources on the `pos.app.ready.data` target.
+Expose POS scanner sources and scan events on the `pos.app.ready.data` target. Scanner sources are read-only state available through `shopify.scanner.sources`, while scans are delivered as discrete `scan` events via `shopify.addEventListener('scan', ...)`.

--- a/packages/ui-extensions-tester/src/point-of-sale/factories.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/factories.ts
@@ -495,6 +495,17 @@ function createDataTargetMock<T extends ExtensionTarget>(
         hasNextPage: false,
       }),
     },
+    scanner: {
+      scannerData: {
+        current: createReadonlySignalLike({
+          data: undefined,
+          source: undefined,
+        }),
+      },
+      sources: {
+        current: createReadonlySignalLike<ScannerSource[]>([]),
+      },
+    },
     ...createMockCartApi(),
   };
 }

--- a/packages/ui-extensions-tester/src/point-of-sale/factories.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/factories.ts
@@ -496,12 +496,6 @@ function createDataTargetMock<T extends ExtensionTarget>(
       }),
     },
     scanner: {
-      scannerData: {
-        current: createReadonlySignalLike({
-          data: undefined,
-          source: undefined,
-        }),
-      },
       sources: {
         current: createReadonlySignalLike<ScannerSource[]>([]),
       },

--- a/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
+++ b/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
@@ -57,6 +57,20 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     expect(typeof shopify.removeEventListener).toBe('function');
   });
 
+  it('exposes read-only scanner data on the shopify global', () => {
+    const extension = setUpExt();
+
+    expect(
+      extension.shopify.scanner.scannerData.current.value.data,
+    ).toBeUndefined();
+    expect(
+      extension.shopify.scanner.scannerData.current.value.source,
+    ).toBeUndefined();
+    expect(extension.shopify.scanner.sources.current.value).toHaveLength(0);
+    expect('showCameraScanner' in extension.shopify.scanner).toBe(false);
+    expect('hideCameraScanner' in extension.shopify.scanner).toBe(false);
+  });
+
   it('dispatches a registered listener with the provided event payload', () => {
     const extension = setUpExt();
     const shopify = (globalThis as any).shopify;

--- a/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
+++ b/packages/ui-extensions-tester/src/tests/shopify-events.test.ts
@@ -1,5 +1,6 @@
 import type {
   CashTrackingSessionStartEvent,
+  ScanEvent,
   TransactionCompleteEvent,
 } from '@shopify/ui-extensions/point-of-sale';
 
@@ -30,6 +31,13 @@ function makeCashTrackingSessionStartEvent(): CashTrackingSessionStartEvent {
   });
 }
 
+function makeScanEvent(): ScanEvent {
+  return Object.assign(new Event('scan'), {
+    data: '012345678905',
+    source: 'external' as const,
+  });
+}
+
 describe('shopify.addEventListener / extension.dispatch', () => {
   let sandbox: TestSandbox;
 
@@ -57,18 +65,26 @@ describe('shopify.addEventListener / extension.dispatch', () => {
     expect(typeof shopify.removeEventListener).toBe('function');
   });
 
-  it('exposes read-only scanner data on the shopify global', () => {
+  it('exposes read-only scanner sources on the shopify global', () => {
     const extension = setUpExt();
 
-    expect(
-      extension.shopify.scanner.scannerData.current.value.data,
-    ).toBeUndefined();
-    expect(
-      extension.shopify.scanner.scannerData.current.value.source,
-    ).toBeUndefined();
     expect(extension.shopify.scanner.sources.current.value).toHaveLength(0);
+    expect('scannerData' in extension.shopify.scanner).toBe(false);
     expect('showCameraScanner' in extension.shopify.scanner).toBe(false);
     expect('hideCameraScanner' in extension.shopify.scanner).toBe(false);
+  });
+
+  it('dispatches scan events to registered listeners', () => {
+    const extension = setUpExt();
+    const shopify = (globalThis as any).shopify;
+    const listener = jest.fn();
+    shopify.addEventListener('scan', listener);
+
+    const event = makeScanEvent();
+    extension.dispatch('scan', event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
   });
 
   it('dispatches a registered listener with the provided event payload', () => {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -25,6 +25,7 @@ export type {
   TransactionCompleteEvent,
   CashTrackingSessionStartEvent,
   CashTrackingSessionCompleteEvent,
+  ScanEvent,
   ShopifyEventMap,
 } from './events';
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -76,6 +76,10 @@ export type {
 export type {
   ScannerSource,
   ScannerSubscriptionResult,
+  ScannerSources,
+  ScannerData,
+  ReadonlyScannerApi,
+  ReadonlyScannerApiContent,
   ScannerApi,
   ScannerApiContent,
 } from './api/scanner-api/scanner-api';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/data-target-api/data-target-api.ts
@@ -4,6 +4,7 @@ import {DeviceApi} from '../device-api/device-api';
 import {ExtensionApi} from '../extension-api/extension-api';
 import {LocaleApi} from '../locale-api/locale-api';
 import {ProductSearchApi} from '../product-search-api/product-search-api';
+import {ReadonlyScannerApi} from '../scanner-api/scanner-api';
 import {SessionApi} from '../session-api/session-api';
 import {StorageApi} from '../storage-api/storage-api';
 import type {I18n} from '../../../../api';
@@ -25,4 +26,5 @@ export type DataTargetApi<T> = {
   ConnectivityApi &
   DeviceApi &
   ProductSearchApi &
-  ReadonlyCartApi;
+  ReadonlyCartApi &
+  ReadonlyScannerApi;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -42,16 +42,16 @@ export interface ScannerSources {
  */
 export interface ScannerData {
   /**
-   * Current available scanner sources with subscription support. The `value` property provides current sources, and `subscribe` listens for changes. Use to monitor which scanners are available.
+   * Current scanner data with subscription support. The `value` property provides current scan data, and `subscribe` listens for changes. Use to receive scanner events.
    */
   current: ReadonlySignalLike<ScannerSubscriptionResult>;
 }
 
 /**
- * The `ScannerApi` object provides scan results and scanner controls.
+ * The readonly scanner API provides scan results and scanner source information.
  * @publicDocs
  */
-export interface ScannerApiContent {
+export interface ReadonlyScannerApiContent {
   /**
    * Access current scan data and subscribe to new scan events. Use to receive real-time scan results.
    */
@@ -60,6 +60,13 @@ export interface ScannerApiContent {
    * Access available scanner sources on the device. Use to check which scanners are available (camera, external, or embedded).
    */
   sources: ScannerSources;
+}
+
+/**
+ * The `ScannerApi` object provides scan results and scanner controls.
+ * @publicDocs
+ */
+export interface ScannerApiContent extends ReadonlyScannerApiContent {
   /**
    * Show the camera scanner.
    */
@@ -68,6 +75,14 @@ export interface ScannerApiContent {
    * Hide the camera scanner.
    */
   hideCameraScanner: () => void;
+}
+
+/**
+ * The readonly scanner API provides access to scanner data and scanner source information. Access these properties through `shopify.scanner` to monitor scan events and available scanner sources.
+ * @publicDocs
+ */
+export interface ReadonlyScannerApi {
+  scanner: ReadonlyScannerApiContent;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -48,14 +48,10 @@ export interface ScannerData {
 }
 
 /**
- * The readonly scanner API provides scan results and scanner source information.
+ * The readonly scanner API provides scanner source information. Scan events are delivered separately through `shopify.addEventListener('scan', ...)`.
  * @publicDocs
  */
 export interface ReadonlyScannerApiContent {
-  /**
-   * Access current scan data and subscribe to new scan events. Use to receive real-time scan results.
-   */
-  scannerData: ScannerData;
   /**
    * Access available scanner sources on the device. Use to check which scanners are available (camera, external, or embedded).
    */
@@ -68,6 +64,10 @@ export interface ReadonlyScannerApiContent {
  */
 export interface ScannerApiContent extends ReadonlyScannerApiContent {
   /**
+   * Access current scan data and subscribe to new scan events. Use to receive real-time scan results.
+   */
+  scannerData: ScannerData;
+  /**
    * Show the camera scanner.
    */
   showCameraScanner: () => void;
@@ -78,7 +78,7 @@ export interface ScannerApiContent extends ReadonlyScannerApiContent {
 }
 
 /**
- * The readonly scanner API provides access to scanner data and scanner source information. Access these properties through `shopify.scanner` to monitor scan events and available scanner sources.
+ * The readonly scanner API provides access to scanner source information. Access `scanner.sources` through `shopify.scanner` to monitor available scanner sources, and use `shopify.addEventListener('scan', ...)` to receive scan events.
  * @publicDocs
  */
 export interface ReadonlyScannerApi {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/scanner-api/scanner-api.ts
@@ -63,7 +63,7 @@ export interface ReadonlyScannerApiContent {
 }
 
 /**
- * The `ScannerApi` object provides scan results and scanner controls.
+ * The `ScannerApi` object provides scan data, scanner sources, and camera controls.
  * @publicDocs
  */
 export interface ScannerApiContent extends ReadonlyScannerApiContent {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -3,6 +3,7 @@ import type {
   CashTrackingSessionStartEvent,
   CashTrackingSessionCompleteEvent,
 } from './events/cash-tracking-session-events';
+import type {ScanEvent} from './events/scan-event';
 
 /**
  * Canonical event-name constants for POS host events. Prefer these over string
@@ -14,6 +15,7 @@ export const POS_EVENT_NAMES = {
   TRANSACTION_COMPLETE: 'transactioncomplete',
   CASH_TRACKING_SESSION_START: 'cashtrackingsessionstart',
   CASH_TRACKING_SESSION_COMPLETE: 'cashtrackingsessioncomplete',
+  SCAN: 'scan',
 } as const;
 
 /**
@@ -28,10 +30,12 @@ export interface ShopifyEventMap {
   [POS_EVENT_NAMES.TRANSACTION_COMPLETE]: TransactionCompleteEvent;
   [POS_EVENT_NAMES.CASH_TRACKING_SESSION_START]: CashTrackingSessionStartEvent;
   [POS_EVENT_NAMES.CASH_TRACKING_SESSION_COMPLETE]: CashTrackingSessionCompleteEvent;
+  [POS_EVENT_NAMES.SCAN]: ScanEvent;
 }
 
 export type {
   TransactionCompleteEvent,
   CashTrackingSessionStartEvent,
   CashTrackingSessionCompleteEvent,
+  ScanEvent,
 };

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events/scan-event.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events/scan-event.ts
@@ -7,7 +7,7 @@ import type {ScannerSource} from '../api/scanner-api/scanner-api';
  * @example
  * ```ts
  * shopify.addEventListener('scan', (event) => {
- *   console.log(event.data, event.source);
+ *   handleScan(event.data, event.source);
  * });
  * ```
  * @publicDocs

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events/scan-event.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events/scan-event.ts
@@ -1,0 +1,24 @@
+import type {ScannerSource} from '../api/scanner-api/scanner-api';
+
+/**
+ * Dispatched when the POS device captures a scan from any scanner source
+ * (camera, external, or embedded hardware).
+ *
+ * @example
+ * ```ts
+ * shopify.addEventListener('scan', (event) => {
+ *   console.log(event.data, event.source);
+ * });
+ * ```
+ * @publicDocs
+ */
+export interface ScanEvent extends Event {
+  /**
+   * The decoded string captured by the scanner. Contains the scanned barcode, QR code, or other scannable data.
+   */
+  readonly data: string;
+  /**
+   * The scanner source that captured this scan.
+   */
+  readonly source: ScannerSource;
+}


### PR DESCRIPTION
### Background

POS background data extensions need a way to react to scanner input while POS is running, without requiring merchants to open an extension UI first.

The merchant use case is passive scanner awareness from a background target: an associate scans with POS hardware, and the extension can react to that new scan without first opening a modal/action extension UI.

### Design iteration

This PR originally explored exposing a read-only scanner surface on `pos.app.ready.data` with both:

```ts
shopify.scanner.sources.current.value;
shopify.scanner.scannerData.current.subscribe(...);
```

After review discussion, we changed the shape. The feedback was that background data targets should not become a dumping ground for stateful signals when the thing being represented is actually an occurrence. Scan payloads are closer to cart/transaction events than durable state: an extension wants to know that a scan happened now, not read whatever the last scan happened to be.

The final design is therefore:

- Scanner availability remains state: `shopify.scanner.sources`.
- Scan payloads become events: `shopify.addEventListener('scan', ...)`.
- Camera scanner controls remain unavailable on background targets.

### API decision

This PR intentionally splits scanner information into two shapes:

1. Scanner availability is state, so it is exposed as a read-only signal:

```ts
shopify.scanner.sources.current.value;
```

2. Scan payloads are occurrences, so they are delivered as events:

```ts
shopify.addEventListener('scan', event => {
  handleScan(event.data, event.source);
});
```

We should not expose background scan payloads as `shopify.scanner.scannerData.current`. A scan is not durable state like cart contents or scanner availability. Keeping the last scan as a readable signal creates stale "last scanned value" semantics: an extension could read or subscribe after a scan and process an old payload as if it were new. Delivering scan payloads through `shopify.addEventListener('scan', ...)` makes the timing explicit: a scan happened now.

### Solution

- Added `ReadonlyScannerApiContent` / `ReadonlyScannerApi` for background scanner source access.
- Added `ReadonlyScannerApi` to `DataTargetApi`.
- Added `ScanEvent` for `shopify.addEventListener('scan', ...)`.
- Exported scanner source and scan event helper types from the POS API barrel.
- Updated `@shopify/ui-extensions-tester` data target mocks to expose scanner sources without `scannerData` or camera controls.

On `pos.app.ready.data`, developers can use:

```ts
shopify.scanner.sources.current.value;

shopify.addEventListener('scan', event => {
  handleScan(event.data, event.source);
});
```

The background target does not expose:

```ts
shopify.scanner.scannerData;
shopify.scanner.showCameraScanner;
shopify.scanner.hideCameraScanner;
```

Foreground/action scanner targets keep the existing full Scanner API shape for compatibility.

### What this PR does not do

This is the public TypeScript contract and tester support only. Live scan delivery still requires companion runtime work:

- extensibility: expose only scanner sources on `pos.app.ready.data` and route scan payloads through the existing host event listener path.
- POS Mobile: listen for native scanner results while background extensions are enabled and dispatch `scan` events to the background runtime.

### How to test

1. Add the latest snapshot from this PR to an extension `package.json` and install it.
2. Set `api_version = "2026-07"` and target `pos.app.ready.data` in `shopify.extension.toml`.
3. In the background module, read scanner sources with `shopify.scanner.sources.current.value`.
4. Register a scan listener with `shopify.addEventListener('scan', event => handleScan(event.data, event.source))`.
5. Confirm `shopify.scanner.sources` compiles and `shopify.addEventListener('scan', ...)` is typed.
6. Confirm `shopify.scanner.scannerData`, `showCameraScanner`, and `hideCameraScanner` are not available on the background target.

Live runtime scanner delivery requires the companion extensibility runtime and POS Mobile changes.

### Checklist

- [x] I have updated relevant documentation through JSDoc / generated types
- [x] I have added a changeset
