### PR TITLE
Expose s-section padding in public types

### DIFF
--- a/.changeset/soft-otters-share.md
+++ b/.changeset/soft-otters-share.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Expose the `padding` prop on the checkout and customer account `s-section` components.

--- a/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
@@ -128609,9 +128609,18 @@
           "value": "string",
           "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
           "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/components/Section.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "The padding applied to all edges of the section.\n\n- `base`: Applies context-appropriate padding. In some contexts this may result in no visible padding.\n- `none`: Removes all padding, allowing child elements to span the full width of the section. Use a Box with `base` padding to restore spacing for individual content areas.",
+          "isOptional": true,
+          "defaultValue": "'base'"
         }
       ],
-      "value": "export interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id'> {\n}"
+      "value": "export interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding'> {\n}"
     }
   },
   "SectionElement": {
@@ -130542,6 +130551,15 @@
         {
           "filePath": "src/surfaces/checkout/components/Section.ts",
           "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "The padding applied to all edges of the section.\n\n- `base`: Applies context-appropriate padding. In some contexts this may result in no visible padding.\n- `none`: Removes all padding, allowing child elements to span the full width of the section. Use a Box with `base` padding to restore spacing for individual content areas.",
+          "isOptional": true,
+          "defaultValue": "'base'"
+        },
+        {
+          "filePath": "src/surfaces/checkout/components/Section.ts",
+          "syntaxKind": "PropertySignature",
           "name": "parentElement",
           "value": "HTMLElement | null",
           "description": "The read-only **`parentElement`** property of Node interface returns the DOM node's parent Element, or `null` if the node either has no parent, or its parent isn't a DOM Element.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/parentElement)"
@@ -130947,6 +130965,15 @@
           "value": "string",
           "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
           "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/components/Section.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "The padding applied to all edges of the section.\n\n- `base`: Applies context-appropriate padding. In some contexts this may result in no visible padding.\n- `none`: Removes all padding, allowing child elements to span the full width of the section. Use a Box with `base` padding to restore spacing for individual content areas.",
+          "isOptional": true,
+          "defaultValue": "'base'"
         }
       ],
       "value": "export interface SectionProps extends SectionElementProps {\n}"

--- a/packages/ui-extensions/docs/surfaces/customer-account/generated/customer_account_ui_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/generated/customer_account_ui_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -14105,7 +14105,7 @@
           "syntaxKind": "PropertySignature",
           "name": "inlineSize",
           "value": "'large' | 'base'",
-          "description": "The inline size of the page\n- `base` corresponds to a set default inline size\n- `large` full width with whitespace",
+          "description": "The inline size of the page.\n\n- `base`: Matches the narrow width used by native pages for simple workflows.\n- `large`: Uses the full width available to the main content area in customer accounts. Recommended for content-heavy pages or desktop-first experiences.",
           "isOptional": true,
           "defaultValue": "'base'"
         },
@@ -15067,7 +15067,7 @@
           "syntaxKind": "PropertySignature",
           "name": "inlineSize",
           "value": "'large' | 'base'",
-          "description": "The inline size of the page\n- `base` corresponds to a set default inline size\n- `large` full width with whitespace",
+          "description": "The inline size of the page.\n\n- `base`: Matches the narrow width used by native pages for simple workflows.\n- `large`: Uses the full width available to the main content area in customer accounts. Recommended for content-heavy pages or desktop-first experiences.",
           "isOptional": true,
           "defaultValue": "'base'"
         },
@@ -23588,6 +23588,15 @@
           "value": "string",
           "description": "A unique identifier for the element. Use this to target the element with CSS, JavaScript, or accessibility attributes. The `id` must be unique within the document.",
           "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/customer-account/components.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "Adjust the padding of all edges.\n\n- `base`: Applies padding that is appropriate for the element. Note that it may result in no padding if this is the right design decision in a particular context.\n- `none`: Removes all padding from the element. This can be useful when elements inside the Section need to span to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base' to bring back the desired padding for the rest of the content.",
+          "isOptional": true,
+          "defaultValue": "'base'"
         }
       ]
     }
@@ -25518,6 +25527,15 @@
           "name": "ownerDocument",
           "value": "Document",
           "description": "The read-only **`ownerDocument`** property of the Node interface returns the top-level document object of the node.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/ownerDocument)"
+        },
+        {
+          "filePath": "src/surfaces/customer-account/components.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "Adjust the padding of all edges.\n\n- `base`: Applies padding that is appropriate for the element. Note that it may result in no padding if this is the right design decision in a particular context.\n- `none`: Removes all padding from the element. This can be useful when elements inside the Section need to span to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base' to bring back the desired padding for the rest of the content.",
+          "isOptional": true,
+          "defaultValue": "'base'"
         },
         {
           "filePath": "src/surfaces/customer-account/components.ts",
@@ -146637,9 +146655,18 @@
           "value": "string",
           "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
           "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/components/Section.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "The padding applied to all edges of the section.\n\n- `base`: Applies context-appropriate padding. In some contexts this may result in no visible padding.\n- `none`: Removes all padding, allowing child elements to span the full width of the section. Use a Box with `base` padding to restore spacing for individual content areas.",
+          "isOptional": true,
+          "defaultValue": "'base'"
         }
       ],
-      "value": "export interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id'> {\n}"
+      "value": "export interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding'> {\n}"
     }
   },
   "SectionElement": {
@@ -148570,6 +148597,15 @@
         {
           "filePath": "src/surfaces/checkout/components/Section.ts",
           "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "The padding applied to all edges of the section.\n\n- `base`: Applies context-appropriate padding. In some contexts this may result in no visible padding.\n- `none`: Removes all padding, allowing child elements to span the full width of the section. Use a Box with `base` padding to restore spacing for individual content areas.",
+          "isOptional": true,
+          "defaultValue": "'base'"
+        },
+        {
+          "filePath": "src/surfaces/checkout/components/Section.ts",
+          "syntaxKind": "PropertySignature",
           "name": "parentElement",
           "value": "HTMLElement | null",
           "description": "The read-only **`parentElement`** property of Node interface returns the DOM node's parent Element, or `null` if the node either has no parent, or its parent isn't a DOM Element.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/parentElement)"
@@ -148975,6 +149011,15 @@
           "value": "string",
           "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
           "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/components/Section.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "padding",
+          "value": "'base' | 'none'",
+          "description": "The padding applied to all edges of the section.\n\n- `base`: Applies context-appropriate padding. In some contexts this may result in no visible padding.\n- `none`: Removes all padding, allowing child elements to span the full width of the section. Use a Box with `base` padding to restore spacing for individual content areas.",
+          "isOptional": true,
+          "defaultValue": "'base'"
         }
       ],
       "value": "export interface SectionProps extends SectionElementProps {\n}"

--- a/packages/ui-extensions/src/surfaces/checkout/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Section.d.ts
@@ -28,7 +28,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends Base
 
 declare const tagName = "s-section";
 /** @publicDocs */
-export interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id'> {
+export interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding'> {
 }
 /** @publicDocs */
 export interface SectionElement extends SectionElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/checkout/components/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/components.d.ts
@@ -4849,7 +4849,7 @@ declare module 'preact' {
 
 declare const tagName$e = "s-section";
 /** @publicDocs */
-interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id'> {
+interface SectionElementProps extends Pick<SectionProps$1, 'accessibilityLabel' | 'heading' | 'id' | 'padding'> {
 }
 /** @publicDocs */
 interface SectionElement extends SectionElementProps, Omit<HTMLElement, 'id'> {

--- a/packages/ui-extensions/src/surfaces/customer-account/components/Section.d.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/components/Section.d.ts
@@ -10,6 +10,19 @@ export interface SectionProps extends IdProps {
    * A title that describes the content of the section.
    */
   heading?: string;
+
+  /**
+   * Adjust the padding of all edges.
+   *
+   * - `base`: Applies padding that is appropriate for the element. Note that it may result in no padding if
+   * this is the right design decision in a particular context.
+   * - `none`: Removes all padding from the element. This can be useful when elements inside the Section need to span
+   * to the edge of the Section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base'
+   * to bring back the desired padding for the rest of the content.
+   *
+   * @default 'base'
+   */
+  padding?: 'base' | 'none';
 }
 
 export interface SectionElementSlots {


### PR DESCRIPTION
## Summary

Part of https://github.com/shop/issues-customer-accounts-and-login/issues/4381
Related to https://github.com/shop/world/pull/821852

Expose the existing checkout and customer account `s-section` `padding` prop in the public `@shopify/ui-extensions` generated type declarations and docs data. The checkout-web and cusotmer-account-web already support `padding="base"` and `padding="none"`, but the public generated `SectionElementProps` omitted the prop.

## 🎩 

1. Go to the code for a checkout or customer account UI extension
2. Update the `@shopify/ui-extensions` package to use the [snapshot](https://github.com/Shopify/ui-extensions/pull/4511#issuecomment-4684042972)
3. Verify that you can see the type of `padding` on `s-section`
4. Verify docs for [checkout](https://pr-821852.shopify-dev.shopify.io/docs/api/checkout-ui-extensions/2026-07-rc/web-components/layout-and-structure/section#sectionelementprops-propertydetail-padding) and [customer accounts](https://pr-821852.shopify-dev.shopify.io/docs/api/checkout-ui-extensions/2026-07-rc/web-components/layout-and-structure/section#sectionelementprops-propertydetail-padding)

Co-authored-by: GPT-5.5 <noreply@openai.com>
Orchestrated-by: ae <noreply@shopify.com>
