### PR TITLE
Document POS discount allocation API version

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -180,7 +180,7 @@ export interface MutableCartApiContent {
   removeLineItemProperties(uuid: string, keys: string[]): Promise<void>;
 
   /**
-   * Apply a discount to a specific line item using its `UUID`. Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value with improved discount allocation tracking.
+   * Apply a discount to a specific line item using its `UUID`. Specify the discount type (`'Percentage'` or `'FixedAmount'`), title, and amount value with improved discount allocation tracking. `FixedAmount` discounts use per-unit amounts. For example, passing `'5.00'` on a line item with quantity 2 results in a $10.00 total discount.
    *
    * @param uuid the uuid of the line item that should receive a discount
    * @param type the type of discount applied (example: 'Percentage')
@@ -195,7 +195,7 @@ export interface MutableCartApiContent {
   ): Promise<void>;
 
   /**
-   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations with enhanced validation and allocation tracking.
+   * Apply discounts to multiple line items simultaneously. Each input specifies the line item `UUID` and discount details for efficient bulk discount operations with enhanced validation and allocation tracking. `FixedAmount` discounts use per-unit amounts. For example, passing `'5.00'` on a line item with quantity 2 results in a $10.00 total discount.
    *
    * @param lineItemDiscounts a map of discounts to add. They key is the uuid of the line item you want to add the discount to. The value is the discount input.
    */


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-retail/issues/27165.

POS is moving custom fixed-amount line item discounts from ACROSS allocation to EACH allocation for POS UI Extensions API version 2026-07. Extensions on 2026-04 and earlier keep the existing behavior, where POS accepts the total line-item discount amount and converts it automatically.

### Solution

Update the Cart API JSDoc for `setLineItemDiscount` and `bulkSetLineItemDiscounts` to describe the 2026-07 behavior plainly: `FixedAmount` line item discount amounts are per-unit amounts, including the quantity 2 example.

### Developer changelog

I’ll create a developer changelog entry for the version-delta framing: 2026-04 and earlier accepted the total fixed-amount line item discount and converted it automatically; 2026-07 expects a per-unit `FixedAmount` amount. Example: passing `'5.00'` on a line item with quantity 2 results in a $10.00 total discount.

### Generated docs plan

After this merges into `2026-07-rc`, trigger the shop/world POS UI Extensions API regen workflow with `api_version = 2026-07-rc` and use the bot-generated shop/world companion PR as the generated-docs PR.

### 🎩

- Ran `yarn docs:point-of-sale 2026-07-rc` in this repo.
- Used the generated files to preview the 2026-07 Cart API docs locally in `shopify-dev`.
- Confirmed the `FixedAmount` per-unit description appears inline on the `setLineItemDiscount()` and `bulkSetLineItemDiscounts()` method descriptions.
- Also ran:
  - `yarn build`
  - `yarn type-check`

<img width="3248" height="2122" alt="Screenshot 2026-06-09 at 1 13 05 PM" src="https://github.com/user-attachments/assets/9e8f1607-e4b7-4a98-9060-a70f50be9a6c" />

<img width="3248" height="2122" alt="Screenshot 2026-06-09 at 1 13 02 PM" src="https://github.com/user-attachments/assets/7eef8b3f-242d-4c80-8820-61130f710d76" />

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
