### PR TITLE
Add optional discountAllocations field to pos bundle lineItemComponent

### DIFF
--- a/.changeset/bundle-component-discount-allocations.md
+++ b/.changeset/bundle-component-discount-allocations.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added optional `discountAllocations` field to POS bundle `LineItemComponent` so extensions can access the discount amount allocated to each bundle component.

--- a/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -443,6 +443,14 @@
         {
           "filePath": "src/surfaces/point-of-sale/types/cart.ts",
           "syntaxKind": "PropertySignature",
+          "name": "discountAllocations",
+          "value": "DiscountAllocation[]",
+          "description": "An array of discount allocations applied to this component, providing a detailed breakdown of how discounts are distributed across bundle components. Returns `undefined` if no allocations exist.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/point-of-sale/types/cart.ts",
+          "syntaxKind": "PropertySignature",
           "name": "price",
           "value": "number",
           "description": "The price for the custom sale item as currency string. Must be a valid positive amount. Use for non-catalog items and custom pricing.",
@@ -494,7 +502,7 @@
           "isOptional": true
         }
       ],
-      "value": "export interface LineItemComponent {\n  /**\n   * The display name for the custom sale item. Appears on receipts and in cart displays. Should be descriptive and customer-friendly.\n   */\n  title?: string;\n  /**\n   * The quantity of the custom sale item. Must be a positive integer. Use for quantity-based pricing and inventory management.\n   */\n  quantity: number;\n  /**\n   * The price for the custom sale item as currency string. Must be a valid positive amount. Use for non-catalog items and custom pricing.\n   */\n  price?: number;\n  /**\n   * Determines whether the custom sale item is taxable. Set to `true` to apply tax calculations, `false` to exempt from taxes.\n   */\n  taxable: boolean;\n  /**\n   * An array of tax lines applied to this component.\n   */\n  taxLines: TaxLine[];\n  /**\n   * The unique numeric identifier for the product variant this component represents, if applicable.\n   */\n  variantId?: number;\n  /**\n   * The unique numeric identifier for the product this component represents, if applicable.\n   */\n  productId?: number;\n}"
+      "value": "export interface LineItemComponent {\n  /**\n   * The display name for the custom sale item. Appears on receipts and in cart displays. Should be descriptive and customer-friendly.\n   */\n  title?: string;\n  /**\n   * The quantity of the custom sale item. Must be a positive integer. Use for quantity-based pricing and inventory management.\n   */\n  quantity: number;\n  /**\n   * The price for the custom sale item as currency string. Must be a valid positive amount. Use for non-catalog items and custom pricing.\n   */\n  price?: number;\n  /**\n   * Determines whether the custom sale item is taxable. Set to `true` to apply tax calculations, `false` to exempt from taxes.\n   */\n  taxable: boolean;\n  /**\n   * An array of tax lines applied to this component.\n   */\n  taxLines: TaxLine[];\n  /**\n   * An array of discount allocations applied to this component, providing a detailed breakdown of how discounts are distributed across bundle components. Returns `undefined` if no allocations exist.\n   */\n  discountAllocations?: DiscountAllocation[];\n  /**\n   * The unique numeric identifier for the product variant this component represents, if applicable.\n   */\n  variantId?: number;\n  /**\n   * The unique numeric identifier for the product this component represents, if applicable.\n   */\n  productId?: number;\n}"
     }
   },
   "SellingPlan": {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -118,6 +118,8 @@ export type {
 
 export type {TaxLine} from './types/tax-line';
 
+export type {DiscountAllocation} from './types/discount-allocation';
+
 export type {PaymentMethod, Payment} from './types/payment';
 
 export type {MultipleResourceResult} from './types/multiple-resource-result';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -200,6 +200,10 @@ export interface LineItemComponent {
    */
   taxLines: TaxLine[];
   /**
+   * An array of discount allocations applied to this component, providing a detailed breakdown of how discounts are distributed across bundle components. Returns `undefined` if no allocations exist.
+   */
+  discountAllocations?: DiscountAllocation[];
+  /**
    * The unique numeric identifier for the product variant this component represents, if applicable.
    */
   variantId?: number;


### PR DESCRIPTION
 ## TLDR                                                                                                                            
   - Add optional `discountAllocations` to POS bundle `LineItemComponent`                                                             
   - Export the POS `DiscountAllocation` type for extension authors                                                                   
   - Regenerate `2026-07-rc` POS API docs and add a changeset                                                                         
                                                                                                                                      
## Why                                                                                                                             
 POS UI Extensions expose bundle component tax lines, but not bundle component discount allocations. This blocks compliance partners from reconstructing correct component-level tax splits for discounted bundles with mixed tax rates and tax-inclusive pricing. 
See https://github.com/shop/issues-retail/issues/21806.  