### PR TITLE
Regenerate admin docs JSON for 2026-07-rc

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -962,7 +962,7 @@
     "src/surfaces/admin/api/intents/intents.ts": {
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "name": "IntentInvokeApi",
-      "description": "The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating or editing resources, such as products, customers, or discounts. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created or updated resource data.",
+      "description": "The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating, editing, or picking resources, such as products, customers, or files. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created, updated, or selected resource data.",
       "isPublicDocs": true,
       "members": [],
       "value": "export interface IntentInvokeApi {\n  (query: IntentQuery): Promise<IntentActivity>;\n  (intentURL: string, options?: IntentQueryOptions): Promise<IntentActivity>;\n}"
@@ -1506,14 +1506,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "initials",
           "value": "string",
-          "description": "The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials, such as \"JD\" for John Doe."
+          "description": "The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials, such as \"JD\" for John Doe.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The URL or path to the avatar image. When provided, the image takes priority over `initials`. If the image fails to load or loads slowly, `initials` will be rendered as a fallback."
+          "description": "The URL or path to the avatar image. When provided, the image takes priority over `initials`. If the image fails to load or loads slowly, `initials` will be rendered as a fallback.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1521,14 +1523,16 @@
           "name": "size",
           "value": "\"small\" | \"small-200\" | \"base\" | \"large\" | \"large-200\"",
           "description": "The size of the avatar image.\n\n- `small-200`: Extra small avatar, suitable for compact displays or lists with many items.\n- `small`: Small avatar, good for secondary contexts or tight layouts.\n- `base`: Default size that works well in most contexts.\n- `large`: Large avatar for emphasis or when the avatar is a focal point.\n- `large-200`: Extra large avatar for prominent display.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "alt",
           "value": "string",
-          "description": "Alternative text that describes the avatar for accessibility.\n\nProvides a text description of the avatar for users with assistive technology and serves as a fallback when the avatar fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an avatar, it reads this description aloud. When an avatar fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt)."
+          "description": "Alternative text that describes the avatar for accessibility.\n\nProvides a text description of the avatar for users with assistive technology and serves as a fallback when the avatar fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an avatar, it reads this description aloud. When an avatar fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1536,7 +1540,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1544,7 +1549,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1552,7 +1558,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1560,7 +1567,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1568,7 +1576,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1576,7 +1585,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1584,7 +1594,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Avatar extends PreactCustomElement implements AvatarProps {\n  accessor initials: AvatarProps['initials'];\n  accessor src: AvatarProps['src'];\n  accessor size: AvatarProps['size'];\n  accessor alt: AvatarProps['alt'];\n  constructor();\n}"
@@ -1660,14 +1671,16 @@
           "name": "color",
           "value": "\"base\" | \"strong\"",
           "description": "Controls the visual weight and emphasis of the badge.\n\n- `base`: Standard weight with moderate emphasis, suitable for most use cases.\n- `strong`: Increased visual weight for higher emphasis and prominence.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1675,7 +1688,8 @@
           "name": "size",
           "value": "\"base\" | \"large\" | \"large-100\"",
           "description": "The size of the badge.\n\n- `base`: Default size suitable for most badge use cases.\n- `large`: Larger badge for increased visibility and prominence.\n- `large-100`: Extra large badge for maximum visibility in emphasized contexts.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1683,7 +1697,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.\n- `caution`: Advisory notices that need attention.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1691,7 +1706,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1699,7 +1715,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1707,7 +1724,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1715,7 +1733,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1723,7 +1742,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1731,7 +1751,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1739,7 +1760,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Badge extends PreactCustomElement implements BadgeProps {\n  accessor color: BadgeProps['color'];\n  accessor icon: BadgeProps['icon'];\n  accessor size: BadgeProps['size'];\n  accessor tone: BadgeProps['tone'];\n  constructor();\n}"
@@ -1758,7 +1780,8 @@
           "name": "heading",
           "value": "string",
           "description": "The heading text displayed at the top of the banner.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1766,7 +1789,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1774,7 +1798,8 @@
           "name": "hidden",
           "value": "boolean",
           "description": "Controls whether the banner is visible or hidden.\n\nWhen using a controlled component pattern and the banner is `dismissible`, update this property to `true` when the `dismiss` event fires.\n\nYou can hide the banner programmatically by setting this to `true` even if it's not `dismissible`.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1782,7 +1807,8 @@
           "name": "dismissible",
           "value": "boolean",
           "description": "Whether the banner displays a close button that allows users to dismiss it.\n\nWhen the close button is pressed, the `dismiss` event fires, then `hidden` is set to `true`, any animation completes, and the `afterhide` event fires.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1790,7 +1816,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1798,7 +1825,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1806,7 +1834,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1814,7 +1843,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1822,7 +1852,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1830,7 +1861,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1838,7 +1870,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Banner extends PreactCustomElement implements BannerProps {\n  accessor heading: BannerProps['heading'];\n  accessor tone: BannerProps['tone'];\n  accessor hidden: BannerProps['hidden'];\n  accessor dismissible: BannerProps['dismissible'];\n  constructor();\n}"
@@ -1857,7 +1890,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1865,7 +1899,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1873,7 +1908,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1881,7 +1917,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1889,7 +1926,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1897,7 +1935,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1905,7 +1944,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1913,7 +1953,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1921,7 +1962,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1929,7 +1971,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1937,7 +1980,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1945,7 +1989,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1953,7 +1998,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1961,7 +2007,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1969,7 +2016,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1977,7 +2025,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1997,7 +2046,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2005,7 +2055,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2013,7 +2064,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2021,7 +2073,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2029,14 +2082,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2044,7 +2099,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2052,7 +2108,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2060,7 +2117,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2068,7 +2126,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2076,7 +2135,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2084,7 +2144,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2092,7 +2153,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2100,7 +2162,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2108,7 +2171,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Box extends BoxElement implements BoxProps {\n  constructor();\n}"
@@ -2287,14 +2351,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the button is disabled, preventing it from being clicked or receiving focus.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the button, typically positioned before the button text. Use icons to help users quickly identify the button's action or to improve scannability. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the button, typically positioned before the button text. Use icons to help users quickly identify the button's action or to improve scannability. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2302,7 +2368,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether to replace the button content with a loading indicator while a background action is being performed.\n\nThis also disables the button component.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2310,7 +2377,8 @@
           "name": "variant",
           "value": "\"auto\" | \"primary\" | \"secondary\" | \"tertiary\"",
           "description": "The visual appearance of the button component.\n\n- `auto`: The variant is automatically determined by the button component's context.\n- `primary`: High emphasis button for the primary action on the page. Should be used sparingly.\n- `secondary`: Medium emphasis button for secondary actions.\n- `tertiary`: Low emphasis button for less important actions.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2318,7 +2386,8 @@
           "name": "tone",
           "value": "\"critical\" | \"auto\" | \"neutral\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2326,21 +2395,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2348,14 +2420,16 @@
           "name": "type",
           "value": "\"button\" | \"reset\" | \"submit\"",
           "description": "The behavior of the button component.\n\n- `button`: Used to indicate the component acts as a button, meaning it has no default action.\n- `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).\n- `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.\n\nThis property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.",
-          "defaultValue": "'button'"
+          "defaultValue": "'button'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2363,7 +2437,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2371,7 +2446,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2379,7 +2455,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2387,7 +2464,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2395,7 +2473,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2403,7 +2482,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2411,7 +2491,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2419,21 +2500,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Button extends Button_base implements ButtonProps {\n  accessor disabled: ButtonProps['disabled'];\n  accessor icon: ButtonProps['icon'];\n  accessor loading: ButtonProps['loading'];\n  accessor variant: ButtonProps['variant'];\n  accessor tone: ButtonProps['tone'];\n  accessor target: ButtonProps['target'];\n  accessor href: ButtonProps['href'];\n  accessor download: ButtonProps['download'];\n  accessor type: ButtonProps['type'];\n  accessor accessibilityLabel: ButtonProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2462,14 +2546,16 @@
           "name": "gap",
           "value": "\"base\" | \"none\"",
           "description": "The spacing between buttons in the group.\n\n- `base`: Standard spacing that provides clear visual separation between buttons.\n- `none`: No spacing, creating a connected button group.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2477,7 +2563,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2485,7 +2572,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2493,7 +2581,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2501,7 +2590,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2509,7 +2599,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2517,7 +2608,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2525,7 +2617,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ButtonGroup\n  extends PreactCustomElement\n  implements ButtonGroupProps\n{\n  accessor gap: ButtonGroupProps['gap'];\n  accessor accessibilityLabel: ButtonGroupProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2543,7 +2636,8 @@
           "syntaxKind": "GetAccessor",
           "name": "indeterminate",
           "value": "boolean",
-          "description": "Whether the checkbox displays in an indeterminate state (neither checked nor unchecked), typically used to indicate partial selection in hierarchical lists.\n\nThis visual state takes priority over the `checked` prop in appearance only. The form submission value is still determined by the `checked` prop.\n\nIf `indeterminate` has not been explicitly set and hasn't been modified by user interaction, it returns the value of `defaultIndeterminate`."
+          "description": "Whether the checkbox displays in an indeterminate state (neither checked nor unchecked), typically used to indicate partial selection in hierarchical lists.\n\nThis visual state takes priority over the `checked` prop in appearance only. The form submission value is still determined by the `checked` prop.\n\nIf `indeterminate` has not been explicitly set and hasn't been modified by user interaction, it returns the value of `defaultIndeterminate`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2551,7 +2645,8 @@
           "name": "defaultIndeterminate",
           "value": "boolean",
           "description": "The initial indeterminate state for uncontrolled components. Use this when you want the checkbox to start in an indeterminate state but don't need to control it afterward.\n\nThis value applies until `indeterminate` is explicitly set or the user changes the checkbox state by clicking.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2559,14 +2654,16 @@
           "name": "checked",
           "value": "boolean",
           "description": "Whether the control is currently checked. Use this for controlled components where you manage the checked state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the checkbox is checked.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2574,35 +2671,40 @@
           "name": "defaultChecked",
           "value": "boolean",
           "description": "The initial checked state for uncontrolled components. Use this when you want the control to start checked but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2610,7 +2712,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field needs a value. This requirement adds semantic value to the field, but it will not cause an error to appear automatically. If you want to present an error when this field is empty, you can do so with the `error` property.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2618,7 +2721,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2626,21 +2730,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2648,7 +2755,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2656,7 +2764,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2664,7 +2773,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2672,7 +2782,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2680,7 +2791,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2688,7 +2800,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2696,7 +2809,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2704,7 +2818,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Checkbox extends PreactCheckboxElement implements CheckboxProps {\n  get indeterminate(): CheckboxProps['indeterminate'];\n  set indeterminate(indeterminate: CheckboxProps['indeterminate']);\n  accessor defaultIndeterminate: CheckboxProps['defaultIndeterminate'];\n  constructor();\n}"
@@ -2723,14 +2838,16 @@
           "name": "color",
           "value": "ColorKeyword",
           "description": "The color emphasis level that controls visual intensity.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2738,7 +2855,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2746,7 +2864,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2754,7 +2873,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2762,7 +2882,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2770,7 +2891,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2778,7 +2900,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2786,7 +2909,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Chip extends PreactCustomElement implements ChipProps {\n  accessor color: ChipProps['color'];\n  accessor accessibilityLabel: ChipProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2805,7 +2929,8 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2813,21 +2938,24 @@
           "name": "selected",
           "value": "boolean",
           "description": "Whether the option is currently selected. Use this for controlled components where you manage the selection state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2835,7 +2963,8 @@
           "name": "defaultSelected",
           "value": "boolean",
           "description": "The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2843,7 +2972,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2851,7 +2981,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2859,7 +2990,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2867,7 +2999,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2875,7 +3008,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2883,7 +3017,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2891,7 +3026,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Choice extends PreactCustomElement implements ChoiceProps {\n  accessor disabled: ChoiceProps['disabled'];\n  get selected(): boolean;\n  set selected(selected: ChoiceProps['selected']);\n  accessor value: ChoiceProps['value'];\n  accessor accessibilityLabel: ChoiceProps['accessibilityLabel'];\n  accessor defaultSelected: ChoiceProps['defaultSelected'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -2910,28 +3046,32 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction. When `true`, the `disabled` property on any child choices is ignored.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2939,14 +3079,16 @@
           "name": "multiple",
           "value": "boolean",
           "description": "Whether multiple choices can be selected.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2954,14 +3096,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "values",
           "value": "string[]",
-          "description": "An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected."
+          "description": "An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2969,7 +3113,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2977,7 +3122,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2985,7 +3131,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2993,7 +3140,8 @@
           "name": "__@internals$3@2409",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3001,7 +3149,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3009,7 +3158,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3017,7 +3167,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3025,7 +3176,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3033,7 +3185,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ChoiceList extends BaseClass$3 implements ChoiceListProps {\n  accessor disabled: ChoiceListProps['disabled'];\n  accessor name: ChoiceListProps['name'];\n  accessor error: ChoiceListProps['error'];\n  accessor details: ChoiceListProps['details'];\n  accessor multiple: ChoiceListProps['multiple'];\n  accessor label: ChoiceListProps['label'];\n  accessor labelAccessibilityVisibility: ChoiceListProps['labelAccessibilityVisibility'];\n  get values(): ChoiceListProps['values'];\n  set values(values: ChoiceListProps['values']);\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -3051,14 +3204,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You shouldapply disabled styling as needed."
+          "description": "Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You shouldapply disabled styling as needed.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "loading",
           "value": "boolean",
-          "description": "Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction."
+          "description": "Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3066,21 +3221,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3088,7 +3246,8 @@
           "name": "type",
           "value": "\"button\" | \"reset\" | \"submit\"",
           "description": "The behavior of the button component.\n\n- `button`: Used to indicate the component acts as a button, meaning it has no default action.\n- `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).\n- `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.\n\nThis property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.",
-          "defaultValue": "'button'"
+          "defaultValue": "'button'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3096,7 +3255,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3104,7 +3264,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3112,7 +3273,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3120,7 +3282,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3128,7 +3291,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3136,7 +3300,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3144,7 +3309,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3152,7 +3318,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3160,7 +3327,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3168,7 +3336,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3176,7 +3345,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3184,7 +3354,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3192,7 +3363,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3200,7 +3372,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3208,7 +3381,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3216,7 +3390,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3236,7 +3411,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3244,7 +3420,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3252,7 +3429,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3260,7 +3438,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3268,14 +3447,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3283,7 +3464,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3291,7 +3473,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3299,7 +3482,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3307,7 +3491,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3315,7 +3500,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3323,7 +3509,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3331,7 +3518,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3339,7 +3527,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3347,7 +3536,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3355,21 +3545,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Clickable extends Clickable_base implements ClickableProps {\n  accessor disabled: ClickableProps['disabled'];\n  accessor loading: ClickableProps['loading'];\n  accessor target: ClickableProps['target'];\n  accessor href: ClickableProps['href'];\n  accessor download: ClickableProps['download'];\n  accessor type: ClickableProps['type'];\n  constructor();\n}"
@@ -3388,14 +3581,16 @@
           "name": "color",
           "value": "ColorKeyword",
           "description": "The color emphasis level that controls visual intensity.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3403,7 +3598,8 @@
           "name": "removable",
           "value": "boolean",
           "description": "Whether the chip displays a remove button for dismissal. When clicked, the `remove` callback fires.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3411,7 +3607,8 @@
           "name": "hidden",
           "value": "boolean",
           "description": "Whether the chip is hidden from view. When using controlled component pattern with `removable` chips, update this property when the `remove` event fires. For non-removable chips, manually toggle this property to show or hide the chip.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3419,14 +3616,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the chip is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3434,7 +3633,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3442,7 +3642,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3450,7 +3651,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3458,7 +3660,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3466,7 +3669,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3474,7 +3678,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3482,7 +3687,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3490,21 +3696,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class ClickableChip\n  extends ClickableChip_base\n  implements ClickableChipProps\n{\n  accessor color: ClickableChipProps['color'];\n  accessor accessibilityLabel: ClickableChipProps['accessibilityLabel'];\n  accessor removable: ClickableChipProps['removable'];\n  accessor hidden: ClickableChipProps['hidden'];\n  accessor disabled: ClickableChipProps['disabled'];\n  accessor href: ClickableChipProps['href'];\n  constructor();\n}"
@@ -3523,14 +3732,16 @@
           "name": "alpha",
           "value": "boolean",
           "description": "Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format."
+          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3538,7 +3749,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3546,7 +3758,8 @@
           "name": "setInternalValue",
           "value": "(value: string, normalize: boolean) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3554,35 +3767,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\"",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3590,14 +3808,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3605,7 +3825,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3613,7 +3834,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3621,7 +3843,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3629,7 +3852,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3637,7 +3861,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3645,7 +3870,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3653,21 +3879,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3675,7 +3904,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3683,7 +3913,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3691,7 +3922,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3699,7 +3931,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3707,7 +3940,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3715,7 +3949,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3723,7 +3958,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ColorField\n  extends PreactFieldElement<ColorFieldProps['autocomplete']>\n  implements ColorFieldProps\n{\n  accessor alpha: ColorFieldProps['alpha'];\n  get value(): string;\n  set value(value: string);\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n  /** @private */\n  setInternalValue(value: string, normalize: boolean): void;\n}"
@@ -3742,35 +3978,40 @@
           "name": "alpha",
           "value": "boolean",
           "description": "Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format."
+          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "formResetCallback",
           "value": "() => void",
-          "description": "A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`."
+          "description": "A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3778,7 +4019,8 @@
           "name": "__@internals$2@2510",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3786,7 +4028,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3794,7 +4037,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3802,7 +4046,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3810,7 +4055,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3818,7 +4064,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3826,7 +4073,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3834,7 +4082,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ColorPicker extends BaseClass$2 implements ColorPickerProps {\n  accessor alpha: boolean;\n  accessor name: string;\n  accessor defaultValue: string;\n  get value(): string;\n  set value(value: string);\n  /**\n   * A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`.\n   */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -3853,7 +4102,8 @@
           "name": "allow",
           "value": "string",
           "description": "Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `2024-02--2025`: February 2024 through end of 2025\n- `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3861,7 +4111,8 @@
           "name": "disallow",
           "value": "string",
           "description": "Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `--2024-02`: All dates before February 2024\n- `2024-05-09, 2024-05-11`: May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3869,7 +4120,8 @@
           "name": "allowDays",
           "value": "string",
           "description": "Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (only weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3877,21 +4129,24 @@
           "name": "disallowDays",
           "value": "string",
           "description": "Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (no weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "SetAccessor",
           "name": "view",
           "value": "string",
-          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`."
+          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultView",
           "value": "string",
-          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale."
+          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3899,7 +4154,8 @@
           "name": "autocomplete",
           "value": "DateAutocompleteField",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3907,28 +4163,32 @@
           "name": "defaultValue",
           "value": "string",
           "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3936,14 +4196,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3951,7 +4213,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3959,7 +4222,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3967,7 +4231,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3975,7 +4240,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3983,7 +4249,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3991,7 +4258,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3999,7 +4267,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4007,21 +4276,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4029,7 +4301,8 @@
           "name": "value",
           "value": "string",
           "description": "The currently selected date in `YYYY-MM-DD` format. An empty string means no date is selected.",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4037,7 +4310,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4045,7 +4319,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4053,7 +4328,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4061,7 +4337,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4069,7 +4346,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4077,7 +4355,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4085,7 +4364,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DateField\n  extends PreactFieldElement<DateFieldProps['autocomplete']>\n  implements DateFieldProps\n{\n  accessor allow: DateFieldProps['allow'];\n  accessor disallow: DateFieldProps['disallow'];\n  accessor allowDays: DateFieldProps['allowDays'];\n  accessor disallowDays: DateFieldProps['disallowDays'];\n  set view(view: string);\n  get view(): string;\n  accessor defaultView: DateFieldProps['defaultView'];\n  constructor();\n}"
@@ -4113,14 +4393,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultView",
           "value": "string",
-          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale."
+          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "SetAccessor",
           "name": "view",
           "value": "string",
-          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`."
+          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4128,7 +4410,8 @@
           "name": "allow",
           "value": "string",
           "description": "Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `2024-02--2025`: February 2024 through end of 2025\n- `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4136,7 +4419,8 @@
           "name": "disallow",
           "value": "string",
           "description": "Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `--2024-02`: All dates before February 2024\n- `2024-05-09, 2024-05-11`: May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4144,7 +4428,8 @@
           "name": "allowDays",
           "value": "string",
           "description": "Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (only weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4152,7 +4437,8 @@
           "name": "disallowDays",
           "value": "string",
           "description": "Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (no weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4160,7 +4446,8 @@
           "name": "type",
           "value": "\"single\" | \"range\"",
           "description": "The type of date selection allowed.\n\n- `single`: Select a single date\n- `range`: Select a date range",
-          "defaultValue": "\"single\""
+          "defaultValue": "\"single\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4168,14 +4455,16 @@
           "name": "defaultValue",
           "value": "string",
           "description": "The initially selected date(s) when the component first renders. An empty string means no date is initially selected.\n\n- Single date in `YYYY-MM-DD` format when `type` is set to `\"single\"`\n- Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `\"range\"`",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4183,7 +4472,8 @@
           "name": "value",
           "value": "string",
           "description": "The currently selected date(s). An empty string means no date is selected.\n\n- Single date in `YYYY-MM-DD` format when `type` is set to `\"single\"`\n- Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `\"range\"`",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4191,7 +4481,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4199,7 +4490,8 @@
           "name": "__@dirtyStateSymbol@2554",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4207,7 +4499,8 @@
           "name": "__@internals$1@2553",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4215,7 +4508,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4223,7 +4517,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4231,7 +4526,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4239,7 +4535,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4247,7 +4544,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4255,7 +4553,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4263,7 +4562,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DatePicker extends BaseClass$1 implements DatePickerProps {\n  accessor defaultView: string;\n  set view(view: string);\n  get view(): string;\n  accessor allow: DatePickerProps['allow'];\n  accessor disallow: DatePickerProps['disallow'];\n  accessor allowDays: DatePickerProps['allowDays'];\n  accessor disallowDays: DatePickerProps['disallowDays'];\n  accessor type: DatePickerProps['type'];\n  accessor defaultValue: DatePickerProps['defaultValue'];\n  accessor name: DatePickerProps['name'];\n  set value(value: string);\n  get value(): string;\n  /** @private */\n  [dirtyStateSymbol]: boolean;\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -4282,14 +4582,16 @@
           "name": "accept",
           "value": "string",
           "description": "A string representing the types of files that are accepted by the drop zone. This string is a comma-separated list of unique file type specifiers which can be one of the following:\n- A file extension starting with a period (\".\") character (e.g. .jpg, .pdf, .doc)\n- A valid MIME type string with no extensions\n\nIf omitted, all file types are accepted.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or contents of the item. When set, it will be announced to buyers using assistive technologies and will provide them with more context."
+          "description": "A label that describes the purpose or contents of the item. When set, it will be announced to buyers using assistive technologies and will provide them with more context.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4297,21 +4599,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4319,7 +4624,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4327,14 +4633,16 @@
           "name": "multiple",
           "value": "boolean",
           "description": "Whether multiple files can be selected or dropped at once.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4342,7 +4650,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4350,7 +4659,8 @@
           "name": "value",
           "value": "string",
           "description": "This sets the input value for a file type, which cannot be set programatically, so it can only be reset.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4358,7 +4668,8 @@
           "name": "files",
           "value": "File[]",
           "description": "An array of File objects representing the files currently selected by the user.\n\nThis property is read-only and cannot be directly modified. To clear the selected files, set the `value` prop to an empty string or null.",
-          "defaultValue": "[]"
+          "defaultValue": "[]",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4366,7 +4677,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4374,7 +4686,8 @@
           "name": "__@setFiles@2589",
           "value": "(files: File[]) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4382,7 +4695,8 @@
           "name": "__@getFileInput@2591",
           "value": "() => HTMLInputElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4390,7 +4704,8 @@
           "name": "__@internals@2590",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4398,7 +4713,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4406,7 +4722,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4414,7 +4731,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4422,7 +4740,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4430,7 +4749,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4438,7 +4758,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4446,7 +4767,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DropZone extends BaseClass implements DropZoneProps {\n  accessor accept: DropZoneProps['accept'];\n  accessor accessibilityLabel: DropZoneProps['accessibilityLabel'];\n  accessor disabled: DropZoneProps['disabled'];\n  accessor error: DropZoneProps['error'];\n  accessor label: DropZoneProps['label'];\n  accessor labelAccessibilityVisibility: DropZoneProps['labelAccessibilityVisibility'];\n  accessor multiple: DropZoneProps['multiple'];\n  accessor name: DropZoneProps['name'];\n  accessor required: DropZoneProps['required'];\n  get value(): string;\n  /** This sets the input value for a file type, which cannot be set programatically, so it can only be reset. */\n  set value(value: '' | null);\n  get files(): File[];\n  set files(files: File[]);\n  /** @private */\n  [setFiles](files: File[]): void;\n  /** @private */\n  [getFileInput](): ReplaceType<\n    Element | null | undefined,\n    Element,\n    HTMLInputElement\n  >;\n\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -4465,7 +4787,8 @@
           "name": "direction",
           "value": "\"inline\" | \"block\"",
           "description": "The orientation of the divider line, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).\n\n- `inline`: Horizontal divider for separating vertically stacked content\n- `block`: Vertical divider for separating horizontally arranged content",
-          "defaultValue": "'inline'"
+          "defaultValue": "'inline'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4473,7 +4796,8 @@
           "name": "color",
           "value": "\"base\" | \"strong\"",
           "description": "The visual prominence of the divider line.\n\n- `base`: Standard divider for most separations (default)\n- `strong`: More prominent divider for major section breaks",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4481,7 +4805,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4489,7 +4814,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4497,7 +4823,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4505,7 +4832,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4513,7 +4841,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4521,7 +4850,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4529,7 +4859,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Divider extends PreactCustomElement implements DividerProps {\n  accessor direction: DividerProps['direction'];\n  accessor color: DividerProps['color'];\n  constructor();\n}"
@@ -4548,7 +4879,8 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | EmailAutocompleteField | `section-${string} email` | `section-${string} home email` | `section-${string} mobile email` | `section-${string} fax email` | `section-${string} pager email` | \"shipping email\" | \"shipping home email\" | \"shipping mobile email\" | ... 16 more ... | `section-${string} billing p...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4556,7 +4888,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4564,42 +4897,48 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing."
+          "description": "The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4607,14 +4946,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4622,7 +4963,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4630,7 +4972,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4638,7 +4981,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4646,7 +4990,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4654,7 +4999,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4662,7 +5008,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4670,7 +5017,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4678,21 +5026,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4700,7 +5051,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4708,7 +5060,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4716,7 +5069,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4724,7 +5078,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4732,7 +5087,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4740,7 +5096,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4748,7 +5105,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class EmailField\n  extends PreactFieldElement<EmailFieldProps['autocomplete']>\n  implements EmailFieldProps\n{\n  accessor autocomplete: EmailFieldProps['autocomplete'];\n  accessor maxLength: EmailFieldProps['maxLength'];\n  accessor minLength: EmailFieldProps['minLength'];\n  /**\n   * The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -4777,7 +5135,8 @@
           "name": "gridTemplateColumns",
           "value": "string",
           "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4785,7 +5144,8 @@
           "name": "gridTemplateRows",
           "value": "string",
           "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4793,7 +5153,8 @@
           "name": "justifyItems",
           "value": "\"\" | JustifyItemsKeyword",
           "description": "Aligns the grid items along the inline axis.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4801,7 +5162,8 @@
           "name": "alignItems",
           "value": "\"\" | AlignItemsKeyword",
           "description": "Aligns the grid items along the block axis.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4809,7 +5171,8 @@
           "name": "placeItems",
           "value": "AlignItemsKeyword | \"normal normal\" | \"normal stretch\" | \"normal baseline\" | \"normal first baseline\" | \"normal last baseline\" | \"normal start\" | \"normal end\" | ... 188 more ... | \"safe center safe center\"",
           "description": "A shorthand property for `justify-items` and `align-items`.",
-          "defaultValue": "'normal normal'"
+          "defaultValue": "'normal normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4817,7 +5180,8 @@
           "name": "justifyContent",
           "value": "\"\" | JustifyContentKeyword",
           "description": "Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4825,7 +5189,8 @@
           "name": "alignContent",
           "value": "\"\" | AlignContentKeyword",
           "description": "Aligns the grid along the block axis. This overrides the block value of `placeContent`.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4833,7 +5198,8 @@
           "name": "placeContent",
           "value": "\"normal normal\" | \"normal stretch\" | \"normal start\" | \"normal end\" | \"normal center\" | \"normal unsafe start\" | \"normal unsafe end\" | \"normal unsafe center\" | \"normal safe start\" | ... 229 more ... | \"space-evenly space-evenly\"",
           "description": "A shorthand property for `justify-content` and `align-content`.",
-          "defaultValue": "'normal normal'"
+          "defaultValue": "'normal normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4841,7 +5207,8 @@
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
           "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4849,7 +5216,8 @@
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4857,7 +5225,8 @@
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4865,7 +5234,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4873,7 +5243,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4881,7 +5252,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4889,7 +5261,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4897,7 +5270,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4905,7 +5279,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4913,7 +5288,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4921,7 +5297,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4929,7 +5306,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4937,7 +5315,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4945,7 +5324,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4953,7 +5333,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4961,7 +5342,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4969,7 +5351,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4977,7 +5360,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4985,7 +5369,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5005,7 +5390,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5013,7 +5399,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5021,7 +5408,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5029,7 +5417,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5037,14 +5426,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5052,7 +5443,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5060,7 +5452,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5068,7 +5461,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5076,7 +5470,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5084,7 +5479,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5092,7 +5488,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5100,7 +5497,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5108,7 +5506,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5116,7 +5515,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Grid extends BoxElement implements GridProps {\n  constructor();\n  accessor gridTemplateColumns: GridProps['gridTemplateColumns'];\n  accessor gridTemplateRows: GridProps['gridTemplateRows'];\n  accessor justifyItems: GridProps['justifyItems'];\n  accessor alignItems: GridProps['alignItems'];\n  accessor placeItems: GridProps['placeItems'];\n  accessor justifyContent: GridProps['justifyContent'];\n  accessor alignContent: GridProps['alignContent'];\n  accessor placeContent: GridProps['placeContent'];\n  accessor gap: GridProps['gap'];\n  accessor rowGap: GridProps['rowGap'];\n  accessor columnGap: GridProps['columnGap'];\n}"
@@ -5225,7 +5625,8 @@
           "name": "gridColumn",
           "value": "\"auto\" | `span ${number}`",
           "description": "The number of columns the item will span across.\n\nLearn more about the [grid-column property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5233,7 +5634,8 @@
           "name": "gridRow",
           "value": "\"auto\" | `span ${number}`",
           "description": "The number of rows the item will span across.\n\nLearn more about the [grid-row property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5241,7 +5643,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5249,7 +5652,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5257,7 +5661,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5265,7 +5670,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5273,7 +5679,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5281,7 +5688,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5289,7 +5697,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5297,7 +5706,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5305,7 +5715,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5313,7 +5724,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5321,7 +5733,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5329,7 +5742,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5337,7 +5751,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5345,7 +5760,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5353,7 +5769,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5361,7 +5778,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5381,7 +5799,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5389,7 +5808,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5397,7 +5817,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5405,7 +5826,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5413,14 +5835,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5428,7 +5852,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5436,7 +5861,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5444,7 +5870,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5452,7 +5879,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5460,7 +5888,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5468,7 +5897,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5476,7 +5906,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5484,7 +5915,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5492,7 +5924,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class GridItem extends BoxElement implements GridItemProps {\n  accessor gridColumn: GridItemProps['gridColumn'];\n  accessor gridRow: GridItemProps['gridRow'];\n  constructor();\n}"
@@ -5511,7 +5944,8 @@
           "name": "accessibilityRole",
           "value": "\"none\" | \"presentation\" | \"heading\"",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.\n\n- `none`: Completely hides the element and its content from assistive technologies\n- `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.\n- `img`: Identifies the element as an image that conveys meaningful information to users.",
-          "defaultValue": "'heading'"
+          "defaultValue": "'heading'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5519,7 +5953,8 @@
           "name": "lineClamp",
           "value": "number",
           "description": "The maximum number of lines to display before truncating the text content.\n\nLearn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).",
-          "defaultValue": "Infinity - no truncation is applied"
+          "defaultValue": "Infinity - no truncation is applied",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5527,7 +5962,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5535,7 +5971,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5543,7 +5980,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5551,7 +5989,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5559,7 +5998,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5567,7 +6007,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5575,7 +6016,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5583,7 +6025,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Heading extends PreactCustomElement implements HeadingProps {\n  accessor accessibilityRole: HeadingProps['accessibilityRole'];\n  accessor lineClamp: HeadingProps['lineClamp'];\n  accessor accessibilityVisibility: HeadingProps['accessibilityVisibility'];\n  constructor();\n}"
@@ -5602,7 +6045,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5610,14 +6054,16 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.\n- `caution`: Advisory notices that need attention.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "type",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "The icon to display from the icon library.\n\nSet to a valid icon name to display that icon. To hide the icon completely, use an empty string `''`. To reserve the icon's space without displaying an icon, use `'empty'`."
+          "description": "The icon to display from the icon library.\n\nSet to a valid icon name to display that icon. To hide the icon completely, use an empty string `''`. To reserve the icon's space without displaying an icon, use `'empty'`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5625,14 +6071,16 @@
           "name": "size",
           "value": "\"small\" | \"base\"",
           "description": "The size of the icon.\n\n- `small`: Smaller icon suitable for inline use within text or compact UI elements.\n- `base`: Default size that works well for standalone icons and standard use cases.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5640,7 +6088,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5648,7 +6097,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5656,7 +6106,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5664,7 +6115,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5672,7 +6124,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5680,7 +6133,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5688,7 +6142,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Icon extends PreactCustomElement implements IconProps {\n  accessor color: IconProps['color'];\n  accessor tone: IconProps['tone'];\n  accessor type: IconProps['type'];\n  accessor size: IconProps['size'];\n  accessor interestFor: string;\n  constructor();\n}"
@@ -5706,21 +6161,24 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered."
+          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "srcSet",
           "value": "string",
-          "description": "A set of image sources and their width or pixel density descriptors. This overrides the `src` property.\n\nLearn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset)."
+          "description": "A set of image sources and their width or pixel density descriptors. This overrides the `src` property.\n\nLearn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "sizes",
           "value": "string",
-          "description": "A set of media conditions and their corresponding sizes.\n\nLearn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes)."
+          "description": "A set of media conditions and their corresponding sizes.\n\nLearn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5728,7 +6186,8 @@
           "name": "alt",
           "value": "string",
           "description": "Alternative text that describes the image for accessibility.\n\nProvides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
-          "defaultValue": "``"
+          "defaultValue": "``",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5736,7 +6195,8 @@
           "name": "aspectRatio",
           "value": "`${number}` | `${number}/${number}` | `${number}/ ${number}` | `${number} /${number}` | `${number} / ${number}`",
           "description": "The aspect ratio of the image.\n\nThe rendering of the image will depend on the `inlineSize` value:\n\n- `inlineSize=\"fill\"`: the aspect ratio will be respected and the image will take the necessary space.\n- `inlineSize=\"auto\"`: the image will not render until it has loaded and the aspect ratio will be ignored.\n\nFor example, if the value is set as `50 / 100`, the getter returns `50 / 100`. If the value is set as `0.5`, the getter returns `0.5 / 1`.\n\nLearn more about the [aspect-ratio property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).",
-          "defaultValue": "'1/1'"
+          "defaultValue": "'1/1'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5744,7 +6204,8 @@
           "name": "objectFit",
           "value": "\"contain\" | \"cover\"",
           "description": "The image resizing behavior to fit within its container.\n\n- `contain`: Scales the image to fit within the container while maintaining its aspect ratio. The entire image is visible, but might leave empty space.\n- `cover`: Scales the image to fill the entire container while maintaining its aspect ratio. The image might be cropped to fit.\n\nThe image is always positioned in the center of the container.\n\nLearn more about the [object-fit property](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).",
-          "defaultValue": "'contain'"
+          "defaultValue": "'contain'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5752,7 +6213,8 @@
           "name": "loading",
           "value": "\"eager\" | \"lazy\"",
           "description": "The loading strategy for the image.\n\n- `eager`: Immediately loads the image, irrespective of its position within the visible viewport.\n- `lazy`: Delays loading the image until it approaches a specified distance from the viewport.\n\nLearn more about the [loading attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading).",
-          "defaultValue": "'eager'"
+          "defaultValue": "'eager'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5760,7 +6222,8 @@
           "name": "accessibilityRole",
           "value": "\"none\" | \"presentation\" | \"img\"",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.\n\n- `none`: Completely hides the element and its content from assistive technologies\n- `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.\n- `img`: Identifies the element as an image that conveys meaningful information to users.",
-          "defaultValue": "'img'"
+          "defaultValue": "'img'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5768,7 +6231,8 @@
           "name": "inlineSize",
           "value": "\"auto\" | \"fill\"",
           "description": "The displayed inline width of the image.\n\n- `fill`: the image will takes up 100% of the available inline size.\n- `auto`: the image will be displayed at its natural size.\n\nLearn more about the [width attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).",
-          "defaultValue": "'fill'"
+          "defaultValue": "'fill'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5788,7 +6252,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5796,7 +6261,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border around the image. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5804,7 +6270,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border around the image, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5812,7 +6279,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border around the image using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5820,7 +6288,8 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the image's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5828,7 +6297,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5836,7 +6306,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5844,7 +6315,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5852,7 +6324,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5860,7 +6333,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5868,7 +6342,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5876,7 +6351,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Image extends PreactCustomElement implements ImageProps {\n  accessor src: ImageProps['src'];\n  accessor srcSet: ImageProps['srcSet'];\n  accessor sizes: ImageProps['sizes'];\n  accessor alt: ImageProps['alt'];\n  accessor aspectRatio: ImageProps['aspectRatio'];\n  accessor objectFit: ImageProps['objectFit'];\n  accessor loading: ImageProps['loading'];\n  accessor accessibilityRole: ImageProps['accessibilityRole'];\n  accessor inlineSize: ImageProps['inlineSize'];\n  /**\n   * A border applied around the image using shorthand syntax to specify width, color, and style in a single property.\n   */\n  accessor border: ImageProps['border'];\n  /**\n   * The thickness of the border around the image. When set, this overrides the width value specified in the `border` property.\n   */\n  accessor borderWidth: ImageProps['borderWidth'];\n  /**\n   * The visual style of the border around the image, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.\n   */\n  accessor borderStyle: ImageProps['borderStyle'];\n  /**\n   * The color of the border around the image using the design system's color scale. When set, this overrides the color value specified in the `border` property.\n   */\n  accessor borderColor: ImageProps['borderColor'];\n  /**\n   * The roundedness of the image's corners using the design system's radius scale.\n   */\n  accessor borderRadius: ImageProps['borderRadius'];\n  constructor();\n}"
@@ -5895,21 +6371,24 @@
           "name": "tone",
           "value": "\"critical\" | \"auto\" | \"neutral\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5917,21 +6396,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "lang",
           "value": "string",
-          "description": "The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)."
+          "description": "The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5939,7 +6421,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5947,7 +6430,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5955,7 +6439,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5963,7 +6448,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5971,7 +6457,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5979,7 +6466,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5987,7 +6475,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5995,21 +6484,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Link extends Link_base implements LinkProps {\n  accessor tone: LinkProps['tone'];\n  accessor accessibilityLabel: LinkProps['accessibilityLabel'];\n  accessor href: LinkProps['href'];\n  accessor target: LinkProps['target'];\n  accessor download: LinkProps['download'];\n  accessor lang: LinkProps['lang'];\n  constructor();\n}"
@@ -6028,7 +6520,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6036,7 +6529,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6044,7 +6538,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6052,7 +6547,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6060,7 +6556,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6068,7 +6565,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6076,7 +6574,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ListItem extends PreactCustomElement implements ListItemProps {\n  constructor();\n}"
@@ -6094,7 +6593,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6102,7 +6602,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6110,7 +6611,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6118,7 +6620,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6126,7 +6629,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6134,7 +6638,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6142,7 +6647,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6150,7 +6656,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6158,7 +6665,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6166,7 +6674,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6174,7 +6683,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Menu extends PreactOverlayElement implements MenuProps {\n  accessor accessibilityLabel: string;\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -6193,7 +6703,8 @@
           "name": "max",
           "value": "number",
           "description": "The highest decimal or integer value accepted for the field. When used with `step`, the value rounds down to the maximum number.\n\nUsers can still type values higher than the maximum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6201,14 +6712,16 @@
           "name": "min",
           "value": "number",
           "description": "The lowest decimal or integer value accepted for the field. When used with `step`, the value rounds up to the minimum number.\n\nUsers can still type values lower than the minimum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "-Infinity"
+          "defaultValue": "-Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency."
+          "description": "The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6216,35 +6729,40 @@
           "name": "autocomplete",
           "value": "string",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6252,14 +6770,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6267,7 +6787,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6275,7 +6796,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6283,7 +6805,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6291,7 +6814,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6299,7 +6823,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6307,7 +6832,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6315,7 +6841,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6323,21 +6850,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6345,7 +6875,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6353,7 +6884,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6361,7 +6893,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6369,7 +6902,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6377,7 +6911,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6385,7 +6920,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6393,7 +6929,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class MoneyField\n  extends PreactFieldElement<MoneyFieldProps['autocomplete']>\n  implements MoneyFieldProps\n{\n  accessor max: MoneyFieldProps['max'];\n  accessor min: MoneyFieldProps['min'];\n  /**\n   * The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -6411,7 +6948,8 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer)."
+          "description": "The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6419,7 +6957,8 @@
           "name": "inputMode",
           "value": "\"decimal\" | \"numeric\"",
           "description": "The type of virtual keyboard to display on mobile devices.\n\n- `decimal`: Shows a numeric keyboard with a decimal point, suitable for prices or measurements.\n- `numeric`: Shows a numeric keyboard without a decimal point, suitable for whole numbers like quantities.\n\nLearn more about the [inputmode attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).",
-          "defaultValue": "'decimal'"
+          "defaultValue": "'decimal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6427,7 +6966,8 @@
           "name": "step",
           "value": "number",
           "description": "The amount the value can increase or decrease by. This can be an integer or decimal. If a `max` or `min` is specified with `step` when increasing/decreasing the value via the buttons, the final value will always round to the `max` or `min` rather than the closest valid amount.",
-          "defaultValue": "1"
+          "defaultValue": "1",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6435,7 +6975,8 @@
           "name": "max",
           "value": "number",
           "description": "The highest decimal or integer value accepted for the field. When used with `step`, the value rounds down to the maximum number.\n\nUsers can still type values higher than the maximum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6443,7 +6984,8 @@
           "name": "min",
           "value": "number",
           "description": "The lowest decimal or integer value accepted for the field. When used with `step`, the value rounds up to the minimum number.\n\nUsers can still type values lower than the minimum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "-Infinity"
+          "defaultValue": "-Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6451,7 +6993,8 @@
           "name": "prefix",
           "value": "string",
           "description": "A non-editable text value displayed immediately before the editable portion of the field. This is useful for displaying an implied part of the value, such as `https://` or `+353`.\n\nThis text can't be edited by the user and is not included in the field's value. The prefix might not appear until the user interacts with the field. For example, an inline label might occupy the prefix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6459,7 +7002,8 @@
           "name": "suffix",
           "value": "string",
           "description": "A non-editable text value displayed immediately after the editable portion of the field. This is useful for displaying an implied part of the value, such as `@shopify.com` or `%`.\n\nThis text can't be edited by the user and is not included in the field's value. The suffix might not appear until the user interacts with the field. For example, an inline label might occupy the suffix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6467,35 +7011,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | NumberAutocompleteField | `section-${string} one-time-code` | `section-${string} cc-number` | `section-${string} cc-csc` | \"shipping one-time-code\" | \"shipping cc-number\" | \"shipping cc-csc\" | \"billing one-time-code\" | ... 7 more ... | `section-${string} billing cc-csc`",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6503,14 +7052,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6518,7 +7069,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6526,7 +7078,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6534,7 +7087,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6542,7 +7096,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6550,7 +7105,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6558,7 +7114,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6566,7 +7123,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6574,21 +7132,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6596,7 +7157,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6604,7 +7166,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6612,7 +7175,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6620,7 +7184,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6628,7 +7193,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6636,7 +7202,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6644,7 +7211,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class NumberField\n  extends PreactFieldElement<NumberFieldProps['autocomplete']>\n  implements NumberFieldProps\n{\n  /**\n   * The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer).\n   */\n  get value(): string;\n  set value(value: string);\n  accessor inputMode: NumberFieldProps['inputMode'];\n  accessor step: NumberFieldProps['step'];\n  accessor max: NumberFieldProps['max'];\n  accessor min: NumberFieldProps['min'];\n  accessor prefix: NumberFieldProps['prefix'];\n  accessor suffix: NumberFieldProps['suffix'];\n  constructor();\n}"
@@ -6673,7 +7241,8 @@
           "name": "selected",
           "value": "boolean",
           "description": "Whether the option is currently selected. Use this for controlled components where you manage the selection state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6681,14 +7250,16 @@
           "name": "defaultSelected",
           "value": "boolean",
           "description": "The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6696,7 +7267,8 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6704,7 +7276,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6712,7 +7285,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6720,7 +7294,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6728,7 +7303,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6736,7 +7312,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6744,7 +7321,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6752,7 +7330,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Option extends PreactCustomElement implements OptionProps {\n  accessor selected: OptionProps['selected'];\n  accessor defaultSelected: OptionProps['defaultSelected'];\n  accessor value: OptionProps['value'];\n  accessor disabled: OptionProps['disabled'];\n  constructor();\n}"
@@ -6771,14 +7350,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the options within this group can be selected or not.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The user-facing label for this group of options."
+          "description": "The user-facing label for this group of options.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6786,7 +7367,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6794,7 +7376,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6802,7 +7385,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6810,7 +7394,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6818,7 +7403,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6826,7 +7412,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6834,7 +7421,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class OptionGroup\n  extends PreactCustomElement\n  implements OptionGroupProps\n{\n  accessor disabled: OptionGroupProps['disabled'];\n  accessor label: OptionGroupProps['label'];\n  constructor();\n}"
@@ -6853,7 +7441,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6861,7 +7450,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6869,7 +7459,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6877,7 +7468,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6885,7 +7477,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6893,7 +7486,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6901,7 +7495,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class OrderedList\n  extends PreactCustomElement\n  implements OrderedListProps\n{\n  constructor();\n}"
@@ -6920,7 +7515,8 @@
           "name": "fontVariantNumeric",
           "value": "\"auto\" | \"normal\" | \"tabular-nums\"",
           "description": "The rendering style for numbers in the font.\n\n- `auto`: Inherits the setting from the parent element.\n- `normal`: Uses the font's default numeric glyphs.\n- `tabular-nums`: Uses fixed-width numeric glyphs, ensuring numbers align vertically in tables or lists.\n\nLearn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6928,7 +7524,8 @@
           "name": "lineClamp",
           "value": "number",
           "description": "The maximum number of lines to display before truncating the text content.\n\nLearn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).",
-          "defaultValue": "Infinity - no truncation is applied"
+          "defaultValue": "Infinity - no truncation is applied",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6936,7 +7533,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"caution\"",
           "description": "The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.\n\n- `info`: Informational content or helpful tips (blue).\n- `success`: Positive outcomes or successful states (green).\n- `warning`: Important warnings about potential issues (orange).\n- `critical`: Urgent problems or destructive actions (red).\n- `caution`: Advisory notices that need attention (yellow).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6944,7 +7542,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6952,7 +7551,8 @@
           "name": "dir",
           "value": "\"\" | \"auto\" | \"ltr\" | \"rtl\"",
           "description": "Indicates the directionality of the element’s text.\n\n- `\"\"`: The direction is inherited from parent elements (equivalent to not setting the attribute).\n- `auto`: The user agent determines the direction based on the content.\n- `ltr`: The languages written from left to right (such as English).\n- `rtl`: The languages written from right to left (such as Arabic).\n\nLearn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6960,7 +7560,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6968,7 +7569,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6976,7 +7578,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6984,7 +7587,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6992,7 +7596,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7000,7 +7605,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7008,7 +7614,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7016,7 +7623,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Paragraph extends PreactCustomElement implements ParagraphProps {\n  accessor fontVariantNumeric: ParagraphProps['fontVariantNumeric'];\n  accessor lineClamp: ParagraphProps['lineClamp'];\n  /**\n   * The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.\n   *\n   * - `info`: Informational content or helpful tips (blue).\n   * - `success`: Positive outcomes or successful states (green).\n   * - `warning`: Important warnings about potential issues (orange).\n   * - `critical`: Urgent problems or destructive actions (red).\n   * - `caution`: Advisory notices that need attention (yellow).\n   */\n  accessor tone: ParagraphProps['tone'];\n\n  accessor color: ParagraphProps['color'];\n  accessor dir: ParagraphProps['dir'];\n  accessor accessibilityVisibility: ParagraphProps['accessibilityVisibility'];\n  constructor();\n}"
@@ -7035,7 +7643,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7043,14 +7652,16 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security."
+          "description": "The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7058,35 +7669,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | PasswordAutocompleteField | `section-${string} current-password` | `section-${string} new-password` | \"shipping current-password\" | \"shipping new-password\" | \"billing current-password\" | \"billing new-password\" | `section-${string} shipping current-password` | `section-${string} shipping new-password` | `section-${string} billing current-password` | `section-${string} billing new-password`",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7094,14 +7710,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7109,7 +7727,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7117,7 +7736,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7125,7 +7745,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7133,7 +7754,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7141,7 +7763,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7149,7 +7772,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7157,7 +7781,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7165,21 +7790,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7187,7 +7815,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7195,7 +7824,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7203,7 +7833,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7211,7 +7842,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7219,7 +7851,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7227,7 +7860,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7235,7 +7869,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class PasswordField\n  extends PreactFieldElement<PasswordFieldProps['autocomplete']>\n  implements PasswordFieldProps\n{\n  accessor maxLength: PasswordFieldProps['maxLength'];\n  accessor minLength: PasswordFieldProps['minLength'];\n  /**\n   * The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -7264,7 +7899,8 @@
           "name": "containerName",
           "value": "string",
           "description": "An identifier for this container that you can reference in CSS container queries to apply styles based on this specific container's size.\n\nAll query container components automatically receive a container name of `s-default`. You can omit the container name in your queries, so `@container (inline-size <= 300px)` is equivalent to `@container s-default (inline-size <= 300px)`.\n\nWhen you provide a custom `containerName`, it's added alongside `s-default`. For example, `containerName=\"product-card\"` results in `s-default product-card` being set on the `container-name` CSS property, allowing you to target this container with `@container product-card (inline-size <= 300px)`.\n\nLearn more about the [container-name property](https://developer.mozilla.org/en-US/docs/Web/CSS/container-name).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7272,7 +7908,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7280,7 +7917,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7288,7 +7926,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7296,7 +7935,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7304,7 +7944,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7312,7 +7953,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7320,7 +7962,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class QueryContainer\n  extends PreactCustomElement\n  implements QueryContainerProps\n{\n  accessor containerName: QueryContainerProps['containerName'];\n  /** @private */\n  static globalStylesApplied: boolean;\n  constructor();\n}"
@@ -7339,7 +7982,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7347,14 +7991,16 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7362,35 +8008,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7398,14 +8049,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7413,7 +8066,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7421,7 +8075,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7429,7 +8084,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7437,7 +8093,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7445,7 +8102,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7453,7 +8111,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7461,7 +8120,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7469,21 +8129,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7491,7 +8154,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7499,7 +8163,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7507,7 +8172,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7515,7 +8181,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7523,7 +8190,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7531,7 +8199,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7539,7 +8208,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class SearchField\n  extends PreactFieldElement<SearchFieldProps['autocomplete']>\n  implements SearchFieldProps\n{\n  accessor maxLength: SearchFieldProps['maxLength'];\n  accessor minLength: SearchFieldProps['minLength'];\n  /**\n   * The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -7568,21 +8238,24 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure."
+          "description": "The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7590,7 +8263,8 @@
           "name": "padding",
           "value": "\"base\" | \"none\"",
           "description": "The padding applied to all edges of the element.\n\n- `base`: applies padding that is appropriate for the element. Note that it might result in no padding if this is the right design decision in a particular context.\n- `none`: removes all padding from the element. This can be useful when elements inside the section need to span to the edge of the section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base' to bring back the desired padding for the rest of the content.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7598,7 +8272,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7606,7 +8281,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7614,7 +8290,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7622,7 +8299,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7630,7 +8308,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7638,7 +8317,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Section extends PreactCustomElement implements SectionProps {\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  accessor accessibilityLabel: SectionProps['accessibilityLabel'];\n  accessor heading: SectionProps['heading'];\n  accessor padding: SectionProps['padding'];\n}"
@@ -7656,35 +8336,40 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7692,7 +8377,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7700,7 +8386,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7708,7 +8395,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7716,14 +8404,16 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "A lifecycle callback that fires when the component is removed from the DOM. Performs cleanup operations.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component."
+          "description": "The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7731,7 +8421,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7739,7 +8430,8 @@
           "name": "__@usedFirstOptionSymbol@3004",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7747,7 +8439,8 @@
           "name": "__@hasInitialValueSymbol@3005",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7755,21 +8448,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7777,7 +8473,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7785,7 +8482,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7793,7 +8491,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7801,7 +8500,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7809,7 +8509,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7817,7 +8518,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Select extends PreactInputElement implements SelectProps {\n  accessor icon: SelectProps['icon'];\n  accessor details: SelectProps['details'];\n  accessor error: SelectProps['error'];\n  accessor label: SelectProps['label'];\n  accessor placeholder: SelectProps['placeholder'];\n  accessor required: SelectProps['required'];\n  accessor labelAccessibilityVisibility: SelectProps['labelAccessibilityVisibility'];\n  /** @private */\n  connectedCallback(): void;\n  /**\n   * A lifecycle callback that fires when the component is removed from the DOM. Performs cleanup operations.\n   * @private\n   */\n  disconnectedCallback(): void;\n  constructor();\n  /**\n   * A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n   *\n   * This is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.\n   * @private\n   */\n  [usedFirstOptionSymbol]: boolean;\n  /**\n   * @private\n   */\n  [hasInitialValueSymbol]: boolean;\n  /**\n   * The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component.\n   */\n  get value(): string;\n  set value(value: string);\n  /** @private */\n  formResetCallback(): void;\n}"
@@ -7835,7 +8537,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7843,7 +8546,8 @@
           "name": "size",
           "value": "\"base\" | \"large\" | \"large-100\"",
           "description": "The size of the loading spinner.\n\n- `base`: Default size suitable for inline loading indicators or standard UI contexts.\n- `large`: Larger spinner for more prominent loading states.\n- `large-100`: Extra large spinner for full-page or emphasized loading states.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7851,7 +8555,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7859,7 +8564,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7867,7 +8573,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7875,7 +8582,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7883,7 +8591,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7891,7 +8600,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7899,7 +8609,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Spinner extends PreactCustomElement implements SpinnerProps {\n  accessor accessibilityLabel: string;\n  accessor size: SpinnerProps['size'];\n  constructor();\n}"
@@ -7918,7 +8629,8 @@
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
           "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
-          "defaultValue": "'block'"
+          "defaultValue": "'block'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7926,7 +8638,8 @@
           "name": "justifyContent",
           "value": "JustifyContentKeyword",
           "description": "Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n\nUse this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7934,7 +8647,8 @@
           "name": "alignItems",
           "value": "AlignItemsKeyword",
           "description": "Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n\nUse this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7942,7 +8656,8 @@
           "name": "alignContent",
           "value": "AlignContentKeyword",
           "description": "Controls the distribution of lines along the block axis when content wraps into multiple lines.\n\nThis property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7950,7 +8665,8 @@
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
           "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7958,7 +8674,8 @@
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7966,7 +8683,8 @@
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7974,7 +8692,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7982,7 +8701,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7990,7 +8710,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7998,7 +8719,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8006,7 +8728,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8014,7 +8737,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8022,7 +8746,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8030,7 +8755,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8038,7 +8764,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8046,7 +8773,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8054,7 +8782,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8062,7 +8791,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8070,7 +8800,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8078,7 +8809,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8086,7 +8818,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8094,7 +8827,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8114,7 +8848,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8122,7 +8857,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8130,7 +8866,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8138,7 +8875,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8146,14 +8884,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8161,7 +8901,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8169,7 +8910,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8177,7 +8919,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8185,7 +8928,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8193,7 +8937,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8201,7 +8946,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8209,7 +8955,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8217,7 +8964,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8225,7 +8973,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Stack extends BoxElement implements StackProps {\n  constructor();\n  accessor direction: StackProps['direction'];\n  accessor justifyContent: StackProps['justifyContent'];\n  accessor alignItems: StackProps['alignItems'];\n  accessor alignContent: StackProps['alignContent'];\n  accessor gap: StackProps['gap'];\n  accessor rowGap: StackProps['rowGap'];\n  accessor columnGap: StackProps['columnGap'];\n}"
@@ -8244,7 +8993,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8252,14 +9002,16 @@
           "name": "checked",
           "value": "boolean",
           "description": "Whether the control is currently checked. Use this for controlled components where you manage the checked state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the checkbox is checked.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8267,35 +9019,40 @@
           "name": "defaultChecked",
           "value": "boolean",
           "description": "The initial checked state for uncontrolled components. Use this when you want the control to start checked but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8303,7 +9060,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field needs a value. This requirement adds semantic value to the field, but it will not cause an error to appear automatically. If you want to present an error when this field is empty, you can do so with the `error` property.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8311,7 +9069,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8319,21 +9078,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8341,7 +9103,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8349,7 +9112,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8357,7 +9121,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8365,7 +9130,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8373,7 +9139,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8381,7 +9148,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8389,7 +9157,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8397,7 +9166,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Switch extends PreactCheckboxElement implements SwitchProps {\n  accessor labelAccessibilityVisibility: SwitchProps['labelAccessibilityVisibility'];\n  constructor();\n}"
@@ -8416,7 +9186,8 @@
           "name": "variant",
           "value": "\"auto\" | \"list\"",
           "description": "The layout variant of the table component.\n\n- `list`: Always displays as a list layout.\n- `table`: Always displays as a traditional table layout.\n- `auto`: Automatically displays as a table on wide screens and as a list on narrow screens.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8424,7 +9195,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether the table is in a loading state, such as during initial page load or when loading the next page in a paginated table. When `true`, the table might be in an inert state that prevents user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8432,7 +9204,8 @@
           "name": "paginate",
           "value": "boolean",
           "description": "Whether to use pagination controls.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8440,7 +9213,8 @@
           "name": "hasPreviousPage",
           "value": "boolean",
           "description": "Whether there's a previous page of data.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8448,7 +9222,8 @@
           "name": "hasNextPage",
           "value": "boolean",
           "description": "Whether there's an additional page of data.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8456,7 +9231,8 @@
           "name": "__@actualTableVariantSymbol@3080",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8464,7 +9240,8 @@
           "name": "__@tableHeadersSharedDataSymbol@3081",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8472,7 +9249,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8480,7 +9258,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8488,7 +9267,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8496,7 +9276,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8504,7 +9285,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8512,7 +9294,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8520,7 +9303,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Table extends PreactCustomElement implements TableProps {\n  accessor variant: TableProps['variant'];\n  accessor loading: TableProps['loading'];\n  accessor paginate: TableProps['paginate'];\n  accessor hasPreviousPage: TableProps['hasPreviousPage'];\n  accessor hasNextPage: TableProps['hasNextPage'];\n  /**\n   * @private\n   * The actual table variant, which is either 'table' or 'list'.\n   */\n  [actualTableVariantSymbol]: AddedContext<ActualTableVariant>;\n  /** @private */\n  [tableHeadersSharedDataSymbol]: AddedContext<\n    {\n      listSlot: TableHeaderProps['listSlot'];\n      textContent: string;\n      format: HeaderFormat;\n    }[]\n  >;\n\n  constructor();\n}"
@@ -8607,7 +9391,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8615,7 +9400,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8623,7 +9409,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8631,7 +9418,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8639,7 +9427,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8647,7 +9436,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8655,7 +9445,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableBody extends PreactCustomElement implements TableBodyProps {\n  constructor();\n}"
@@ -8674,7 +9465,8 @@
           "name": "__@headerFormatSymbol@3103",
           "value": "HeaderFormat",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8682,7 +9474,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8690,7 +9483,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8698,7 +9492,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8706,7 +9501,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8714,7 +9510,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8722,7 +9519,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8730,7 +9528,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableCell extends PreactCustomElement implements TableCellProps {\n  constructor();\n  /** @private */\n  get [headerFormatSymbol](): HeaderFormat;\n  /** @private */\n  set [headerFormatSymbol](format: HeaderFormat);\n}"
@@ -8749,14 +9548,16 @@
           "name": "listSlot",
           "value": "ListSlotType",
           "description": "The content designation for this column when the table displays in list variant on mobile devices.",
-          "defaultValue": "'labeled'"
+          "defaultValue": "'labeled'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "format",
           "value": "HeaderFormat",
-          "description": "The format of the column that controls styling and alignment of cell content."
+          "description": "The format of the column that controls styling and alignment of cell content.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8764,7 +9565,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8772,7 +9574,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8780,7 +9583,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8788,7 +9592,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8796,7 +9601,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8804,7 +9610,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8812,7 +9619,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableHeader\n  extends PreactCustomElement\n  implements TableHeaderProps\n{\n  accessor listSlot: TableHeaderProps['listSlot'];\n  accessor format: TableHeaderProps['format'];\n  constructor();\n}"
@@ -8831,7 +9639,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8839,7 +9648,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8847,7 +9657,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8855,7 +9666,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8863,7 +9675,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8871,7 +9684,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8879,7 +9693,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableHeaderRow\n  extends PreactCustomElement\n  implements TableHeaderRowProps\n{\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -8897,7 +9712,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "clickDelegate",
           "value": "string",
-          "description": "The ID of an interactive element, such as `s-link`, in the row that will be the target of the click when the row is clicked. This is the primary action for the row; it should not be used for secondary actions.\n\nThis is a click-only affordance, and does not introduce any keyboard or screen reader affordances. Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally."
+          "description": "The ID of an interactive element, such as `s-link`, in the row that will be the target of the click when the row is clicked. This is the primary action for the row; it should not be used for secondary actions.\n\nThis is a click-only affordance, and does not introduce any keyboard or screen reader affordances. Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8905,7 +9721,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8913,7 +9730,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8921,7 +9739,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8929,7 +9748,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8937,7 +9757,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8945,7 +9766,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8953,7 +9775,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableRow extends PreactCustomElement implements TableRowProps {\n  constructor();\n  accessor clickDelegate: string;\n}"
@@ -8972,7 +9795,8 @@
           "name": "fontVariantNumeric",
           "value": "\"auto\" | \"normal\" | \"tabular-nums\"",
           "description": "The rendering style for numbers in the font.\n\n- `auto`: Inherits the setting from the parent element.\n- `normal`: Uses the font's default numeric glyphs.\n- `tabular-nums`: Uses fixed-width numeric glyphs, ensuring numbers align vertically in tables or lists.\n\nLearn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8980,7 +9804,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8988,7 +9813,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic tone that's applied to the text, which changes its color to convey meaning.\n\n- `info`: Informational content or helpful tips (blue).\n- `success`: Positive outcomes or successful states (green).\n- `warning`: Important warnings about potential issues (orange).\n- `critical`: Urgent problems or destructive actions (red).\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent (gray).\n- `caution`: Advisory notices that need attention (yellow).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8996,7 +9822,8 @@
           "name": "type",
           "value": "\"strong\" | \"generic\" | \"address\" | \"redundant\"",
           "description": "The semantic type and styling treatment for the text content.\n\n- `strong`: Emphasizes the text with strong importance, typically displayed in bold.\n- `generic`: Standard text with no special semantic meaning or styling.\n- `address`: Marks the text as contact information, such as a physical or email address.\n- `redundant`: Indicates the text is redundant or duplicated information for screen reader context.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9004,7 +9831,8 @@
           "name": "dir",
           "value": "\"\" | \"auto\" | \"ltr\" | \"rtl\"",
           "description": "Indicates the directionality of the element’s text.\n\n- `\"\"`: The direction is inherited from parent elements (equivalent to not setting the attribute).\n- `auto`: The user agent determines the direction based on the content.\n- `ltr`: The languages written from left to right (such as English).\n- `rtl`: The languages written from right to left (such as Arabic).\n\nLearn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9012,14 +9840,16 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9027,7 +9857,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9035,7 +9866,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9043,7 +9875,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9051,7 +9884,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9059,7 +9893,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9067,7 +9902,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9075,7 +9911,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Text extends PreactCustomElement implements TextProps {\n  accessor fontVariantNumeric: TextProps['fontVariantNumeric'];\n  accessor color: TextProps['color'];\n  /**\n   * The semantic tone that's applied to the text, which changes its color to convey meaning.\n   *\n   * - `info`: Informational content or helpful tips (blue).\n   * - `success`: Positive outcomes or successful states (green).\n   * - `warning`: Important warnings about potential issues (orange).\n   * - `critical`: Urgent problems or destructive actions (red).\n   * - `auto`: Automatically determined based on context.\n   * - `neutral`: General information without specific intent (gray).\n   * - `caution`: Advisory notices that need attention (yellow).\n   */\n  accessor tone: TextProps['tone'];\n  /**\n   * The semantic type and styling treatment for the text content.\n   *\n   * - `strong`: Emphasizes the text with strong importance, typically displayed in bold.\n   * - `generic`: Standard text with no special semantic meaning or styling.\n   * - `address`: Marks the text as contact information, such as a physical or email address.\n   * - `redundant`: Indicates the text is redundant or duplicated information for screen reader context.\n   */\n  accessor type: TextProps['type'];\n  accessor dir: TextProps['dir'];\n  accessor accessibilityVisibility: TextProps['accessibilityVisibility'];\n  accessor interestFor: string;\n  constructor();\n}"
@@ -9094,7 +9931,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9102,7 +9940,8 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9110,14 +9949,16 @@
           "name": "rows",
           "value": "number",
           "description": "A number of visible text lines.",
-          "defaultValue": "2"
+          "defaultValue": "2",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9125,35 +9966,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9161,14 +10007,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9176,7 +10024,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9184,7 +10033,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9192,7 +10042,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9200,7 +10051,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9208,7 +10060,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9216,7 +10069,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9224,7 +10078,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9232,21 +10087,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9254,7 +10112,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9262,7 +10121,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9270,7 +10130,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9278,7 +10139,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9286,7 +10148,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9294,7 +10157,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9302,7 +10166,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TextArea\n  extends PreactFieldElement<TextAreaProps['autocomplete']>\n  implements TextAreaProps\n{\n  accessor maxLength: TextAreaProps['maxLength'];\n  accessor minLength: TextAreaProps['minLength'];\n  accessor rows: TextAreaProps['rows'];\n  /**\n   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -9321,7 +10186,8 @@
           "name": "icon",
           "value": "\"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 542 more ... | AnyString",
           "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9329,7 +10195,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9337,7 +10204,8 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9345,7 +10213,8 @@
           "name": "prefix",
           "value": "string",
           "description": "A non-editable text value displayed immediately before the editable portion of the field. This is useful for displaying an implied part of the value, such as `https://` or `+353`.\n\nThis text can't be edited by the user and is not included in the field's value. The prefix might not appear until the user interacts with the field. For example, an inline label might occupy the prefix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9353,14 +10222,16 @@
           "name": "suffix",
           "value": "string",
           "description": "A non-editable text value displayed immediately after the editable portion of the field. This is useful for displaying an implied part of the value, such as `@shopify.com` or `%`.\n\nThis text can't be edited by the user and is not included in the field's value. The suffix might not appear until the user interacts with the field. For example, an inline label might occupy the suffix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9368,35 +10239,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9404,14 +10280,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9419,7 +10297,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9427,7 +10306,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9435,7 +10315,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9443,7 +10324,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9451,7 +10333,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9459,7 +10342,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9467,7 +10351,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9475,21 +10360,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9497,7 +10385,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9505,7 +10394,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9513,7 +10403,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9521,7 +10412,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9529,7 +10421,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9537,7 +10430,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9545,7 +10439,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TextField\n  extends PreactFieldElement<TextFieldProps['autocomplete']>\n  implements TextFieldProps\n{\n  accessor icon: TextFieldProps['icon'];\n  accessor maxLength: TextFieldProps['maxLength'];\n  accessor minLength: TextFieldProps['minLength'];\n  accessor prefix: TextFieldProps['prefix'];\n  accessor suffix: TextFieldProps['suffix'];\n  /**\n   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -9563,7 +10458,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered."
+          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9571,7 +10467,8 @@
           "name": "alt",
           "value": "string",
           "description": "Alternative text that describes the image for accessibility.\n\nProvides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
-          "defaultValue": "``"
+          "defaultValue": "``",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9579,7 +10476,8 @@
           "name": "size",
           "value": "\"small\" | \"small-200\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
           "description": "The size of the product thumbnail image.\n\n- `small-200`: Smallest thumbnail size, ideal for compact product lists or tables.\n- `small-100`: Very small thumbnail, suitable for dense layouts.\n- `small`: Small thumbnail for space-constrained contexts.\n- `base`: Default size that balances visibility and space efficiency.\n- `large`: Larger thumbnail for featured products or detailed views.\n- `large-100`: Extra large thumbnail for prominent product display.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9587,7 +10485,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9595,7 +10494,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9603,7 +10503,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9611,7 +10512,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9619,7 +10521,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9627,7 +10530,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9635,7 +10539,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Thumbnail extends PreactCustomElement implements ThumbnailProps {\n  accessor src: ThumbnailProps['src'];\n  accessor alt: ThumbnailProps['alt'];\n  accessor size: ThumbnailProps['size'];\n  constructor();\n}"
@@ -9654,7 +10559,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9662,7 +10568,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9670,7 +10577,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9678,7 +10586,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9686,7 +10595,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9694,7 +10604,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9702,7 +10613,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9710,7 +10622,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9718,7 +10631,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9726,7 +10640,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Tooltip extends PreactOverlayElement implements TooltipProps {\n  constructor();\n}"
@@ -9745,7 +10660,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9753,7 +10669,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9761,7 +10678,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9769,7 +10687,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9777,7 +10696,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9785,7 +10705,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9793,7 +10714,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class UnorderedList\n  extends PreactCustomElement\n  implements UnorderedListProps\n{\n  constructor();\n}"
@@ -9812,7 +10734,8 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | `section-${string} url` | `section-${string} photo` | `section-${string} impp` | `section-${string} home impp` | `section-${string} mobile impp` | `section-${string} fax impp` | `section-${string} pager impp` | \"shipping url\" | \"shipping photo\" | \"shipping impp\" | \"shipping home impp\" | \"shipping mobi...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9820,7 +10743,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9828,42 +10752,48 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing."
+          "description": "The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9871,14 +10801,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9886,7 +10818,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9894,7 +10827,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9902,7 +10836,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9910,7 +10845,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9918,7 +10854,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9926,7 +10863,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9934,7 +10872,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9942,21 +10881,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9964,7 +10906,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9972,7 +10915,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9980,7 +10924,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9988,7 +10933,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9996,7 +10942,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10004,7 +10951,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10012,7 +10960,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class URLField\n  extends PreactFieldElement<URLFieldProps['autocomplete']>\n  implements URLFieldProps\n{\n  accessor autocomplete: URLFieldProps['autocomplete'];\n  accessor maxLength: URLFieldProps['maxLength'];\n  accessor minLength: URLFieldProps['minLength'];\n  /**\n   * The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -10030,7 +10979,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The text to use as the Action modal's title. If not provided, the name of the extension will be used."
+          "description": "The text to use as the Action modal's title. If not provided, the name of the extension will be used.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10038,7 +10988,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether the action is in a loading state, such as during initial page load or when the action is being opened. When `true`, the action might be in an inert state that prevents user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10046,7 +10997,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10054,7 +11006,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10062,7 +11015,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10070,7 +11024,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10078,7 +11033,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10086,7 +11042,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10094,7 +11051,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminAction\n  extends PreactCustomElement\n  implements AdminActionProps\n{\n  /**\n   * The text to use as the Action modal's title. If not provided, the name of the extension will be used.\n   */\n  heading: string;\n  /**\n   * Whether the action is in a loading state, such as during initial page load or when the action is being opened.\n   * When `true`, the action might be in an inert state that prevents user interaction.\n   */\n  loading: boolean;\n  constructor();\n}"
@@ -10332,14 +11290,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The text displayed as the block's title in the header. If not provided, the extension name will be used."
+          "description": "The text displayed as the block's title in the header. If not provided, the extension name will be used.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "collapsedSummary",
           "value": "string",
-          "description": "The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated."
+          "description": "The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10347,7 +11307,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10355,7 +11316,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10363,7 +11325,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10371,7 +11334,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10379,7 +11343,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10387,7 +11352,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10395,7 +11361,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminBlock\n  extends PreactCustomElement\n  implements AdminBlockProps\n{\n  /**\n   * The text displayed as the block's title in the header. If not provided, the extension name will be used.\n   */\n  heading: string;\n  /**\n   * The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.\n   */\n  collapsedSummary: string;\n  constructor();\n}"
@@ -10414,7 +11381,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10422,7 +11390,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10430,7 +11399,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10438,7 +11408,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10446,7 +11417,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10454,7 +11426,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10462,7 +11435,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Form extends PreactCustomElement implements FormProps {\n  constructor();\n}"
@@ -11001,14 +11975,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers."
+          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "A title that describes the content of the modal."
+          "description": "A title that describes the content of the modal.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11016,7 +11992,8 @@
           "name": "padding",
           "value": "\"base\" | \"none\"",
           "description": "Adjust the padding around the modal content.\n\n`base`: applies padding that is appropriate for the element.\n\n`none`: removes all padding from the element. This can be useful when elements inside the modal need to span to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base' to bring back the desired padding for the rest of the content.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11024,28 +12001,32 @@
           "name": "size",
           "value": "\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
           "description": "The size of the modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "showOverlay",
           "value": "() => void",
-          "description": "A method to programmatically show the overlay."
+          "description": "A method to programmatically show the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "hideOverlay",
           "value": "() => void",
-          "description": "A method to programmatically hide the overlay."
+          "description": "A method to programmatically hide the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "toggleOverlay",
           "value": "() => void",
-          "description": "A method to programmatically toggle the visibility of the overlay."
+          "description": "A method to programmatically toggle the visibility of the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11053,7 +12034,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11061,7 +12043,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11069,7 +12052,8 @@
           "name": "__@abortController@2785",
           "value": "AbortController",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11077,7 +12061,8 @@
           "name": "__@dialog@2779",
           "value": "HTMLDialogElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11085,7 +12070,8 @@
           "name": "__@focusedElement@2781",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11093,7 +12079,8 @@
           "name": "__@nestedModals@2783",
           "value": "Map<Modal, boolean>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11101,7 +12088,8 @@
           "name": "__@childrenRerenderObserver@2787",
           "value": "MutationObserver",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11109,7 +12097,8 @@
           "name": "__@shadowDomRerenderObserver@2788",
           "value": "MutationObserver",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11117,7 +12106,8 @@
           "name": "__@onEscape@2782",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11125,7 +12115,8 @@
           "name": "__@onBackdropClick@2784",
           "value": "(event: MouseEvent) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11133,7 +12124,8 @@
           "name": "__@onChildModalChange@2786",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11141,7 +12133,8 @@
           "name": "__@isOpen@2778",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11149,7 +12142,8 @@
           "name": "__@dismiss@2780",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11157,7 +12151,8 @@
           "name": "__@hasOpenChildModal@2775",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11165,7 +12160,8 @@
           "name": "__@show@2776",
           "value": "() => Promise<void>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11173,7 +12169,8 @@
           "name": "__@hide@2777",
           "value": "() => Promise<void>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11181,7 +12178,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11189,7 +12187,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11197,7 +12196,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11205,7 +12205,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11213,7 +12214,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11221,7 +12223,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11229,7 +12232,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11237,7 +12241,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Modal extends PreactOverlayElement implements ModalProps {\n  accessor accessibilityLabel: ModalProps['accessibilityLabel'];\n  accessor heading: ModalProps['heading'];\n  accessor padding: ModalProps['padding'];\n  accessor size: ModalProps['size'];\n  /** @private */\n  [abortController]: AbortController;\n  /** @private */\n  [dialog]: HTMLDialogElement | null;\n  /** @private */\n  [focusedElement]: HTMLElement | null;\n  /** @private */\n  [nestedModals]: Map<Modal, boolean>;\n  /** @private */\n  [childrenRerenderObserver]: MutationObserver;\n  /** @private */\n  [shadowDomRerenderObserver]: MutationObserver;\n  /** @private */\n  [onEscape]: (event: KeyboardEvent) => void;\n  /** @private */\n  [onBackdropClick]: (event: MouseEvent) => void;\n  /** @private */\n  [onChildModalChange]: EventListenerOrEventListenerObject;\n  /** @private */\n  get [isOpen](): boolean;\n  /** @private */\n  [dismiss](): void;\n  /** @private */\n  get [hasOpenChildModal](): boolean;\n  /** @private */\n  [show](): Promise<void>;\n  /** @private */\n  [hide](): Promise<void>;\n  showOverlay(): void;\n  hideOverlay(): void;\n  toggleOverlay(): void;\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n  constructor();\n}"
@@ -11256,14 +12261,16 @@
           "name": "inlineSize",
           "value": "\"small\" | \"base\" | \"large\"",
           "description": "The inline size of the page\n- `base` corresponds to a set default inline size\n- `large` full width with whitespace",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The main page heading"
+          "description": "The main page heading",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11271,7 +12278,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11279,7 +12287,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11287,7 +12296,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11295,7 +12305,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11303,7 +12314,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11311,7 +12323,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11319,7 +12332,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Page extends PreactCustomElement implements PageProps {\n  accessor inlineSize: PageProps['inlineSize'];\n  accessor heading: PageProps['heading'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -12086,7 +13100,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12094,7 +13109,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12102,7 +13118,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12110,7 +13127,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12118,7 +13136,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12126,7 +13145,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12134,7 +13154,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class FunctionSettings\n  extends PreactCustomElement\n  implements FunctionSettingsProps\n{\n  constructor();\n}"
@@ -12235,7 +13256,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The `src` URL of the preview and the document to print. If not provided, the preview will show an empty state and the print button will be disabled. HTML, PDFs, and images are supported."
+          "description": "The `src` URL of the preview and the document to print. If not provided, the preview will show an empty state and the print button will be disabled. HTML, PDFs, and images are supported.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12243,7 +13265,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12251,7 +13274,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12259,7 +13283,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12267,7 +13292,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12275,7 +13301,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12283,7 +13310,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12291,7 +13319,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminPrintAction\n  extends PreactCustomElement\n  implements AdminPrintActionProps\n{\n  /**\n   * The `src` URL of the preview and the document to print.\n   * If not provided, the preview will show an empty state and the print button will be disabled.\n   * HTML, PDFs, and images are supported.\n   */\n  src: string;\n  constructor();\n}"
@@ -13234,8 +14263,8 @@
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "IntentAction",
-      "value": "'create' | 'edit'",
-      "description": "The type of operation to perform: creating a new resource or editing an existing one.",
+      "value": "'create' | 'edit' | 'pick'",
+      "description": "The type of operation to perform: creating a new resource, editing an existing one, or picking existing resources.",
       "isPublicDocs": true
     }
   },
@@ -13244,7 +14273,7 @@
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "IntentType",
-      "value": "'shopify/Article' | 'shopify/Catalog' | 'shopify/Collection' | 'shopify/Customer' | 'shopify/Discount' | 'shopify/Location' | 'shopify/Market' | 'shopify/Menu' | 'shopify/MetafieldDefinition' | 'shopify/Metaobject' | 'shopify/MetaobjectDefinition' | 'shopify/Page' | 'shopify/Product' | 'shopify/ProductVariant'",
+      "value": "'shopify/Article' | 'shopify/Catalog' | 'shopify/Collection' | 'shopify/Customer' | 'shopify/Discount' | 'shopify/File' | 'shopify/Location' | 'shopify/Market' | 'shopify/Menu' | 'shopify/MetafieldDefinition' | 'shopify/Metaobject' | 'shopify/MetaobjectDefinition' | 'shopify/Page' | 'shopify/Product' | 'shopify/ProductVariant'",
       "description": "The types of Shopify resources that support intent-based creation and editing workflows.",
       "isPublicDocs": true
     }
@@ -19732,7 +20761,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n\n- `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.\n- `auto`: Automatically sizes based on content and layout constraints.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19740,7 +20770,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum vertical size of the element in standard layouts (min-height in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming smaller than this size along the block axis.\n\nLearn more about the [min-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19748,7 +20779,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum vertical size of the element in standard layouts (max-height in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming larger than this size along the block axis.\n\nLearn more about the [max-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19756,7 +20788,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The horizontal size of the element in standard layouts (width in left-to-right or right-to-left writing modes).\n\nInline size adjusts based on the writing direction: in horizontal layouts, it controls the width; in vertical layouts, it controls the height. This ensures consistent behavior across different text directions.\n\nLearn more about the [inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n\n- `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.\n- `auto`: Automatically sizes based on content and layout constraints.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19764,7 +20797,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum horizontal size of the element in standard layouts (min-width in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming smaller than this size along the inline axis.\n\nLearn more about the [min-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19772,7 +20806,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum horizontal size of the element in standard layouts (max-width in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming larger than this size along the inline axis.\n\nLearn more about the [max-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19780,7 +20815,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19788,7 +20824,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19796,7 +20833,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19804,7 +20842,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19812,7 +20851,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19820,7 +20860,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19828,7 +20869,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19836,7 +20878,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19844,7 +20887,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19852,7 +20896,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Popover\n  extends PreactPopoverElement<typeof tagName$p>\n  implements PopoverProps\n{\n  constructor();\n}"
@@ -20419,14 +21464,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the avatar image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the avatar image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the avatar image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the avatar image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface AvatarEvents {\n  /**\n   * A callback fired when the avatar image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the avatar image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -20463,14 +21510,16 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the banner is hidden."
+          "description": "A callback fired after the banner is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "dismiss",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the banner is dismissed."
+          "description": "A callback fired when the banner is dismissed.",
+          "isOptional": true
         }
       ],
       "value": "export interface BannerEvents {\n  /**\n   * A callback fired when the banner is dismissed.\n   */\n  dismiss: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the banner is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20534,21 +21583,24 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the button loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the button is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the button receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ButtonEvents {\n  /**\n   * A callback fired when the button is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the button loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the button receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20620,14 +21672,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the checkbox value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the checkbox value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the checkbox.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the checkbox.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface CheckboxEvents {\n  /**\n   * A callback fired when the checkbox value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the checkbox.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -20699,14 +21753,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the choice list selection changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the choice list selection changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the choice list.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the choice list.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ChoiceListEvents {\n  /**\n   * A callback fired when the choice list selection changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the choice list.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20743,21 +21799,24 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the component loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the component is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the component receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ClickableEvents {\n  /**\n   * A callback fired when the component is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the component loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the component receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20794,21 +21853,24 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the chip is hidden."
+          "description": "A callback fired after the chip is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the chip is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the chip is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "remove",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the chip is removed."
+          "description": "A callback fired when the chip is removed.",
+          "isOptional": true
         }
       ],
       "value": "export interface ClickableChipEvents {\n  /**\n   * A callback fired when the chip is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the chip is removed.\n   */\n  remove: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the chip is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20853,28 +21915,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the color field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the color field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the color field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the color field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the color field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ColorFieldEvents {\n  /**\n   * A callback fired when the color field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the color field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the color field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the color field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -20892,14 +21958,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the color picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the color picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the color picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the color picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ColorPickerEvents {\n  /**\n   * A callback fired when the color picker value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the color picker.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20917,42 +21985,48 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the date field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the date field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the date field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the date field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the date field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "invalid",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date field value is invalid.\n\nLearn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event)."
+          "description": "A callback fired when the date field value is invalid.\n\nLearn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "viewchange",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the calendar view changes (such as when navigating between months)."
+          "description": "A callback fired when the calendar view changes (such as when navigating between months).",
+          "isOptional": true
         }
       ],
       "value": "export interface DateFieldEvents {\n  /**\n   * A callback fired when the date field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the date field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the date field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the date field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the calendar view changes (such as when navigating between months).\n   */\n  viewchange: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date field value is invalid.\n   *\n   * Learn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event).\n   */\n  invalid: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20970,35 +22044,40 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the date picker loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the date picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the date picker receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the date picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the date picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "viewchange",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the calendar view changes, such as when navigating between months."
+          "description": "A callback fired when the calendar view changes, such as when navigating between months.",
+          "isOptional": true
         }
       ],
       "value": "export interface DatePickerEvents {\n  /**\n   * A callback fired when the calendar view changes, such as when navigating between months.\n   */\n  viewchange: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the date picker.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21016,21 +22095,24 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when the drop zone value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the drop zone value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "droprejected",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when a dropped file is rejected due to file type or size restrictions."
+          "description": "A callback fired when a dropped file is rejected due to file type or size restrictions.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when the user inputs data into the drop zone.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the drop zone.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface DropZoneEvents {\n  /**\n   * A callback fired when the drop zone value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> = null;\n  /**\n   * A callback fired when the user inputs data into the drop zone.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> = null;\n  /**\n   * A callback fired when a dropped file is rejected due to file type or size restrictions.\n   */\n  droprejected: CallbackEventListener<typeof tagName> = null;\n}"
@@ -21067,28 +22149,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the email field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the email field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the email field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the email field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the email field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface EmailFieldEvents {\n  /**\n   * A callback fired when the email field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the email field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the email field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the email field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21163,14 +22249,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ImageEvents {\n  /**\n   * A callback fired when the image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -21188,7 +22276,8 @@
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the link is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the link is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface LinkEvents {\n  /**\n   * A callback fired when the link is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21263,28 +22352,32 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the modal is hidden."
+          "description": "A callback fired after the modal is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftershow",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the modal is shown."
+          "description": "A callback fired after the modal is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "hide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the modal is hidden."
+          "description": "A callback fired when the modal is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "show",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the modal is shown."
+          "description": "A callback fired when the modal is shown.",
+          "isOptional": true
         }
       ],
       "value": "export interface ModalEvents {\n  /**\n   * A callback fired when the modal is hidden.\n   */\n  hide: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the modal is shown.\n   */\n  show: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the modal is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the modal is shown.\n   */\n  aftershow: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21337,28 +22430,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the money field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the money field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the money field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the money field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the money field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface MoneyFieldEvents {\n  /**\n   * A callback fired when the money field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the money field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the money field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the money field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21376,28 +22473,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the number field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the number field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the number field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the number field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the number field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface NumberFieldEvents {\n  /**\n   * A callback fired when the number field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the number field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the number field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the number field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21542,28 +22643,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the password field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the password field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the password field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the password field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the password field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface PasswordFieldEvents {\n  /**\n   * A callback fired when the password field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the password field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the password field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the password field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21581,42 +22686,48 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is hidden."
+          "description": "A callback fired after the popover is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftershow",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is shown."
+          "description": "A callback fired after the popover is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftertoggle",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is toggled."
+          "description": "A callback fired after the popover is toggled.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "hide",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is hidden."
+          "description": "A callback fired when the popover is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "show",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is shown."
+          "description": "A callback fired when the popover is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "toggle",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is toggled."
+          "description": "A callback fired when the popover is toggled.",
+          "isOptional": true
         }
       ],
       "value": "export interface PopoverEvents {\n  /**\n   * A callback fired when the popover is shown.\n   */\n  show: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired when the popover is hidden.\n   */\n  hide: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is shown.\n   */\n  aftershow: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is hidden.\n   */\n  afterhide: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired when the popover is toggled.\n   */\n  toggle: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is toggled.\n   */\n  aftertoggle: CallbackEventListener<TTagName> | null;\n}"
@@ -21672,28 +22783,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the search field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the search field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the search field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the search field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the search field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SearchFieldEvents {\n  /**\n   * A callback fired when the search field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the search field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the search field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the search field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21730,14 +22845,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the select value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the select value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the select.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the select.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SelectEvents {\n  /**\n   * A callback fired when the select value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the select.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -21793,14 +22910,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the switch value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the switch value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the switch.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the switch.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SwitchEvents {\n  /**\n   * A callback fired when the switch value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the switch.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -21818,14 +22937,16 @@
           "syntaxKind": "PropertySignature",
           "name": "nextpage",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user navigates to the next page."
+          "description": "A callback fired when the user navigates to the next page.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "previouspage",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user navigates to the previous page."
+          "description": "A callback fired when the user navigates to the previous page.",
+          "isOptional": true
         }
       ],
       "value": "export interface TableEvents {\n  /**\n   * A callback fired when the user navigates to the previous page.\n   */\n  previouspage: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user navigates to the next page.\n   */\n  nextpage: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21984,28 +23105,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the text area loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the text area value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the text area receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the text area.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the text area.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface TextAreaEvents {\n  /**\n   * A callback fired when the text area value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the text area.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text area loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text area receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22023,28 +23148,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the text field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the text field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the text field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the text field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the text field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface TextFieldEvents {\n  /**\n   * A callback fired when the text field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the text field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22081,14 +23210,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the thumbnail image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the thumbnail image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the thumbnail image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the thumbnail image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ThumbnailEvents {\n  /**\n   * A callback fired when the thumbnail image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the thumbnail image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -22125,28 +23256,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the URL field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the URL field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the URL field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the URL field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the URL field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface URLFieldEvents {\n  /**\n   * A callback fired when the URL field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the URL field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the URL field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the URL field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22208,14 +23343,16 @@
           "syntaxKind": "PropertySignature",
           "name": "reset",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the form is reset."
+          "description": "A callback that is run when the form is reset.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "submit",
           "value": "CallbackExtendableEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the form is submitted."
+          "description": "A callback that is run when the form is submitted.",
+          "isOptional": true
         }
       ],
       "value": "export interface FormEvents {\n  /**\n   * A callback that is run when the form is submitted.\n   */\n  submit: CallbackExtendableEventListener<typeof tagName> | null = null;\n  /**\n   * A callback that is run when the form is reset.\n   */\n  reset: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -22233,21 +23370,24 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "CallbackErrorEventListener<\n    typeof tagName,\n    FunctionSettingsErrorEvent['error']['errors'][0]\n  > | null",
-          "description": "An optional callback function that will be run by the admin when committing the changes to Shopify’s servers fails. The error event you receive includes an `error` property that is an `AggregateError` object. This object includes an array of errors that were caused by data your extension provided. Network errors and user errors that are out of your control will not be reported here.\n\nIn the `onError` callback, you should update your extension’s UI to highlight the fields that caused the errors, and display the error messages to the user."
+          "description": "An optional callback function that will be run by the admin when committing the changes to Shopify’s servers fails. The error event you receive includes an `error` property that is an `AggregateError` object. This object includes an array of errors that were caused by data your extension provided. Network errors and user errors that are out of your control will not be reported here.\n\nIn the `onError` callback, you should update your extension’s UI to highlight the fields that caused the errors, and display the error messages to the user.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "reset",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the function settings form is reset."
+          "description": "A callback that is run when the function settings form is reset.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "submit",
           "value": "CallbackExtendableEventListener<typeof tagName> | null",
-          "description": "An optional callback function that will be run by the admin when the user commits their changes in the admin-rendered part of the function settings experience. If `event.waitUntil` is called with a promise, the admin will wait for the promise to resolve before committing any changes to Shopify’s servers. If the promise rejects, the admin will abort the changes and display an error, using the `message` property of the error you reject with."
+          "description": "An optional callback function that will be run by the admin when the user commits their changes in the admin-rendered part of the function settings experience. If `event.waitUntil` is called with a promise, the admin will wait for the promise to resolve before committing any changes to Shopify’s servers. If the promise rejects, the admin will abort the changes and display an error, using the `message` property of the error you reject with.",
+          "isOptional": true
         }
       ],
       "value": "export interface FunctionSettingsEvents {\n  /**\n   * An optional callback function that will be run by the admin when the user\n   * commits their changes in the admin-rendered part of the function settings\n   * experience. If `event.waitUntil` is called with a promise, the admin will wait for the\n   * promise to resolve before committing any changes to Shopify’s servers. If\n   * the promise rejects, the admin will abort the changes and display an error,\n   * using the `message` property of the error you reject with.\n   */\n  submit: CallbackExtendableEventListener<typeof tagName> | null = null;\n  /**\n   * An optional callback function that will be run by the admin when\n   * committing the changes to Shopify’s servers fails. The error event you receive includes\n   * an `error` property that is an `AggregateError` object. This object includes\n   * an array of errors that were caused by data your extension provided.\n   * Network errors and user errors that are out of your control will not be reported here.\n   *\n   * In the `onError` callback, you should update your extension’s UI to\n   * highlight the fields that caused the errors, and display the error messages\n   * to the user.\n   */\n  error: CallbackErrorEventListener<\n    typeof tagName,\n    FunctionSettingsErrorEvent['error']['errors'][0]\n  > | null = null;\n  /**\n   * A callback that is run when the function settings form is reset.\n   */\n  reset: CallbackEventListener<typeof tagName> | null = null;\n}"

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -962,7 +962,7 @@
     "src/surfaces/admin/api/intents/intents.ts": {
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "name": "IntentInvokeApi",
-      "description": "The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating or editing resources, such as products, customers, or discounts. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created or updated resource data.",
+      "description": "The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating, editing, or picking resources, such as products, customers, or files. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created, updated, or selected resource data.",
       "isPublicDocs": true,
       "members": [],
       "value": "export interface IntentInvokeApi {\n  (query: IntentQuery): Promise<IntentActivity>;\n  (intentURL: string, options?: IntentQueryOptions): Promise<IntentActivity>;\n}"
@@ -1506,14 +1506,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "initials",
           "value": "string",
-          "description": "The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials, such as \"JD\" for John Doe."
+          "description": "The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials, such as \"JD\" for John Doe.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The URL or path to the avatar image. When provided, the image takes priority over `initials`. If the image fails to load or loads slowly, `initials` will be rendered as a fallback."
+          "description": "The URL or path to the avatar image. When provided, the image takes priority over `initials`. If the image fails to load or loads slowly, `initials` will be rendered as a fallback.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1521,14 +1523,16 @@
           "name": "size",
           "value": "\"small\" | \"small-200\" | \"base\" | \"large\" | \"large-200\"",
           "description": "The size of the avatar image.\n\n- `small-200`: Extra small avatar, suitable for compact displays or lists with many items.\n- `small`: Small avatar, good for secondary contexts or tight layouts.\n- `base`: Default size that works well in most contexts.\n- `large`: Large avatar for emphasis or when the avatar is a focal point.\n- `large-200`: Extra large avatar for prominent display.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "alt",
           "value": "string",
-          "description": "Alternative text that describes the avatar for accessibility.\n\nProvides a text description of the avatar for users with assistive technology and serves as a fallback when the avatar fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an avatar, it reads this description aloud. When an avatar fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt)."
+          "description": "Alternative text that describes the avatar for accessibility.\n\nProvides a text description of the avatar for users with assistive technology and serves as a fallback when the avatar fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an avatar, it reads this description aloud. When an avatar fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1536,7 +1540,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1544,7 +1549,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1552,7 +1558,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1560,7 +1567,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1568,7 +1576,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1576,7 +1585,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1584,7 +1594,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Avatar extends PreactCustomElement implements AvatarProps {\n  accessor initials: AvatarProps['initials'];\n  accessor src: AvatarProps['src'];\n  accessor size: AvatarProps['size'];\n  accessor alt: AvatarProps['alt'];\n  constructor();\n}"
@@ -1660,14 +1671,16 @@
           "name": "color",
           "value": "\"base\" | \"strong\"",
           "description": "Controls the visual weight and emphasis of the badge.\n\n- `base`: Standard weight with moderate emphasis, suitable for most use cases.\n- `strong`: Increased visual weight for higher emphasis and prominence.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1675,7 +1688,8 @@
           "name": "size",
           "value": "\"base\" | \"large\" | \"large-100\"",
           "description": "The size of the badge.\n\n- `base`: Default size suitable for most badge use cases.\n- `large`: Larger badge for increased visibility and prominence.\n- `large-100`: Extra large badge for maximum visibility in emphasized contexts.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1683,7 +1697,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.\n- `caution`: Advisory notices that need attention.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1691,7 +1706,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1699,7 +1715,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1707,7 +1724,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1715,7 +1733,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1723,7 +1742,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1731,7 +1751,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1739,7 +1760,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Badge extends PreactCustomElement implements BadgeProps {\n  accessor color: BadgeProps['color'];\n  accessor icon: BadgeProps['icon'];\n  accessor size: BadgeProps['size'];\n  accessor tone: BadgeProps['tone'];\n  constructor();\n}"
@@ -1758,7 +1780,8 @@
           "name": "heading",
           "value": "string",
           "description": "The heading text displayed at the top of the banner.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1766,7 +1789,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1774,7 +1798,8 @@
           "name": "hidden",
           "value": "boolean",
           "description": "Controls whether the banner is visible or hidden.\n\nWhen using a controlled component pattern and the banner is `dismissible`, update this property to `true` when the `dismiss` event fires.\n\nYou can hide the banner programmatically by setting this to `true` even if it's not `dismissible`.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1782,7 +1807,8 @@
           "name": "dismissible",
           "value": "boolean",
           "description": "Whether the banner displays a close button that allows users to dismiss it.\n\nWhen the close button is pressed, the `dismiss` event fires, then `hidden` is set to `true`, any animation completes, and the `afterhide` event fires.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1790,7 +1816,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1798,7 +1825,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1806,7 +1834,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1814,7 +1843,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1822,7 +1852,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1830,7 +1861,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1838,7 +1870,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Banner extends PreactCustomElement implements BannerProps {\n  accessor heading: BannerProps['heading'];\n  accessor tone: BannerProps['tone'];\n  accessor hidden: BannerProps['hidden'];\n  accessor dismissible: BannerProps['dismissible'];\n  constructor();\n}"
@@ -1857,7 +1890,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1865,7 +1899,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1873,7 +1908,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1881,7 +1917,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1889,7 +1926,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1897,7 +1935,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1905,7 +1944,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1913,7 +1953,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1921,7 +1962,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1929,7 +1971,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1937,7 +1980,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1945,7 +1989,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1953,7 +1998,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1961,7 +2007,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1969,7 +2016,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1977,7 +2025,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1997,7 +2046,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2005,7 +2055,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2013,7 +2064,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2021,7 +2073,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2029,14 +2082,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2044,7 +2099,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2052,7 +2108,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2060,7 +2117,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2068,7 +2126,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2076,7 +2135,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2084,7 +2144,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2092,7 +2153,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2100,7 +2162,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2108,7 +2171,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Box extends BoxElement implements BoxProps {\n  constructor();\n}"
@@ -2287,14 +2351,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the button is disabled, preventing it from being clicked or receiving focus.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the button, typically positioned before the button text. Use icons to help users quickly identify the button's action or to improve scannability. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the button, typically positioned before the button text. Use icons to help users quickly identify the button's action or to improve scannability. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2302,7 +2368,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether to replace the button content with a loading indicator while a background action is being performed.\n\nThis also disables the button component.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2310,7 +2377,8 @@
           "name": "variant",
           "value": "\"auto\" | \"primary\" | \"secondary\" | \"tertiary\"",
           "description": "The visual appearance of the button component.\n\n- `auto`: The variant is automatically determined by the button component's context.\n- `primary`: High emphasis button for the primary action on the page. Should be used sparingly.\n- `secondary`: Medium emphasis button for secondary actions.\n- `tertiary`: Low emphasis button for less important actions.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2318,7 +2386,8 @@
           "name": "tone",
           "value": "\"critical\" | \"auto\" | \"neutral\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2326,21 +2395,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2348,14 +2420,16 @@
           "name": "type",
           "value": "\"button\" | \"reset\" | \"submit\"",
           "description": "The behavior of the button component.\n\n- `button`: Used to indicate the component acts as a button, meaning it has no default action.\n- `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).\n- `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.\n\nThis property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.",
-          "defaultValue": "'button'"
+          "defaultValue": "'button'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2363,7 +2437,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2371,7 +2446,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2379,7 +2455,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2387,7 +2464,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2395,7 +2473,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2403,7 +2482,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2411,7 +2491,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2419,21 +2500,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Button extends Button_base implements ButtonProps {\n  accessor disabled: ButtonProps['disabled'];\n  accessor icon: ButtonProps['icon'];\n  accessor loading: ButtonProps['loading'];\n  accessor variant: ButtonProps['variant'];\n  accessor tone: ButtonProps['tone'];\n  accessor target: ButtonProps['target'];\n  accessor href: ButtonProps['href'];\n  accessor download: ButtonProps['download'];\n  accessor type: ButtonProps['type'];\n  accessor accessibilityLabel: ButtonProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2462,14 +2546,16 @@
           "name": "gap",
           "value": "\"base\" | \"none\"",
           "description": "The spacing between buttons in the group.\n\n- `base`: Standard spacing that provides clear visual separation between buttons.\n- `none`: No spacing, creating a connected button group.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2477,7 +2563,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2485,7 +2572,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2493,7 +2581,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2501,7 +2590,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2509,7 +2599,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2517,7 +2608,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2525,7 +2617,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ButtonGroup\n  extends PreactCustomElement\n  implements ButtonGroupProps\n{\n  accessor gap: ButtonGroupProps['gap'];\n  accessor accessibilityLabel: ButtonGroupProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2543,7 +2636,8 @@
           "syntaxKind": "GetAccessor",
           "name": "indeterminate",
           "value": "boolean",
-          "description": "Whether the checkbox displays in an indeterminate state (neither checked nor unchecked), typically used to indicate partial selection in hierarchical lists.\n\nThis visual state takes priority over the `checked` prop in appearance only. The form submission value is still determined by the `checked` prop.\n\nIf `indeterminate` has not been explicitly set and hasn't been modified by user interaction, it returns the value of `defaultIndeterminate`."
+          "description": "Whether the checkbox displays in an indeterminate state (neither checked nor unchecked), typically used to indicate partial selection in hierarchical lists.\n\nThis visual state takes priority over the `checked` prop in appearance only. The form submission value is still determined by the `checked` prop.\n\nIf `indeterminate` has not been explicitly set and hasn't been modified by user interaction, it returns the value of `defaultIndeterminate`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2551,7 +2645,8 @@
           "name": "defaultIndeterminate",
           "value": "boolean",
           "description": "The initial indeterminate state for uncontrolled components. Use this when you want the checkbox to start in an indeterminate state but don't need to control it afterward.\n\nThis value applies until `indeterminate` is explicitly set or the user changes the checkbox state by clicking.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2559,14 +2654,16 @@
           "name": "checked",
           "value": "boolean",
           "description": "Whether the control is currently checked. Use this for controlled components where you manage the checked state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the checkbox is checked.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2574,35 +2671,40 @@
           "name": "defaultChecked",
           "value": "boolean",
           "description": "The initial checked state for uncontrolled components. Use this when you want the control to start checked but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2610,7 +2712,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field needs a value. This requirement adds semantic value to the field, but it will not cause an error to appear automatically. If you want to present an error when this field is empty, you can do so with the `error` property.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2618,7 +2721,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2626,21 +2730,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2648,7 +2755,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2656,7 +2764,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2664,7 +2773,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2672,7 +2782,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2680,7 +2791,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2688,7 +2800,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2696,7 +2809,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2704,7 +2818,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Checkbox extends PreactCheckboxElement implements CheckboxProps {\n  get indeterminate(): CheckboxProps['indeterminate'];\n  set indeterminate(indeterminate: CheckboxProps['indeterminate']);\n  accessor defaultIndeterminate: CheckboxProps['defaultIndeterminate'];\n  constructor();\n}"
@@ -2723,14 +2838,16 @@
           "name": "color",
           "value": "ColorKeyword",
           "description": "The color emphasis level that controls visual intensity.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2738,7 +2855,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2746,7 +2864,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2754,7 +2873,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2762,7 +2882,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2770,7 +2891,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2778,7 +2900,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2786,7 +2909,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Chip extends PreactCustomElement implements ChipProps {\n  accessor color: ChipProps['color'];\n  accessor accessibilityLabel: ChipProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2805,7 +2929,8 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2813,21 +2938,24 @@
           "name": "selected",
           "value": "boolean",
           "description": "Whether the option is currently selected. Use this for controlled components where you manage the selection state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2835,7 +2963,8 @@
           "name": "defaultSelected",
           "value": "boolean",
           "description": "The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2843,7 +2972,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2851,7 +2981,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2859,7 +2990,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2867,7 +2999,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2875,7 +3008,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2883,7 +3017,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2891,7 +3026,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Choice extends PreactCustomElement implements ChoiceProps {\n  accessor disabled: ChoiceProps['disabled'];\n  get selected(): boolean;\n  set selected(selected: ChoiceProps['selected']);\n  accessor value: ChoiceProps['value'];\n  accessor accessibilityLabel: ChoiceProps['accessibilityLabel'];\n  accessor defaultSelected: ChoiceProps['defaultSelected'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -2910,28 +3046,32 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction. When `true`, the `disabled` property on any child choices is ignored.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2939,14 +3079,16 @@
           "name": "multiple",
           "value": "boolean",
           "description": "Whether multiple choices can be selected.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2954,14 +3096,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "values",
           "value": "string[]",
-          "description": "An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected."
+          "description": "An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2969,7 +3113,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2977,7 +3122,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2985,7 +3131,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2993,7 +3140,8 @@
           "name": "__@internals$3@2409",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3001,7 +3149,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3009,7 +3158,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3017,7 +3167,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3025,7 +3176,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3033,7 +3185,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ChoiceList extends BaseClass$3 implements ChoiceListProps {\n  accessor disabled: ChoiceListProps['disabled'];\n  accessor name: ChoiceListProps['name'];\n  accessor error: ChoiceListProps['error'];\n  accessor details: ChoiceListProps['details'];\n  accessor multiple: ChoiceListProps['multiple'];\n  accessor label: ChoiceListProps['label'];\n  accessor labelAccessibilityVisibility: ChoiceListProps['labelAccessibilityVisibility'];\n  get values(): ChoiceListProps['values'];\n  set values(values: ChoiceListProps['values']);\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -3051,14 +3204,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You shouldapply disabled styling as needed."
+          "description": "Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You shouldapply disabled styling as needed.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "loading",
           "value": "boolean",
-          "description": "Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction."
+          "description": "Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3066,21 +3221,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3088,7 +3246,8 @@
           "name": "type",
           "value": "\"button\" | \"reset\" | \"submit\"",
           "description": "The behavior of the button component.\n\n- `button`: Used to indicate the component acts as a button, meaning it has no default action.\n- `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).\n- `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.\n\nThis property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.",
-          "defaultValue": "'button'"
+          "defaultValue": "'button'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3096,7 +3255,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3104,7 +3264,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3112,7 +3273,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3120,7 +3282,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3128,7 +3291,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3136,7 +3300,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3144,7 +3309,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3152,7 +3318,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3160,7 +3327,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3168,7 +3336,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3176,7 +3345,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3184,7 +3354,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3192,7 +3363,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3200,7 +3372,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3208,7 +3381,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3216,7 +3390,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3236,7 +3411,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3244,7 +3420,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3252,7 +3429,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3260,7 +3438,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3268,14 +3447,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3283,7 +3464,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3291,7 +3473,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3299,7 +3482,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3307,7 +3491,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3315,7 +3500,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3323,7 +3509,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3331,7 +3518,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3339,7 +3527,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3347,7 +3536,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3355,21 +3545,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Clickable extends Clickable_base implements ClickableProps {\n  accessor disabled: ClickableProps['disabled'];\n  accessor loading: ClickableProps['loading'];\n  accessor target: ClickableProps['target'];\n  accessor href: ClickableProps['href'];\n  accessor download: ClickableProps['download'];\n  accessor type: ClickableProps['type'];\n  constructor();\n}"
@@ -3388,14 +3581,16 @@
           "name": "color",
           "value": "ColorKeyword",
           "description": "The color emphasis level that controls visual intensity.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3403,7 +3598,8 @@
           "name": "removable",
           "value": "boolean",
           "description": "Whether the chip displays a remove button for dismissal. When clicked, the `remove` callback fires.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3411,7 +3607,8 @@
           "name": "hidden",
           "value": "boolean",
           "description": "Whether the chip is hidden from view. When using controlled component pattern with `removable` chips, update this property when the `remove` event fires. For non-removable chips, manually toggle this property to show or hide the chip.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3419,14 +3616,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the chip is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3434,7 +3633,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3442,7 +3642,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3450,7 +3651,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3458,7 +3660,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3466,7 +3669,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3474,7 +3678,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3482,7 +3687,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3490,21 +3696,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class ClickableChip\n  extends ClickableChip_base\n  implements ClickableChipProps\n{\n  accessor color: ClickableChipProps['color'];\n  accessor accessibilityLabel: ClickableChipProps['accessibilityLabel'];\n  accessor removable: ClickableChipProps['removable'];\n  accessor hidden: ClickableChipProps['hidden'];\n  accessor disabled: ClickableChipProps['disabled'];\n  accessor href: ClickableChipProps['href'];\n  constructor();\n}"
@@ -3523,14 +3732,16 @@
           "name": "alpha",
           "value": "boolean",
           "description": "Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format."
+          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3538,7 +3749,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3546,7 +3758,8 @@
           "name": "setInternalValue",
           "value": "(value: string, normalize: boolean) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3554,35 +3767,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\"",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3590,14 +3808,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3605,7 +3825,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3613,7 +3834,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3621,7 +3843,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3629,7 +3852,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3637,7 +3861,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3645,7 +3870,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3653,21 +3879,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3675,7 +3904,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3683,7 +3913,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3691,7 +3922,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3699,7 +3931,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3707,7 +3940,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3715,7 +3949,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3723,7 +3958,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ColorField\n  extends PreactFieldElement<ColorFieldProps['autocomplete']>\n  implements ColorFieldProps\n{\n  accessor alpha: ColorFieldProps['alpha'];\n  get value(): string;\n  set value(value: string);\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n  /** @private */\n  setInternalValue(value: string, normalize: boolean): void;\n}"
@@ -3742,35 +3978,40 @@
           "name": "alpha",
           "value": "boolean",
           "description": "Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format."
+          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "formResetCallback",
           "value": "() => void",
-          "description": "A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`."
+          "description": "A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3778,7 +4019,8 @@
           "name": "__@internals$2@2510",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3786,7 +4028,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3794,7 +4037,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3802,7 +4046,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3810,7 +4055,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3818,7 +4064,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3826,7 +4073,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3834,7 +4082,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ColorPicker extends BaseClass$2 implements ColorPickerProps {\n  accessor alpha: boolean;\n  accessor name: string;\n  accessor defaultValue: string;\n  get value(): string;\n  set value(value: string);\n  /**\n   * A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`.\n   */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -3853,7 +4102,8 @@
           "name": "allow",
           "value": "string",
           "description": "Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `2024-02--2025`: February 2024 through end of 2025\n- `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3861,7 +4111,8 @@
           "name": "disallow",
           "value": "string",
           "description": "Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `--2024-02`: All dates before February 2024\n- `2024-05-09, 2024-05-11`: May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3869,7 +4120,8 @@
           "name": "allowDays",
           "value": "string",
           "description": "Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (only weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3877,21 +4129,24 @@
           "name": "disallowDays",
           "value": "string",
           "description": "Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (no weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "SetAccessor",
           "name": "view",
           "value": "string",
-          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`."
+          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultView",
           "value": "string",
-          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale."
+          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3899,7 +4154,8 @@
           "name": "autocomplete",
           "value": "DateAutocompleteField",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3907,28 +4163,32 @@
           "name": "defaultValue",
           "value": "string",
           "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3936,14 +4196,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3951,7 +4213,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3959,7 +4222,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3967,7 +4231,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3975,7 +4240,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3983,7 +4249,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3991,7 +4258,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3999,7 +4267,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4007,21 +4276,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4029,7 +4301,8 @@
           "name": "value",
           "value": "string",
           "description": "The currently selected date in `YYYY-MM-DD` format. An empty string means no date is selected.",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4037,7 +4310,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4045,7 +4319,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4053,7 +4328,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4061,7 +4337,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4069,7 +4346,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4077,7 +4355,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4085,7 +4364,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DateField\n  extends PreactFieldElement<DateFieldProps['autocomplete']>\n  implements DateFieldProps\n{\n  accessor allow: DateFieldProps['allow'];\n  accessor disallow: DateFieldProps['disallow'];\n  accessor allowDays: DateFieldProps['allowDays'];\n  accessor disallowDays: DateFieldProps['disallowDays'];\n  set view(view: string);\n  get view(): string;\n  accessor defaultView: DateFieldProps['defaultView'];\n  constructor();\n}"
@@ -4113,14 +4393,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultView",
           "value": "string",
-          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale."
+          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "SetAccessor",
           "name": "view",
           "value": "string",
-          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`."
+          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4128,7 +4410,8 @@
           "name": "allow",
           "value": "string",
           "description": "Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `2024-02--2025`: February 2024 through end of 2025\n- `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4136,7 +4419,8 @@
           "name": "disallow",
           "value": "string",
           "description": "Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `--2024-02`: All dates before February 2024\n- `2024-05-09, 2024-05-11`: May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4144,7 +4428,8 @@
           "name": "allowDays",
           "value": "string",
           "description": "Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (only weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4152,7 +4437,8 @@
           "name": "disallowDays",
           "value": "string",
           "description": "Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (no weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4160,7 +4446,8 @@
           "name": "type",
           "value": "\"single\" | \"range\"",
           "description": "The type of date selection allowed.\n\n- `single`: Select a single date\n- `range`: Select a date range",
-          "defaultValue": "\"single\""
+          "defaultValue": "\"single\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4168,14 +4455,16 @@
           "name": "defaultValue",
           "value": "string",
           "description": "The initially selected date(s) when the component first renders. An empty string means no date is initially selected.\n\n- Single date in `YYYY-MM-DD` format when `type` is set to `\"single\"`\n- Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `\"range\"`",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4183,7 +4472,8 @@
           "name": "value",
           "value": "string",
           "description": "The currently selected date(s). An empty string means no date is selected.\n\n- Single date in `YYYY-MM-DD` format when `type` is set to `\"single\"`\n- Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `\"range\"`",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4191,7 +4481,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4199,7 +4490,8 @@
           "name": "__@dirtyStateSymbol@2554",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4207,7 +4499,8 @@
           "name": "__@internals$1@2553",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4215,7 +4508,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4223,7 +4517,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4231,7 +4526,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4239,7 +4535,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4247,7 +4544,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4255,7 +4553,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4263,7 +4562,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DatePicker extends BaseClass$1 implements DatePickerProps {\n  accessor defaultView: string;\n  set view(view: string);\n  get view(): string;\n  accessor allow: DatePickerProps['allow'];\n  accessor disallow: DatePickerProps['disallow'];\n  accessor allowDays: DatePickerProps['allowDays'];\n  accessor disallowDays: DatePickerProps['disallowDays'];\n  accessor type: DatePickerProps['type'];\n  accessor defaultValue: DatePickerProps['defaultValue'];\n  accessor name: DatePickerProps['name'];\n  set value(value: string);\n  get value(): string;\n  /** @private */\n  [dirtyStateSymbol]: boolean;\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -4282,14 +4582,16 @@
           "name": "accept",
           "value": "string",
           "description": "A string representing the types of files that are accepted by the drop zone. This string is a comma-separated list of unique file type specifiers which can be one of the following:\n- A file extension starting with a period (\".\") character (e.g. .jpg, .pdf, .doc)\n- A valid MIME type string with no extensions\n\nIf omitted, all file types are accepted.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or contents of the item. When set, it will be announced to buyers using assistive technologies and will provide them with more context."
+          "description": "A label that describes the purpose or contents of the item. When set, it will be announced to buyers using assistive technologies and will provide them with more context.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4297,21 +4599,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4319,7 +4624,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4327,14 +4633,16 @@
           "name": "multiple",
           "value": "boolean",
           "description": "Whether multiple files can be selected or dropped at once.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4342,7 +4650,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4350,7 +4659,8 @@
           "name": "value",
           "value": "string",
           "description": "This sets the input value for a file type, which cannot be set programatically, so it can only be reset.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4358,7 +4668,8 @@
           "name": "files",
           "value": "File[]",
           "description": "An array of File objects representing the files currently selected by the user.\n\nThis property is read-only and cannot be directly modified. To clear the selected files, set the `value` prop to an empty string or null.",
-          "defaultValue": "[]"
+          "defaultValue": "[]",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4366,7 +4677,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4374,7 +4686,8 @@
           "name": "__@setFiles@2589",
           "value": "(files: File[]) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4382,7 +4695,8 @@
           "name": "__@getFileInput@2591",
           "value": "() => HTMLInputElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4390,7 +4704,8 @@
           "name": "__@internals@2590",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4398,7 +4713,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4406,7 +4722,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4414,7 +4731,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4422,7 +4740,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4430,7 +4749,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4438,7 +4758,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4446,7 +4767,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DropZone extends BaseClass implements DropZoneProps {\n  accessor accept: DropZoneProps['accept'];\n  accessor accessibilityLabel: DropZoneProps['accessibilityLabel'];\n  accessor disabled: DropZoneProps['disabled'];\n  accessor error: DropZoneProps['error'];\n  accessor label: DropZoneProps['label'];\n  accessor labelAccessibilityVisibility: DropZoneProps['labelAccessibilityVisibility'];\n  accessor multiple: DropZoneProps['multiple'];\n  accessor name: DropZoneProps['name'];\n  accessor required: DropZoneProps['required'];\n  get value(): string;\n  /** This sets the input value for a file type, which cannot be set programatically, so it can only be reset. */\n  set value(value: '' | null);\n  get files(): File[];\n  set files(files: File[]);\n  /** @private */\n  [setFiles](files: File[]): void;\n  /** @private */\n  [getFileInput](): ReplaceType<\n    Element | null | undefined,\n    Element,\n    HTMLInputElement\n  >;\n\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -4465,7 +4787,8 @@
           "name": "direction",
           "value": "\"inline\" | \"block\"",
           "description": "The orientation of the divider line, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).\n\n- `inline`: Horizontal divider for separating vertically stacked content\n- `block`: Vertical divider for separating horizontally arranged content",
-          "defaultValue": "'inline'"
+          "defaultValue": "'inline'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4473,7 +4796,8 @@
           "name": "color",
           "value": "\"base\" | \"strong\"",
           "description": "The visual prominence of the divider line.\n\n- `base`: Standard divider for most separations (default)\n- `strong`: More prominent divider for major section breaks",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4481,7 +4805,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4489,7 +4814,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4497,7 +4823,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4505,7 +4832,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4513,7 +4841,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4521,7 +4850,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4529,7 +4859,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Divider extends PreactCustomElement implements DividerProps {\n  accessor direction: DividerProps['direction'];\n  accessor color: DividerProps['color'];\n  constructor();\n}"
@@ -4548,7 +4879,8 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | EmailAutocompleteField | `section-${string} email` | `section-${string} home email` | `section-${string} mobile email` | `section-${string} fax email` | `section-${string} pager email` | \"shipping email\" | \"shipping home email\" | \"shipping mobile email\" | ... 16 more ... | `section-${string} billing p...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4556,7 +4888,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4564,42 +4897,48 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing."
+          "description": "The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4607,14 +4946,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4622,7 +4963,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4630,7 +4972,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4638,7 +4981,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4646,7 +4990,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4654,7 +4999,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4662,7 +5008,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4670,7 +5017,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4678,21 +5026,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4700,7 +5051,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4708,7 +5060,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4716,7 +5069,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4724,7 +5078,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4732,7 +5087,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4740,7 +5096,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4748,7 +5105,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class EmailField\n  extends PreactFieldElement<EmailFieldProps['autocomplete']>\n  implements EmailFieldProps\n{\n  accessor autocomplete: EmailFieldProps['autocomplete'];\n  accessor maxLength: EmailFieldProps['maxLength'];\n  accessor minLength: EmailFieldProps['minLength'];\n  /**\n   * The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -4777,7 +5135,8 @@
           "name": "gridTemplateColumns",
           "value": "string",
           "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4785,7 +5144,8 @@
           "name": "gridTemplateRows",
           "value": "string",
           "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4793,7 +5153,8 @@
           "name": "justifyItems",
           "value": "\"\" | JustifyItemsKeyword",
           "description": "Aligns the grid items along the inline axis.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4801,7 +5162,8 @@
           "name": "alignItems",
           "value": "\"\" | AlignItemsKeyword",
           "description": "Aligns the grid items along the block axis.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4809,7 +5171,8 @@
           "name": "placeItems",
           "value": "AlignItemsKeyword | \"normal normal\" | \"normal stretch\" | \"normal baseline\" | \"normal first baseline\" | \"normal last baseline\" | \"normal start\" | \"normal end\" | ... 188 more ... | \"safe center safe center\"",
           "description": "A shorthand property for `justify-items` and `align-items`.",
-          "defaultValue": "'normal normal'"
+          "defaultValue": "'normal normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4817,7 +5180,8 @@
           "name": "justifyContent",
           "value": "\"\" | JustifyContentKeyword",
           "description": "Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4825,7 +5189,8 @@
           "name": "alignContent",
           "value": "\"\" | AlignContentKeyword",
           "description": "Aligns the grid along the block axis. This overrides the block value of `placeContent`.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4833,7 +5198,8 @@
           "name": "placeContent",
           "value": "\"normal normal\" | \"normal stretch\" | \"normal start\" | \"normal end\" | \"normal center\" | \"normal unsafe start\" | \"normal unsafe end\" | \"normal unsafe center\" | \"normal safe start\" | ... 229 more ... | \"space-evenly space-evenly\"",
           "description": "A shorthand property for `justify-content` and `align-content`.",
-          "defaultValue": "'normal normal'"
+          "defaultValue": "'normal normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4841,7 +5207,8 @@
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
           "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4849,7 +5216,8 @@
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4857,7 +5225,8 @@
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4865,7 +5234,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4873,7 +5243,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4881,7 +5252,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4889,7 +5261,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4897,7 +5270,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4905,7 +5279,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4913,7 +5288,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4921,7 +5297,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4929,7 +5306,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4937,7 +5315,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4945,7 +5324,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4953,7 +5333,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4961,7 +5342,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4969,7 +5351,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4977,7 +5360,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4985,7 +5369,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5005,7 +5390,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5013,7 +5399,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5021,7 +5408,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5029,7 +5417,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5037,14 +5426,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5052,7 +5443,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5060,7 +5452,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5068,7 +5461,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5076,7 +5470,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5084,7 +5479,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5092,7 +5488,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5100,7 +5497,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5108,7 +5506,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5116,7 +5515,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Grid extends BoxElement implements GridProps {\n  constructor();\n  accessor gridTemplateColumns: GridProps['gridTemplateColumns'];\n  accessor gridTemplateRows: GridProps['gridTemplateRows'];\n  accessor justifyItems: GridProps['justifyItems'];\n  accessor alignItems: GridProps['alignItems'];\n  accessor placeItems: GridProps['placeItems'];\n  accessor justifyContent: GridProps['justifyContent'];\n  accessor alignContent: GridProps['alignContent'];\n  accessor placeContent: GridProps['placeContent'];\n  accessor gap: GridProps['gap'];\n  accessor rowGap: GridProps['rowGap'];\n  accessor columnGap: GridProps['columnGap'];\n}"
@@ -5225,7 +5625,8 @@
           "name": "gridColumn",
           "value": "\"auto\" | `span ${number}`",
           "description": "The number of columns the item will span across.\n\nLearn more about the [grid-column property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5233,7 +5634,8 @@
           "name": "gridRow",
           "value": "\"auto\" | `span ${number}`",
           "description": "The number of rows the item will span across.\n\nLearn more about the [grid-row property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5241,7 +5643,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5249,7 +5652,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5257,7 +5661,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5265,7 +5670,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5273,7 +5679,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5281,7 +5688,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5289,7 +5697,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5297,7 +5706,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5305,7 +5715,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5313,7 +5724,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5321,7 +5733,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5329,7 +5742,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5337,7 +5751,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5345,7 +5760,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5353,7 +5769,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5361,7 +5778,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5381,7 +5799,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5389,7 +5808,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5397,7 +5817,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5405,7 +5826,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5413,14 +5835,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5428,7 +5852,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5436,7 +5861,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5444,7 +5870,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5452,7 +5879,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5460,7 +5888,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5468,7 +5897,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5476,7 +5906,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5484,7 +5915,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5492,7 +5924,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class GridItem extends BoxElement implements GridItemProps {\n  accessor gridColumn: GridItemProps['gridColumn'];\n  accessor gridRow: GridItemProps['gridRow'];\n  constructor();\n}"
@@ -5511,7 +5944,8 @@
           "name": "accessibilityRole",
           "value": "\"none\" | \"presentation\" | \"heading\"",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.\n\n- `none`: Completely hides the element and its content from assistive technologies\n- `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.\n- `img`: Identifies the element as an image that conveys meaningful information to users.",
-          "defaultValue": "'heading'"
+          "defaultValue": "'heading'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5519,7 +5953,8 @@
           "name": "lineClamp",
           "value": "number",
           "description": "The maximum number of lines to display before truncating the text content.\n\nLearn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).",
-          "defaultValue": "Infinity - no truncation is applied"
+          "defaultValue": "Infinity - no truncation is applied",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5527,7 +5962,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5535,7 +5971,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5543,7 +5980,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5551,7 +5989,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5559,7 +5998,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5567,7 +6007,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5575,7 +6016,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5583,7 +6025,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Heading extends PreactCustomElement implements HeadingProps {\n  accessor accessibilityRole: HeadingProps['accessibilityRole'];\n  accessor lineClamp: HeadingProps['lineClamp'];\n  accessor accessibilityVisibility: HeadingProps['accessibilityVisibility'];\n  constructor();\n}"
@@ -5602,7 +6045,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5610,14 +6054,16 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.\n- `caution`: Advisory notices that need attention.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "type",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "The icon to display from the icon library.\n\nSet to a valid icon name to display that icon. To hide the icon completely, use an empty string `''`. To reserve the icon's space without displaying an icon, use `'empty'`."
+          "description": "The icon to display from the icon library.\n\nSet to a valid icon name to display that icon. To hide the icon completely, use an empty string `''`. To reserve the icon's space without displaying an icon, use `'empty'`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5625,14 +6071,16 @@
           "name": "size",
           "value": "\"small\" | \"base\"",
           "description": "The size of the icon.\n\n- `small`: Smaller icon suitable for inline use within text or compact UI elements.\n- `base`: Default size that works well for standalone icons and standard use cases.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5640,7 +6088,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5648,7 +6097,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5656,7 +6106,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5664,7 +6115,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5672,7 +6124,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5680,7 +6133,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5688,7 +6142,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Icon extends PreactCustomElement implements IconProps {\n  accessor color: IconProps['color'];\n  accessor tone: IconProps['tone'];\n  accessor type: IconProps['type'];\n  accessor size: IconProps['size'];\n  accessor interestFor: string;\n  constructor();\n}"
@@ -5706,21 +6161,24 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered."
+          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "srcSet",
           "value": "string",
-          "description": "A set of image sources and their width or pixel density descriptors. This overrides the `src` property.\n\nLearn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset)."
+          "description": "A set of image sources and their width or pixel density descriptors. This overrides the `src` property.\n\nLearn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "sizes",
           "value": "string",
-          "description": "A set of media conditions and their corresponding sizes.\n\nLearn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes)."
+          "description": "A set of media conditions and their corresponding sizes.\n\nLearn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5728,7 +6186,8 @@
           "name": "alt",
           "value": "string",
           "description": "Alternative text that describes the image for accessibility.\n\nProvides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
-          "defaultValue": "``"
+          "defaultValue": "``",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5736,7 +6195,8 @@
           "name": "aspectRatio",
           "value": "`${number}` | `${number}/${number}` | `${number}/ ${number}` | `${number} /${number}` | `${number} / ${number}`",
           "description": "The aspect ratio of the image.\n\nThe rendering of the image will depend on the `inlineSize` value:\n\n- `inlineSize=\"fill\"`: the aspect ratio will be respected and the image will take the necessary space.\n- `inlineSize=\"auto\"`: the image will not render until it has loaded and the aspect ratio will be ignored.\n\nFor example, if the value is set as `50 / 100`, the getter returns `50 / 100`. If the value is set as `0.5`, the getter returns `0.5 / 1`.\n\nLearn more about the [aspect-ratio property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).",
-          "defaultValue": "'1/1'"
+          "defaultValue": "'1/1'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5744,7 +6204,8 @@
           "name": "objectFit",
           "value": "\"contain\" | \"cover\"",
           "description": "The image resizing behavior to fit within its container.\n\n- `contain`: Scales the image to fit within the container while maintaining its aspect ratio. The entire image is visible, but might leave empty space.\n- `cover`: Scales the image to fill the entire container while maintaining its aspect ratio. The image might be cropped to fit.\n\nThe image is always positioned in the center of the container.\n\nLearn more about the [object-fit property](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).",
-          "defaultValue": "'contain'"
+          "defaultValue": "'contain'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5752,7 +6213,8 @@
           "name": "loading",
           "value": "\"eager\" | \"lazy\"",
           "description": "The loading strategy for the image.\n\n- `eager`: Immediately loads the image, irrespective of its position within the visible viewport.\n- `lazy`: Delays loading the image until it approaches a specified distance from the viewport.\n\nLearn more about the [loading attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading).",
-          "defaultValue": "'eager'"
+          "defaultValue": "'eager'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5760,7 +6222,8 @@
           "name": "accessibilityRole",
           "value": "\"none\" | \"presentation\" | \"img\"",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.\n\n- `none`: Completely hides the element and its content from assistive technologies\n- `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.\n- `img`: Identifies the element as an image that conveys meaningful information to users.",
-          "defaultValue": "'img'"
+          "defaultValue": "'img'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5768,7 +6231,8 @@
           "name": "inlineSize",
           "value": "\"auto\" | \"fill\"",
           "description": "The displayed inline width of the image.\n\n- `fill`: the image will takes up 100% of the available inline size.\n- `auto`: the image will be displayed at its natural size.\n\nLearn more about the [width attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).",
-          "defaultValue": "'fill'"
+          "defaultValue": "'fill'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5788,7 +6252,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5796,7 +6261,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border around the image. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5804,7 +6270,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border around the image, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5812,7 +6279,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border around the image using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5820,7 +6288,8 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the image's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5828,7 +6297,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5836,7 +6306,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5844,7 +6315,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5852,7 +6324,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5860,7 +6333,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5868,7 +6342,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5876,7 +6351,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Image extends PreactCustomElement implements ImageProps {\n  accessor src: ImageProps['src'];\n  accessor srcSet: ImageProps['srcSet'];\n  accessor sizes: ImageProps['sizes'];\n  accessor alt: ImageProps['alt'];\n  accessor aspectRatio: ImageProps['aspectRatio'];\n  accessor objectFit: ImageProps['objectFit'];\n  accessor loading: ImageProps['loading'];\n  accessor accessibilityRole: ImageProps['accessibilityRole'];\n  accessor inlineSize: ImageProps['inlineSize'];\n  /**\n   * A border applied around the image using shorthand syntax to specify width, color, and style in a single property.\n   */\n  accessor border: ImageProps['border'];\n  /**\n   * The thickness of the border around the image. When set, this overrides the width value specified in the `border` property.\n   */\n  accessor borderWidth: ImageProps['borderWidth'];\n  /**\n   * The visual style of the border around the image, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.\n   */\n  accessor borderStyle: ImageProps['borderStyle'];\n  /**\n   * The color of the border around the image using the design system's color scale. When set, this overrides the color value specified in the `border` property.\n   */\n  accessor borderColor: ImageProps['borderColor'];\n  /**\n   * The roundedness of the image's corners using the design system's radius scale.\n   */\n  accessor borderRadius: ImageProps['borderRadius'];\n  constructor();\n}"
@@ -5895,21 +6371,24 @@
           "name": "tone",
           "value": "\"critical\" | \"auto\" | \"neutral\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5917,21 +6396,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "lang",
           "value": "string",
-          "description": "The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)."
+          "description": "The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5939,7 +6421,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5947,7 +6430,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5955,7 +6439,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5963,7 +6448,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5971,7 +6457,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5979,7 +6466,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5987,7 +6475,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5995,21 +6484,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Link extends Link_base implements LinkProps {\n  accessor tone: LinkProps['tone'];\n  accessor accessibilityLabel: LinkProps['accessibilityLabel'];\n  accessor href: LinkProps['href'];\n  accessor target: LinkProps['target'];\n  accessor download: LinkProps['download'];\n  accessor lang: LinkProps['lang'];\n  constructor();\n}"
@@ -6028,7 +6520,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6036,7 +6529,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6044,7 +6538,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6052,7 +6547,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6060,7 +6556,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6068,7 +6565,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6076,7 +6574,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ListItem extends PreactCustomElement implements ListItemProps {\n  constructor();\n}"
@@ -6094,7 +6593,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6102,7 +6602,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6110,7 +6611,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6118,7 +6620,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6126,7 +6629,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6134,7 +6638,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6142,7 +6647,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6150,7 +6656,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6158,7 +6665,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6166,7 +6674,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6174,7 +6683,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Menu extends PreactOverlayElement implements MenuProps {\n  accessor accessibilityLabel: string;\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -6193,7 +6703,8 @@
           "name": "max",
           "value": "number",
           "description": "The highest decimal or integer value accepted for the field. When used with `step`, the value rounds down to the maximum number.\n\nUsers can still type values higher than the maximum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6201,14 +6712,16 @@
           "name": "min",
           "value": "number",
           "description": "The lowest decimal or integer value accepted for the field. When used with `step`, the value rounds up to the minimum number.\n\nUsers can still type values lower than the minimum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "-Infinity"
+          "defaultValue": "-Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency."
+          "description": "The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6216,35 +6729,40 @@
           "name": "autocomplete",
           "value": "string",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6252,14 +6770,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6267,7 +6787,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6275,7 +6796,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6283,7 +6805,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6291,7 +6814,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6299,7 +6823,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6307,7 +6832,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6315,7 +6841,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6323,21 +6850,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6345,7 +6875,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6353,7 +6884,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6361,7 +6893,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6369,7 +6902,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6377,7 +6911,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6385,7 +6920,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6393,7 +6929,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class MoneyField\n  extends PreactFieldElement<MoneyFieldProps['autocomplete']>\n  implements MoneyFieldProps\n{\n  accessor max: MoneyFieldProps['max'];\n  accessor min: MoneyFieldProps['min'];\n  /**\n   * The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -6411,7 +6948,8 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer)."
+          "description": "The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6419,7 +6957,8 @@
           "name": "inputMode",
           "value": "\"decimal\" | \"numeric\"",
           "description": "The type of virtual keyboard to display on mobile devices.\n\n- `decimal`: Shows a numeric keyboard with a decimal point, suitable for prices or measurements.\n- `numeric`: Shows a numeric keyboard without a decimal point, suitable for whole numbers like quantities.\n\nLearn more about the [inputmode attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).",
-          "defaultValue": "'decimal'"
+          "defaultValue": "'decimal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6427,7 +6966,8 @@
           "name": "step",
           "value": "number",
           "description": "The amount the value can increase or decrease by. This can be an integer or decimal. If a `max` or `min` is specified with `step` when increasing/decreasing the value via the buttons, the final value will always round to the `max` or `min` rather than the closest valid amount.",
-          "defaultValue": "1"
+          "defaultValue": "1",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6435,7 +6975,8 @@
           "name": "max",
           "value": "number",
           "description": "The highest decimal or integer value accepted for the field. When used with `step`, the value rounds down to the maximum number.\n\nUsers can still type values higher than the maximum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6443,7 +6984,8 @@
           "name": "min",
           "value": "number",
           "description": "The lowest decimal or integer value accepted for the field. When used with `step`, the value rounds up to the minimum number.\n\nUsers can still type values lower than the minimum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "-Infinity"
+          "defaultValue": "-Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6451,7 +6993,8 @@
           "name": "prefix",
           "value": "string",
           "description": "A non-editable text value displayed immediately before the editable portion of the field. This is useful for displaying an implied part of the value, such as `https://` or `+353`.\n\nThis text can't be edited by the user and is not included in the field's value. The prefix might not appear until the user interacts with the field. For example, an inline label might occupy the prefix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6459,7 +7002,8 @@
           "name": "suffix",
           "value": "string",
           "description": "A non-editable text value displayed immediately after the editable portion of the field. This is useful for displaying an implied part of the value, such as `@shopify.com` or `%`.\n\nThis text can't be edited by the user and is not included in the field's value. The suffix might not appear until the user interacts with the field. For example, an inline label might occupy the suffix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6467,35 +7011,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | NumberAutocompleteField | `section-${string} one-time-code` | `section-${string} cc-number` | `section-${string} cc-csc` | \"shipping one-time-code\" | \"shipping cc-number\" | \"shipping cc-csc\" | \"billing one-time-code\" | ... 7 more ... | `section-${string} billing cc-csc`",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6503,14 +7052,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6518,7 +7069,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6526,7 +7078,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6534,7 +7087,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6542,7 +7096,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6550,7 +7105,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6558,7 +7114,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6566,7 +7123,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6574,21 +7132,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6596,7 +7157,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6604,7 +7166,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6612,7 +7175,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6620,7 +7184,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6628,7 +7193,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6636,7 +7202,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6644,7 +7211,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class NumberField\n  extends PreactFieldElement<NumberFieldProps['autocomplete']>\n  implements NumberFieldProps\n{\n  /**\n   * The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer).\n   */\n  get value(): string;\n  set value(value: string);\n  accessor inputMode: NumberFieldProps['inputMode'];\n  accessor step: NumberFieldProps['step'];\n  accessor max: NumberFieldProps['max'];\n  accessor min: NumberFieldProps['min'];\n  accessor prefix: NumberFieldProps['prefix'];\n  accessor suffix: NumberFieldProps['suffix'];\n  constructor();\n}"
@@ -6673,7 +7241,8 @@
           "name": "selected",
           "value": "boolean",
           "description": "Whether the option is currently selected. Use this for controlled components where you manage the selection state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6681,14 +7250,16 @@
           "name": "defaultSelected",
           "value": "boolean",
           "description": "The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6696,7 +7267,8 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6704,7 +7276,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6712,7 +7285,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6720,7 +7294,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6728,7 +7303,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6736,7 +7312,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6744,7 +7321,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6752,7 +7330,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Option extends PreactCustomElement implements OptionProps {\n  accessor selected: OptionProps['selected'];\n  accessor defaultSelected: OptionProps['defaultSelected'];\n  accessor value: OptionProps['value'];\n  accessor disabled: OptionProps['disabled'];\n  constructor();\n}"
@@ -6771,14 +7350,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the options within this group can be selected or not.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The user-facing label for this group of options."
+          "description": "The user-facing label for this group of options.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6786,7 +7367,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6794,7 +7376,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6802,7 +7385,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6810,7 +7394,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6818,7 +7403,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6826,7 +7412,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6834,7 +7421,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class OptionGroup\n  extends PreactCustomElement\n  implements OptionGroupProps\n{\n  accessor disabled: OptionGroupProps['disabled'];\n  accessor label: OptionGroupProps['label'];\n  constructor();\n}"
@@ -6853,7 +7441,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6861,7 +7450,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6869,7 +7459,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6877,7 +7468,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6885,7 +7477,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6893,7 +7486,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6901,7 +7495,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class OrderedList\n  extends PreactCustomElement\n  implements OrderedListProps\n{\n  constructor();\n}"
@@ -6920,7 +7515,8 @@
           "name": "fontVariantNumeric",
           "value": "\"auto\" | \"normal\" | \"tabular-nums\"",
           "description": "The rendering style for numbers in the font.\n\n- `auto`: Inherits the setting from the parent element.\n- `normal`: Uses the font's default numeric glyphs.\n- `tabular-nums`: Uses fixed-width numeric glyphs, ensuring numbers align vertically in tables or lists.\n\nLearn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6928,7 +7524,8 @@
           "name": "lineClamp",
           "value": "number",
           "description": "The maximum number of lines to display before truncating the text content.\n\nLearn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).",
-          "defaultValue": "Infinity - no truncation is applied"
+          "defaultValue": "Infinity - no truncation is applied",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6936,7 +7533,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"caution\"",
           "description": "The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.\n\n- `info`: Informational content or helpful tips (blue).\n- `success`: Positive outcomes or successful states (green).\n- `warning`: Important warnings about potential issues (orange).\n- `critical`: Urgent problems or destructive actions (red).\n- `caution`: Advisory notices that need attention (yellow).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6944,7 +7542,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6952,7 +7551,8 @@
           "name": "dir",
           "value": "\"\" | \"auto\" | \"ltr\" | \"rtl\"",
           "description": "Indicates the directionality of the element’s text.\n\n- `\"\"`: The direction is inherited from parent elements (equivalent to not setting the attribute).\n- `auto`: The user agent determines the direction based on the content.\n- `ltr`: The languages written from left to right (such as English).\n- `rtl`: The languages written from right to left (such as Arabic).\n\nLearn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6960,7 +7560,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6968,7 +7569,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6976,7 +7578,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6984,7 +7587,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6992,7 +7596,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7000,7 +7605,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7008,7 +7614,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7016,7 +7623,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Paragraph extends PreactCustomElement implements ParagraphProps {\n  accessor fontVariantNumeric: ParagraphProps['fontVariantNumeric'];\n  accessor lineClamp: ParagraphProps['lineClamp'];\n  /**\n   * The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.\n   *\n   * - `info`: Informational content or helpful tips (blue).\n   * - `success`: Positive outcomes or successful states (green).\n   * - `warning`: Important warnings about potential issues (orange).\n   * - `critical`: Urgent problems or destructive actions (red).\n   * - `caution`: Advisory notices that need attention (yellow).\n   */\n  accessor tone: ParagraphProps['tone'];\n\n  accessor color: ParagraphProps['color'];\n  accessor dir: ParagraphProps['dir'];\n  accessor accessibilityVisibility: ParagraphProps['accessibilityVisibility'];\n  constructor();\n}"
@@ -7035,7 +7643,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7043,14 +7652,16 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security."
+          "description": "The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7058,35 +7669,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | PasswordAutocompleteField | `section-${string} current-password` | `section-${string} new-password` | \"shipping current-password\" | \"shipping new-password\" | \"billing current-password\" | \"billing new-password\" | `section-${string} shipping current-password` | `section-${string} shipping new-password` | `section-${string} billing current-password` | `section-${string} billing new-password`",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7094,14 +7710,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7109,7 +7727,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7117,7 +7736,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7125,7 +7745,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7133,7 +7754,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7141,7 +7763,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7149,7 +7772,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7157,7 +7781,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7165,21 +7790,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7187,7 +7815,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7195,7 +7824,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7203,7 +7833,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7211,7 +7842,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7219,7 +7851,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7227,7 +7860,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7235,7 +7869,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class PasswordField\n  extends PreactFieldElement<PasswordFieldProps['autocomplete']>\n  implements PasswordFieldProps\n{\n  accessor maxLength: PasswordFieldProps['maxLength'];\n  accessor minLength: PasswordFieldProps['minLength'];\n  /**\n   * The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -7264,7 +7899,8 @@
           "name": "containerName",
           "value": "string",
           "description": "An identifier for this container that you can reference in CSS container queries to apply styles based on this specific container's size.\n\nAll query container components automatically receive a container name of `s-default`. You can omit the container name in your queries, so `@container (inline-size <= 300px)` is equivalent to `@container s-default (inline-size <= 300px)`.\n\nWhen you provide a custom `containerName`, it's added alongside `s-default`. For example, `containerName=\"product-card\"` results in `s-default product-card` being set on the `container-name` CSS property, allowing you to target this container with `@container product-card (inline-size <= 300px)`.\n\nLearn more about the [container-name property](https://developer.mozilla.org/en-US/docs/Web/CSS/container-name).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7272,7 +7908,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7280,7 +7917,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7288,7 +7926,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7296,7 +7935,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7304,7 +7944,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7312,7 +7953,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7320,7 +7962,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class QueryContainer\n  extends PreactCustomElement\n  implements QueryContainerProps\n{\n  accessor containerName: QueryContainerProps['containerName'];\n  /** @private */\n  static globalStylesApplied: boolean;\n  constructor();\n}"
@@ -7339,7 +7982,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7347,14 +7991,16 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7362,35 +8008,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7398,14 +8049,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7413,7 +8066,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7421,7 +8075,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7429,7 +8084,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7437,7 +8093,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7445,7 +8102,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7453,7 +8111,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7461,7 +8120,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7469,21 +8129,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7491,7 +8154,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7499,7 +8163,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7507,7 +8172,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7515,7 +8181,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7523,7 +8190,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7531,7 +8199,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7539,7 +8208,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class SearchField\n  extends PreactFieldElement<SearchFieldProps['autocomplete']>\n  implements SearchFieldProps\n{\n  accessor maxLength: SearchFieldProps['maxLength'];\n  accessor minLength: SearchFieldProps['minLength'];\n  /**\n   * The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -7568,21 +8238,24 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure."
+          "description": "The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7590,7 +8263,8 @@
           "name": "padding",
           "value": "\"base\" | \"none\"",
           "description": "The padding applied to all edges of the element.\n\n- `base`: applies padding that is appropriate for the element. Note that it might result in no padding if this is the right design decision in a particular context.\n- `none`: removes all padding from the element. This can be useful when elements inside the section need to span to the edge of the section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base' to bring back the desired padding for the rest of the content.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7598,7 +8272,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7606,7 +8281,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7614,7 +8290,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7622,7 +8299,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7630,7 +8308,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7638,7 +8317,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Section extends PreactCustomElement implements SectionProps {\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  accessor accessibilityLabel: SectionProps['accessibilityLabel'];\n  accessor heading: SectionProps['heading'];\n  accessor padding: SectionProps['padding'];\n}"
@@ -7656,35 +8336,40 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7692,7 +8377,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7700,7 +8386,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7708,7 +8395,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7716,14 +8404,16 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "A lifecycle callback that fires when the component is removed from the DOM. Performs cleanup operations.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component."
+          "description": "The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7731,7 +8421,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7739,7 +8430,8 @@
           "name": "__@usedFirstOptionSymbol@3004",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7747,7 +8439,8 @@
           "name": "__@hasInitialValueSymbol@3005",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7755,21 +8448,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7777,7 +8473,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7785,7 +8482,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7793,7 +8491,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7801,7 +8500,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7809,7 +8509,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7817,7 +8518,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Select extends PreactInputElement implements SelectProps {\n  accessor icon: SelectProps['icon'];\n  accessor details: SelectProps['details'];\n  accessor error: SelectProps['error'];\n  accessor label: SelectProps['label'];\n  accessor placeholder: SelectProps['placeholder'];\n  accessor required: SelectProps['required'];\n  accessor labelAccessibilityVisibility: SelectProps['labelAccessibilityVisibility'];\n  /** @private */\n  connectedCallback(): void;\n  /**\n   * A lifecycle callback that fires when the component is removed from the DOM. Performs cleanup operations.\n   * @private\n   */\n  disconnectedCallback(): void;\n  constructor();\n  /**\n   * A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n   *\n   * This is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.\n   * @private\n   */\n  [usedFirstOptionSymbol]: boolean;\n  /**\n   * @private\n   */\n  [hasInitialValueSymbol]: boolean;\n  /**\n   * The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component.\n   */\n  get value(): string;\n  set value(value: string);\n  /** @private */\n  formResetCallback(): void;\n}"
@@ -7835,7 +8537,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7843,7 +8546,8 @@
           "name": "size",
           "value": "\"base\" | \"large\" | \"large-100\"",
           "description": "The size of the loading spinner.\n\n- `base`: Default size suitable for inline loading indicators or standard UI contexts.\n- `large`: Larger spinner for more prominent loading states.\n- `large-100`: Extra large spinner for full-page or emphasized loading states.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7851,7 +8555,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7859,7 +8564,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7867,7 +8573,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7875,7 +8582,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7883,7 +8591,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7891,7 +8600,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7899,7 +8609,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Spinner extends PreactCustomElement implements SpinnerProps {\n  accessor accessibilityLabel: string;\n  accessor size: SpinnerProps['size'];\n  constructor();\n}"
@@ -7918,7 +8629,8 @@
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
           "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
-          "defaultValue": "'block'"
+          "defaultValue": "'block'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7926,7 +8638,8 @@
           "name": "justifyContent",
           "value": "JustifyContentKeyword",
           "description": "Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n\nUse this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7934,7 +8647,8 @@
           "name": "alignItems",
           "value": "AlignItemsKeyword",
           "description": "Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n\nUse this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7942,7 +8656,8 @@
           "name": "alignContent",
           "value": "AlignContentKeyword",
           "description": "Controls the distribution of lines along the block axis when content wraps into multiple lines.\n\nThis property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7950,7 +8665,8 @@
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
           "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7958,7 +8674,8 @@
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7966,7 +8683,8 @@
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7974,7 +8692,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7982,7 +8701,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7990,7 +8710,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7998,7 +8719,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8006,7 +8728,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8014,7 +8737,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8022,7 +8746,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8030,7 +8755,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8038,7 +8764,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8046,7 +8773,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8054,7 +8782,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8062,7 +8791,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8070,7 +8800,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8078,7 +8809,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8086,7 +8818,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8094,7 +8827,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8114,7 +8848,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8122,7 +8857,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8130,7 +8866,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8138,7 +8875,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8146,14 +8884,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8161,7 +8901,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8169,7 +8910,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8177,7 +8919,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8185,7 +8928,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8193,7 +8937,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8201,7 +8946,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8209,7 +8955,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8217,7 +8964,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8225,7 +8973,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Stack extends BoxElement implements StackProps {\n  constructor();\n  accessor direction: StackProps['direction'];\n  accessor justifyContent: StackProps['justifyContent'];\n  accessor alignItems: StackProps['alignItems'];\n  accessor alignContent: StackProps['alignContent'];\n  accessor gap: StackProps['gap'];\n  accessor rowGap: StackProps['rowGap'];\n  accessor columnGap: StackProps['columnGap'];\n}"
@@ -8244,7 +8993,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8252,14 +9002,16 @@
           "name": "checked",
           "value": "boolean",
           "description": "Whether the control is currently checked. Use this for controlled components where you manage the checked state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the checkbox is checked.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8267,35 +9019,40 @@
           "name": "defaultChecked",
           "value": "boolean",
           "description": "The initial checked state for uncontrolled components. Use this when you want the control to start checked but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8303,7 +9060,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field needs a value. This requirement adds semantic value to the field, but it will not cause an error to appear automatically. If you want to present an error when this field is empty, you can do so with the `error` property.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8311,7 +9069,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8319,21 +9078,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8341,7 +9103,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8349,7 +9112,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8357,7 +9121,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8365,7 +9130,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8373,7 +9139,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8381,7 +9148,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8389,7 +9157,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8397,7 +9166,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Switch extends PreactCheckboxElement implements SwitchProps {\n  accessor labelAccessibilityVisibility: SwitchProps['labelAccessibilityVisibility'];\n  constructor();\n}"
@@ -8416,7 +9186,8 @@
           "name": "variant",
           "value": "\"auto\" | \"list\"",
           "description": "The layout variant of the table component.\n\n- `list`: Always displays as a list layout.\n- `table`: Always displays as a traditional table layout.\n- `auto`: Automatically displays as a table on wide screens and as a list on narrow screens.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8424,7 +9195,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether the table is in a loading state, such as during initial page load or when loading the next page in a paginated table. When `true`, the table might be in an inert state that prevents user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8432,7 +9204,8 @@
           "name": "paginate",
           "value": "boolean",
           "description": "Whether to use pagination controls.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8440,7 +9213,8 @@
           "name": "hasPreviousPage",
           "value": "boolean",
           "description": "Whether there's a previous page of data.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8448,7 +9222,8 @@
           "name": "hasNextPage",
           "value": "boolean",
           "description": "Whether there's an additional page of data.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8456,7 +9231,8 @@
           "name": "__@actualTableVariantSymbol@3080",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8464,7 +9240,8 @@
           "name": "__@tableHeadersSharedDataSymbol@3081",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8472,7 +9249,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8480,7 +9258,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8488,7 +9267,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8496,7 +9276,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8504,7 +9285,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8512,7 +9294,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8520,7 +9303,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Table extends PreactCustomElement implements TableProps {\n  accessor variant: TableProps['variant'];\n  accessor loading: TableProps['loading'];\n  accessor paginate: TableProps['paginate'];\n  accessor hasPreviousPage: TableProps['hasPreviousPage'];\n  accessor hasNextPage: TableProps['hasNextPage'];\n  /**\n   * @private\n   * The actual table variant, which is either 'table' or 'list'.\n   */\n  [actualTableVariantSymbol]: AddedContext<ActualTableVariant>;\n  /** @private */\n  [tableHeadersSharedDataSymbol]: AddedContext<\n    {\n      listSlot: TableHeaderProps['listSlot'];\n      textContent: string;\n      format: HeaderFormat;\n    }[]\n  >;\n\n  constructor();\n}"
@@ -8607,7 +9391,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8615,7 +9400,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8623,7 +9409,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8631,7 +9418,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8639,7 +9427,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8647,7 +9436,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8655,7 +9445,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableBody extends PreactCustomElement implements TableBodyProps {\n  constructor();\n}"
@@ -8674,7 +9465,8 @@
           "name": "__@headerFormatSymbol@3103",
           "value": "HeaderFormat",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8682,7 +9474,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8690,7 +9483,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8698,7 +9492,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8706,7 +9501,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8714,7 +9510,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8722,7 +9519,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8730,7 +9528,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableCell extends PreactCustomElement implements TableCellProps {\n  constructor();\n  /** @private */\n  get [headerFormatSymbol](): HeaderFormat;\n  /** @private */\n  set [headerFormatSymbol](format: HeaderFormat);\n}"
@@ -8749,14 +9548,16 @@
           "name": "listSlot",
           "value": "ListSlotType",
           "description": "The content designation for this column when the table displays in list variant on mobile devices.",
-          "defaultValue": "'labeled'"
+          "defaultValue": "'labeled'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "format",
           "value": "HeaderFormat",
-          "description": "The format of the column that controls styling and alignment of cell content."
+          "description": "The format of the column that controls styling and alignment of cell content.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8764,7 +9565,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8772,7 +9574,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8780,7 +9583,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8788,7 +9592,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8796,7 +9601,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8804,7 +9610,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8812,7 +9619,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableHeader\n  extends PreactCustomElement\n  implements TableHeaderProps\n{\n  accessor listSlot: TableHeaderProps['listSlot'];\n  accessor format: TableHeaderProps['format'];\n  constructor();\n}"
@@ -8831,7 +9639,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8839,7 +9648,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8847,7 +9657,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8855,7 +9666,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8863,7 +9675,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8871,7 +9684,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8879,7 +9693,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableHeaderRow\n  extends PreactCustomElement\n  implements TableHeaderRowProps\n{\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -8897,7 +9712,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "clickDelegate",
           "value": "string",
-          "description": "The ID of an interactive element, such as `s-link`, in the row that will be the target of the click when the row is clicked. This is the primary action for the row; it should not be used for secondary actions.\n\nThis is a click-only affordance, and does not introduce any keyboard or screen reader affordances. Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally."
+          "description": "The ID of an interactive element, such as `s-link`, in the row that will be the target of the click when the row is clicked. This is the primary action for the row; it should not be used for secondary actions.\n\nThis is a click-only affordance, and does not introduce any keyboard or screen reader affordances. Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8905,7 +9721,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8913,7 +9730,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8921,7 +9739,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8929,7 +9748,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8937,7 +9757,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8945,7 +9766,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8953,7 +9775,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableRow extends PreactCustomElement implements TableRowProps {\n  constructor();\n  accessor clickDelegate: string;\n}"
@@ -8972,7 +9795,8 @@
           "name": "fontVariantNumeric",
           "value": "\"auto\" | \"normal\" | \"tabular-nums\"",
           "description": "The rendering style for numbers in the font.\n\n- `auto`: Inherits the setting from the parent element.\n- `normal`: Uses the font's default numeric glyphs.\n- `tabular-nums`: Uses fixed-width numeric glyphs, ensuring numbers align vertically in tables or lists.\n\nLearn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8980,7 +9804,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8988,7 +9813,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic tone that's applied to the text, which changes its color to convey meaning.\n\n- `info`: Informational content or helpful tips (blue).\n- `success`: Positive outcomes or successful states (green).\n- `warning`: Important warnings about potential issues (orange).\n- `critical`: Urgent problems or destructive actions (red).\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent (gray).\n- `caution`: Advisory notices that need attention (yellow).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8996,7 +9822,8 @@
           "name": "type",
           "value": "\"strong\" | \"generic\" | \"address\" | \"redundant\"",
           "description": "The semantic type and styling treatment for the text content.\n\n- `strong`: Emphasizes the text with strong importance, typically displayed in bold.\n- `generic`: Standard text with no special semantic meaning or styling.\n- `address`: Marks the text as contact information, such as a physical or email address.\n- `redundant`: Indicates the text is redundant or duplicated information for screen reader context.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9004,7 +9831,8 @@
           "name": "dir",
           "value": "\"\" | \"auto\" | \"ltr\" | \"rtl\"",
           "description": "Indicates the directionality of the element’s text.\n\n- `\"\"`: The direction is inherited from parent elements (equivalent to not setting the attribute).\n- `auto`: The user agent determines the direction based on the content.\n- `ltr`: The languages written from left to right (such as English).\n- `rtl`: The languages written from right to left (such as Arabic).\n\nLearn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9012,14 +9840,16 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9027,7 +9857,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9035,7 +9866,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9043,7 +9875,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9051,7 +9884,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9059,7 +9893,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9067,7 +9902,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9075,7 +9911,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Text extends PreactCustomElement implements TextProps {\n  accessor fontVariantNumeric: TextProps['fontVariantNumeric'];\n  accessor color: TextProps['color'];\n  /**\n   * The semantic tone that's applied to the text, which changes its color to convey meaning.\n   *\n   * - `info`: Informational content or helpful tips (blue).\n   * - `success`: Positive outcomes or successful states (green).\n   * - `warning`: Important warnings about potential issues (orange).\n   * - `critical`: Urgent problems or destructive actions (red).\n   * - `auto`: Automatically determined based on context.\n   * - `neutral`: General information without specific intent (gray).\n   * - `caution`: Advisory notices that need attention (yellow).\n   */\n  accessor tone: TextProps['tone'];\n  /**\n   * The semantic type and styling treatment for the text content.\n   *\n   * - `strong`: Emphasizes the text with strong importance, typically displayed in bold.\n   * - `generic`: Standard text with no special semantic meaning or styling.\n   * - `address`: Marks the text as contact information, such as a physical or email address.\n   * - `redundant`: Indicates the text is redundant or duplicated information for screen reader context.\n   */\n  accessor type: TextProps['type'];\n  accessor dir: TextProps['dir'];\n  accessor accessibilityVisibility: TextProps['accessibilityVisibility'];\n  accessor interestFor: string;\n  constructor();\n}"
@@ -9094,7 +9931,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9102,7 +9940,8 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9110,14 +9949,16 @@
           "name": "rows",
           "value": "number",
           "description": "A number of visible text lines.",
-          "defaultValue": "2"
+          "defaultValue": "2",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9125,35 +9966,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9161,14 +10007,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9176,7 +10024,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9184,7 +10033,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9192,7 +10042,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9200,7 +10051,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9208,7 +10060,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9216,7 +10069,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9224,7 +10078,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9232,21 +10087,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9254,7 +10112,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9262,7 +10121,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9270,7 +10130,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9278,7 +10139,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9286,7 +10148,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9294,7 +10157,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9302,7 +10166,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TextArea\n  extends PreactFieldElement<TextAreaProps['autocomplete']>\n  implements TextAreaProps\n{\n  accessor maxLength: TextAreaProps['maxLength'];\n  accessor minLength: TextAreaProps['minLength'];\n  accessor rows: TextAreaProps['rows'];\n  /**\n   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -9321,7 +10186,8 @@
           "name": "icon",
           "value": "\"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 542 more ... | AnyString",
           "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9329,7 +10195,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9337,7 +10204,8 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9345,7 +10213,8 @@
           "name": "prefix",
           "value": "string",
           "description": "A non-editable text value displayed immediately before the editable portion of the field. This is useful for displaying an implied part of the value, such as `https://` or `+353`.\n\nThis text can't be edited by the user and is not included in the field's value. The prefix might not appear until the user interacts with the field. For example, an inline label might occupy the prefix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9353,14 +10222,16 @@
           "name": "suffix",
           "value": "string",
           "description": "A non-editable text value displayed immediately after the editable portion of the field. This is useful for displaying an implied part of the value, such as `@shopify.com` or `%`.\n\nThis text can't be edited by the user and is not included in the field's value. The suffix might not appear until the user interacts with the field. For example, an inline label might occupy the suffix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9368,35 +10239,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9404,14 +10280,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9419,7 +10297,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9427,7 +10306,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9435,7 +10315,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9443,7 +10324,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9451,7 +10333,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9459,7 +10342,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9467,7 +10351,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9475,21 +10360,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9497,7 +10385,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9505,7 +10394,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9513,7 +10403,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9521,7 +10412,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9529,7 +10421,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9537,7 +10430,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9545,7 +10439,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TextField\n  extends PreactFieldElement<TextFieldProps['autocomplete']>\n  implements TextFieldProps\n{\n  accessor icon: TextFieldProps['icon'];\n  accessor maxLength: TextFieldProps['maxLength'];\n  accessor minLength: TextFieldProps['minLength'];\n  accessor prefix: TextFieldProps['prefix'];\n  accessor suffix: TextFieldProps['suffix'];\n  /**\n   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -9563,7 +10458,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered."
+          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9571,7 +10467,8 @@
           "name": "alt",
           "value": "string",
           "description": "Alternative text that describes the image for accessibility.\n\nProvides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
-          "defaultValue": "``"
+          "defaultValue": "``",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9579,7 +10476,8 @@
           "name": "size",
           "value": "\"small\" | \"small-200\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
           "description": "The size of the product thumbnail image.\n\n- `small-200`: Smallest thumbnail size, ideal for compact product lists or tables.\n- `small-100`: Very small thumbnail, suitable for dense layouts.\n- `small`: Small thumbnail for space-constrained contexts.\n- `base`: Default size that balances visibility and space efficiency.\n- `large`: Larger thumbnail for featured products or detailed views.\n- `large-100`: Extra large thumbnail for prominent product display.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9587,7 +10485,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9595,7 +10494,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9603,7 +10503,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9611,7 +10512,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9619,7 +10521,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9627,7 +10530,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9635,7 +10539,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Thumbnail extends PreactCustomElement implements ThumbnailProps {\n  accessor src: ThumbnailProps['src'];\n  accessor alt: ThumbnailProps['alt'];\n  accessor size: ThumbnailProps['size'];\n  constructor();\n}"
@@ -9654,7 +10559,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9662,7 +10568,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9670,7 +10577,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9678,7 +10586,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9686,7 +10595,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9694,7 +10604,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9702,7 +10613,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9710,7 +10622,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9718,7 +10631,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9726,7 +10640,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Tooltip extends PreactOverlayElement implements TooltipProps {\n  constructor();\n}"
@@ -9745,7 +10660,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9753,7 +10669,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9761,7 +10678,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9769,7 +10687,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9777,7 +10696,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9785,7 +10705,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9793,7 +10714,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class UnorderedList\n  extends PreactCustomElement\n  implements UnorderedListProps\n{\n  constructor();\n}"
@@ -9812,7 +10734,8 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | `section-${string} url` | `section-${string} photo` | `section-${string} impp` | `section-${string} home impp` | `section-${string} mobile impp` | `section-${string} fax impp` | `section-${string} pager impp` | \"shipping url\" | \"shipping photo\" | \"shipping impp\" | \"shipping home impp\" | \"shipping mobi...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9820,7 +10743,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9828,42 +10752,48 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing."
+          "description": "The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9871,14 +10801,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9886,7 +10818,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9894,7 +10827,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9902,7 +10836,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9910,7 +10845,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9918,7 +10854,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9926,7 +10863,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9934,7 +10872,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9942,21 +10881,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9964,7 +10906,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9972,7 +10915,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9980,7 +10924,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9988,7 +10933,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9996,7 +10942,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10004,7 +10951,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10012,7 +10960,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class URLField\n  extends PreactFieldElement<URLFieldProps['autocomplete']>\n  implements URLFieldProps\n{\n  accessor autocomplete: URLFieldProps['autocomplete'];\n  accessor maxLength: URLFieldProps['maxLength'];\n  accessor minLength: URLFieldProps['minLength'];\n  /**\n   * The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -10030,7 +10979,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The text to use as the Action modal's title. If not provided, the name of the extension will be used."
+          "description": "The text to use as the Action modal's title. If not provided, the name of the extension will be used.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10038,7 +10988,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether the action is in a loading state, such as during initial page load or when the action is being opened. When `true`, the action might be in an inert state that prevents user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10046,7 +10997,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10054,7 +11006,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10062,7 +11015,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10070,7 +11024,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10078,7 +11033,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10086,7 +11042,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10094,7 +11051,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminAction\n  extends PreactCustomElement\n  implements AdminActionProps\n{\n  /**\n   * The text to use as the Action modal's title. If not provided, the name of the extension will be used.\n   */\n  heading: string;\n  /**\n   * Whether the action is in a loading state, such as during initial page load or when the action is being opened.\n   * When `true`, the action might be in an inert state that prevents user interaction.\n   */\n  loading: boolean;\n  constructor();\n}"
@@ -10332,14 +11290,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The text displayed as the block's title in the header. If not provided, the extension name will be used."
+          "description": "The text displayed as the block's title in the header. If not provided, the extension name will be used.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "collapsedSummary",
           "value": "string",
-          "description": "The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated."
+          "description": "The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10347,7 +11307,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10355,7 +11316,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10363,7 +11325,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10371,7 +11334,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10379,7 +11343,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10387,7 +11352,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10395,7 +11361,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminBlock\n  extends PreactCustomElement\n  implements AdminBlockProps\n{\n  /**\n   * The text displayed as the block's title in the header. If not provided, the extension name will be used.\n   */\n  heading: string;\n  /**\n   * The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.\n   */\n  collapsedSummary: string;\n  constructor();\n}"
@@ -10414,7 +11381,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10422,7 +11390,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10430,7 +11399,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10438,7 +11408,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10446,7 +11417,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10454,7 +11426,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10462,7 +11435,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Form extends PreactCustomElement implements FormProps {\n  constructor();\n}"
@@ -11001,14 +11975,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers."
+          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "A title that describes the content of the modal."
+          "description": "A title that describes the content of the modal.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11016,7 +11992,8 @@
           "name": "padding",
           "value": "\"base\" | \"none\"",
           "description": "Adjust the padding around the modal content.\n\n`base`: applies padding that is appropriate for the element.\n\n`none`: removes all padding from the element. This can be useful when elements inside the modal need to span to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base' to bring back the desired padding for the rest of the content.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11024,28 +12001,32 @@
           "name": "size",
           "value": "\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
           "description": "The size of the modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "showOverlay",
           "value": "() => void",
-          "description": "A method to programmatically show the overlay."
+          "description": "A method to programmatically show the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "hideOverlay",
           "value": "() => void",
-          "description": "A method to programmatically hide the overlay."
+          "description": "A method to programmatically hide the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "toggleOverlay",
           "value": "() => void",
-          "description": "A method to programmatically toggle the visibility of the overlay."
+          "description": "A method to programmatically toggle the visibility of the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11053,7 +12034,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11061,7 +12043,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11069,7 +12052,8 @@
           "name": "__@abortController@2785",
           "value": "AbortController",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11077,7 +12061,8 @@
           "name": "__@dialog@2779",
           "value": "HTMLDialogElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11085,7 +12070,8 @@
           "name": "__@focusedElement@2781",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11093,7 +12079,8 @@
           "name": "__@nestedModals@2783",
           "value": "Map<Modal, boolean>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11101,7 +12088,8 @@
           "name": "__@childrenRerenderObserver@2787",
           "value": "MutationObserver",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11109,7 +12097,8 @@
           "name": "__@shadowDomRerenderObserver@2788",
           "value": "MutationObserver",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11117,7 +12106,8 @@
           "name": "__@onEscape@2782",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11125,7 +12115,8 @@
           "name": "__@onBackdropClick@2784",
           "value": "(event: MouseEvent) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11133,7 +12124,8 @@
           "name": "__@onChildModalChange@2786",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11141,7 +12133,8 @@
           "name": "__@isOpen@2778",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11149,7 +12142,8 @@
           "name": "__@dismiss@2780",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11157,7 +12151,8 @@
           "name": "__@hasOpenChildModal@2775",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11165,7 +12160,8 @@
           "name": "__@show@2776",
           "value": "() => Promise<void>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11173,7 +12169,8 @@
           "name": "__@hide@2777",
           "value": "() => Promise<void>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11181,7 +12178,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11189,7 +12187,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11197,7 +12196,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11205,7 +12205,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11213,7 +12214,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11221,7 +12223,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11229,7 +12232,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11237,7 +12241,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Modal extends PreactOverlayElement implements ModalProps {\n  accessor accessibilityLabel: ModalProps['accessibilityLabel'];\n  accessor heading: ModalProps['heading'];\n  accessor padding: ModalProps['padding'];\n  accessor size: ModalProps['size'];\n  /** @private */\n  [abortController]: AbortController;\n  /** @private */\n  [dialog]: HTMLDialogElement | null;\n  /** @private */\n  [focusedElement]: HTMLElement | null;\n  /** @private */\n  [nestedModals]: Map<Modal, boolean>;\n  /** @private */\n  [childrenRerenderObserver]: MutationObserver;\n  /** @private */\n  [shadowDomRerenderObserver]: MutationObserver;\n  /** @private */\n  [onEscape]: (event: KeyboardEvent) => void;\n  /** @private */\n  [onBackdropClick]: (event: MouseEvent) => void;\n  /** @private */\n  [onChildModalChange]: EventListenerOrEventListenerObject;\n  /** @private */\n  get [isOpen](): boolean;\n  /** @private */\n  [dismiss](): void;\n  /** @private */\n  get [hasOpenChildModal](): boolean;\n  /** @private */\n  [show](): Promise<void>;\n  /** @private */\n  [hide](): Promise<void>;\n  showOverlay(): void;\n  hideOverlay(): void;\n  toggleOverlay(): void;\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n  constructor();\n}"
@@ -11256,14 +12261,16 @@
           "name": "inlineSize",
           "value": "\"small\" | \"base\" | \"large\"",
           "description": "The inline size of the page\n- `base` corresponds to a set default inline size\n- `large` full width with whitespace",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The main page heading"
+          "description": "The main page heading",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11271,7 +12278,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11279,7 +12287,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11287,7 +12296,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11295,7 +12305,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11303,7 +12314,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11311,7 +12323,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11319,7 +12332,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Page extends PreactCustomElement implements PageProps {\n  accessor inlineSize: PageProps['inlineSize'];\n  accessor heading: PageProps['heading'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -12086,7 +13100,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12094,7 +13109,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12102,7 +13118,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12110,7 +13127,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12118,7 +13136,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12126,7 +13145,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12134,7 +13154,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class FunctionSettings\n  extends PreactCustomElement\n  implements FunctionSettingsProps\n{\n  constructor();\n}"
@@ -12235,7 +13256,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The `src` URL of the preview and the document to print. If not provided, the preview will show an empty state and the print button will be disabled. HTML, PDFs, and images are supported."
+          "description": "The `src` URL of the preview and the document to print. If not provided, the preview will show an empty state and the print button will be disabled. HTML, PDFs, and images are supported.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12243,7 +13265,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12251,7 +13274,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12259,7 +13283,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12267,7 +13292,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12275,7 +13301,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12283,7 +13310,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12291,7 +13319,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminPrintAction\n  extends PreactCustomElement\n  implements AdminPrintActionProps\n{\n  /**\n   * The `src` URL of the preview and the document to print.\n   * If not provided, the preview will show an empty state and the print button will be disabled.\n   * HTML, PDFs, and images are supported.\n   */\n  src: string;\n  constructor();\n}"
@@ -13234,8 +14263,8 @@
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "IntentAction",
-      "value": "'create' | 'edit'",
-      "description": "The type of operation to perform: creating a new resource or editing an existing one.",
+      "value": "'create' | 'edit' | 'pick'",
+      "description": "The type of operation to perform: creating a new resource, editing an existing one, or picking existing resources.",
       "isPublicDocs": true
     }
   },
@@ -13244,7 +14273,7 @@
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "IntentType",
-      "value": "'shopify/Article' | 'shopify/Catalog' | 'shopify/Collection' | 'shopify/Customer' | 'shopify/Discount' | 'shopify/Location' | 'shopify/Market' | 'shopify/Menu' | 'shopify/MetafieldDefinition' | 'shopify/Metaobject' | 'shopify/MetaobjectDefinition' | 'shopify/Page' | 'shopify/Product' | 'shopify/ProductVariant'",
+      "value": "'shopify/Article' | 'shopify/Catalog' | 'shopify/Collection' | 'shopify/Customer' | 'shopify/Discount' | 'shopify/File' | 'shopify/Location' | 'shopify/Market' | 'shopify/Menu' | 'shopify/MetafieldDefinition' | 'shopify/Metaobject' | 'shopify/MetaobjectDefinition' | 'shopify/Page' | 'shopify/Product' | 'shopify/ProductVariant'",
       "description": "The types of Shopify resources that support intent-based creation and editing workflows.",
       "isPublicDocs": true
     }
@@ -19732,7 +20761,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n\n- `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.\n- `auto`: Automatically sizes based on content and layout constraints.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19740,7 +20770,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum vertical size of the element in standard layouts (min-height in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming smaller than this size along the block axis.\n\nLearn more about the [min-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19748,7 +20779,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum vertical size of the element in standard layouts (max-height in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming larger than this size along the block axis.\n\nLearn more about the [max-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19756,7 +20788,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The horizontal size of the element in standard layouts (width in left-to-right or right-to-left writing modes).\n\nInline size adjusts based on the writing direction: in horizontal layouts, it controls the width; in vertical layouts, it controls the height. This ensures consistent behavior across different text directions.\n\nLearn more about the [inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n\n- `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.\n- `auto`: Automatically sizes based on content and layout constraints.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19764,7 +20797,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum horizontal size of the element in standard layouts (min-width in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming smaller than this size along the inline axis.\n\nLearn more about the [min-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19772,7 +20806,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum horizontal size of the element in standard layouts (max-width in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming larger than this size along the inline axis.\n\nLearn more about the [max-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19780,7 +20815,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19788,7 +20824,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19796,7 +20833,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19804,7 +20842,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19812,7 +20851,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19820,7 +20860,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19828,7 +20869,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19836,7 +20878,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19844,7 +20887,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19852,7 +20896,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Popover\n  extends PreactPopoverElement<typeof tagName$p>\n  implements PopoverProps\n{\n  constructor();\n}"
@@ -20419,14 +21464,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the avatar image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the avatar image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the avatar image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the avatar image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface AvatarEvents {\n  /**\n   * A callback fired when the avatar image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the avatar image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -20463,14 +21510,16 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the banner is hidden."
+          "description": "A callback fired after the banner is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "dismiss",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the banner is dismissed."
+          "description": "A callback fired when the banner is dismissed.",
+          "isOptional": true
         }
       ],
       "value": "export interface BannerEvents {\n  /**\n   * A callback fired when the banner is dismissed.\n   */\n  dismiss: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the banner is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20534,21 +21583,24 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the button loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the button is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the button receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ButtonEvents {\n  /**\n   * A callback fired when the button is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the button loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the button receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20620,14 +21672,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the checkbox value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the checkbox value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the checkbox.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the checkbox.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface CheckboxEvents {\n  /**\n   * A callback fired when the checkbox value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the checkbox.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -20699,14 +21753,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the choice list selection changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the choice list selection changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the choice list.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the choice list.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ChoiceListEvents {\n  /**\n   * A callback fired when the choice list selection changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the choice list.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20743,21 +21799,24 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the component loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the component is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the component receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ClickableEvents {\n  /**\n   * A callback fired when the component is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the component loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the component receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20794,21 +21853,24 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the chip is hidden."
+          "description": "A callback fired after the chip is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the chip is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the chip is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "remove",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the chip is removed."
+          "description": "A callback fired when the chip is removed.",
+          "isOptional": true
         }
       ],
       "value": "export interface ClickableChipEvents {\n  /**\n   * A callback fired when the chip is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the chip is removed.\n   */\n  remove: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the chip is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20853,28 +21915,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the color field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the color field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the color field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the color field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the color field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ColorFieldEvents {\n  /**\n   * A callback fired when the color field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the color field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the color field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the color field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -20892,14 +21958,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the color picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the color picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the color picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the color picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ColorPickerEvents {\n  /**\n   * A callback fired when the color picker value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the color picker.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20917,42 +21985,48 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the date field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the date field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the date field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the date field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the date field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "invalid",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date field value is invalid.\n\nLearn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event)."
+          "description": "A callback fired when the date field value is invalid.\n\nLearn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "viewchange",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the calendar view changes (such as when navigating between months)."
+          "description": "A callback fired when the calendar view changes (such as when navigating between months).",
+          "isOptional": true
         }
       ],
       "value": "export interface DateFieldEvents {\n  /**\n   * A callback fired when the date field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the date field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the date field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the date field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the calendar view changes (such as when navigating between months).\n   */\n  viewchange: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date field value is invalid.\n   *\n   * Learn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event).\n   */\n  invalid: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20970,35 +22044,40 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the date picker loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the date picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the date picker receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the date picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the date picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "viewchange",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the calendar view changes, such as when navigating between months."
+          "description": "A callback fired when the calendar view changes, such as when navigating between months.",
+          "isOptional": true
         }
       ],
       "value": "export interface DatePickerEvents {\n  /**\n   * A callback fired when the calendar view changes, such as when navigating between months.\n   */\n  viewchange: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the date picker.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21016,21 +22095,24 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when the drop zone value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the drop zone value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "droprejected",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when a dropped file is rejected due to file type or size restrictions."
+          "description": "A callback fired when a dropped file is rejected due to file type or size restrictions.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when the user inputs data into the drop zone.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the drop zone.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface DropZoneEvents {\n  /**\n   * A callback fired when the drop zone value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> = null;\n  /**\n   * A callback fired when the user inputs data into the drop zone.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> = null;\n  /**\n   * A callback fired when a dropped file is rejected due to file type or size restrictions.\n   */\n  droprejected: CallbackEventListener<typeof tagName> = null;\n}"
@@ -21067,28 +22149,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the email field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the email field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the email field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the email field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the email field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface EmailFieldEvents {\n  /**\n   * A callback fired when the email field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the email field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the email field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the email field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21163,14 +22249,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ImageEvents {\n  /**\n   * A callback fired when the image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -21188,7 +22276,8 @@
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the link is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the link is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface LinkEvents {\n  /**\n   * A callback fired when the link is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21263,28 +22352,32 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the modal is hidden."
+          "description": "A callback fired after the modal is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftershow",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the modal is shown."
+          "description": "A callback fired after the modal is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "hide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the modal is hidden."
+          "description": "A callback fired when the modal is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "show",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the modal is shown."
+          "description": "A callback fired when the modal is shown.",
+          "isOptional": true
         }
       ],
       "value": "export interface ModalEvents {\n  /**\n   * A callback fired when the modal is hidden.\n   */\n  hide: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the modal is shown.\n   */\n  show: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the modal is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the modal is shown.\n   */\n  aftershow: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21337,28 +22430,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the money field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the money field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the money field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the money field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the money field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface MoneyFieldEvents {\n  /**\n   * A callback fired when the money field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the money field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the money field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the money field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21376,28 +22473,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the number field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the number field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the number field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the number field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the number field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface NumberFieldEvents {\n  /**\n   * A callback fired when the number field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the number field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the number field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the number field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21542,28 +22643,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the password field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the password field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the password field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the password field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the password field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface PasswordFieldEvents {\n  /**\n   * A callback fired when the password field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the password field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the password field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the password field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21581,42 +22686,48 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is hidden."
+          "description": "A callback fired after the popover is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftershow",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is shown."
+          "description": "A callback fired after the popover is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftertoggle",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is toggled."
+          "description": "A callback fired after the popover is toggled.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "hide",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is hidden."
+          "description": "A callback fired when the popover is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "show",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is shown."
+          "description": "A callback fired when the popover is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "toggle",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is toggled."
+          "description": "A callback fired when the popover is toggled.",
+          "isOptional": true
         }
       ],
       "value": "export interface PopoverEvents {\n  /**\n   * A callback fired when the popover is shown.\n   */\n  show: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired when the popover is hidden.\n   */\n  hide: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is shown.\n   */\n  aftershow: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is hidden.\n   */\n  afterhide: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired when the popover is toggled.\n   */\n  toggle: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is toggled.\n   */\n  aftertoggle: CallbackEventListener<TTagName> | null;\n}"
@@ -21672,28 +22783,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the search field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the search field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the search field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the search field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the search field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SearchFieldEvents {\n  /**\n   * A callback fired when the search field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the search field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the search field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the search field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21730,14 +22845,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the select value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the select value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the select.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the select.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SelectEvents {\n  /**\n   * A callback fired when the select value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the select.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -21793,14 +22910,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the switch value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the switch value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the switch.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the switch.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SwitchEvents {\n  /**\n   * A callback fired when the switch value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the switch.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -21818,14 +22937,16 @@
           "syntaxKind": "PropertySignature",
           "name": "nextpage",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user navigates to the next page."
+          "description": "A callback fired when the user navigates to the next page.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "previouspage",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user navigates to the previous page."
+          "description": "A callback fired when the user navigates to the previous page.",
+          "isOptional": true
         }
       ],
       "value": "export interface TableEvents {\n  /**\n   * A callback fired when the user navigates to the previous page.\n   */\n  previouspage: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user navigates to the next page.\n   */\n  nextpage: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21984,28 +23105,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the text area loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the text area value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the text area receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the text area.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the text area.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface TextAreaEvents {\n  /**\n   * A callback fired when the text area value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the text area.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text area loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text area receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22023,28 +23148,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the text field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the text field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the text field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the text field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the text field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface TextFieldEvents {\n  /**\n   * A callback fired when the text field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the text field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22081,14 +23210,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the thumbnail image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the thumbnail image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the thumbnail image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the thumbnail image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ThumbnailEvents {\n  /**\n   * A callback fired when the thumbnail image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the thumbnail image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -22125,28 +23256,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the URL field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the URL field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the URL field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the URL field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the URL field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface URLFieldEvents {\n  /**\n   * A callback fired when the URL field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the URL field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the URL field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the URL field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22208,14 +23343,16 @@
           "syntaxKind": "PropertySignature",
           "name": "reset",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the form is reset."
+          "description": "A callback that is run when the form is reset.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "submit",
           "value": "CallbackExtendableEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the form is submitted."
+          "description": "A callback that is run when the form is submitted.",
+          "isOptional": true
         }
       ],
       "value": "export interface FormEvents {\n  /**\n   * A callback that is run when the form is submitted.\n   */\n  submit: CallbackExtendableEventListener<typeof tagName> | null = null;\n  /**\n   * A callback that is run when the form is reset.\n   */\n  reset: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -22233,21 +23370,24 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "CallbackErrorEventListener<\n    typeof tagName,\n    FunctionSettingsErrorEvent['error']['errors'][0]\n  > | null",
-          "description": "An optional callback function that will be run by the admin when committing the changes to Shopify’s servers fails. The error event you receive includes an `error` property that is an `AggregateError` object. This object includes an array of errors that were caused by data your extension provided. Network errors and user errors that are out of your control will not be reported here.\n\nIn the `onError` callback, you should update your extension’s UI to highlight the fields that caused the errors, and display the error messages to the user."
+          "description": "An optional callback function that will be run by the admin when committing the changes to Shopify’s servers fails. The error event you receive includes an `error` property that is an `AggregateError` object. This object includes an array of errors that were caused by data your extension provided. Network errors and user errors that are out of your control will not be reported here.\n\nIn the `onError` callback, you should update your extension’s UI to highlight the fields that caused the errors, and display the error messages to the user.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "reset",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the function settings form is reset."
+          "description": "A callback that is run when the function settings form is reset.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "submit",
           "value": "CallbackExtendableEventListener<typeof tagName> | null",
-          "description": "An optional callback function that will be run by the admin when the user commits their changes in the admin-rendered part of the function settings experience. If `event.waitUntil` is called with a promise, the admin will wait for the promise to resolve before committing any changes to Shopify’s servers. If the promise rejects, the admin will abort the changes and display an error, using the `message` property of the error you reject with."
+          "description": "An optional callback function that will be run by the admin when the user commits their changes in the admin-rendered part of the function settings experience. If `event.waitUntil` is called with a promise, the admin will wait for the promise to resolve before committing any changes to Shopify’s servers. If the promise rejects, the admin will abort the changes and display an error, using the `message` property of the error you reject with.",
+          "isOptional": true
         }
       ],
       "value": "export interface FunctionSettingsEvents {\n  /**\n   * An optional callback function that will be run by the admin when the user\n   * commits their changes in the admin-rendered part of the function settings\n   * experience. If `event.waitUntil` is called with a promise, the admin will wait for the\n   * promise to resolve before committing any changes to Shopify’s servers. If\n   * the promise rejects, the admin will abort the changes and display an error,\n   * using the `message` property of the error you reject with.\n   */\n  submit: CallbackExtendableEventListener<typeof tagName> | null = null;\n  /**\n   * An optional callback function that will be run by the admin when\n   * committing the changes to Shopify’s servers fails. The error event you receive includes\n   * an `error` property that is an `AggregateError` object. This object includes\n   * an array of errors that were caused by data your extension provided.\n   * Network errors and user errors that are out of your control will not be reported here.\n   *\n   * In the `onError` callback, you should update your extension’s UI to\n   * highlight the fields that caused the errors, and display the error messages\n   * to the user.\n   */\n  error: CallbackErrorEventListener<\n    typeof tagName,\n    FunctionSettingsErrorEvent['error']['errors'][0]\n  > | null = null;\n  /**\n   * A callback that is run when the function settings form is reset.\n   */\n  reset: CallbackEventListener<typeof tagName> | null = null;\n}"

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
@@ -962,7 +962,7 @@
     "src/surfaces/admin/api/intents/intents.ts": {
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "name": "IntentInvokeApi",
-      "description": "The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating or editing resources, such as products, customers, or discounts. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created or updated resource data.",
+      "description": "The [`invoke` method](/docs/api/admin-extensions/{API_VERSION}/target-apis/utility-apis/intents-api#invoke-method) in the Intents API launches a Shopify admin workflow for creating, editing, or picking resources, such as products, customers, or files. It opens a native admin interface, waits for the merchant to complete the workflow, and returns the result including any created, updated, or selected resource data.",
       "isPublicDocs": true,
       "members": [],
       "value": "export interface IntentInvokeApi {\n  (query: IntentQuery): Promise<IntentActivity>;\n  (intentURL: string, options?: IntentQueryOptions): Promise<IntentActivity>;\n}"
@@ -1506,14 +1506,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "initials",
           "value": "string",
-          "description": "The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials, such as \"JD\" for John Doe."
+          "description": "The initials to display in the avatar when no image is provided or fails to load. Typically one or two characters representing a person's first and last name initials, such as \"JD\" for John Doe.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The URL or path to the avatar image. When provided, the image takes priority over `initials`. If the image fails to load or loads slowly, `initials` will be rendered as a fallback."
+          "description": "The URL or path to the avatar image. When provided, the image takes priority over `initials`. If the image fails to load or loads slowly, `initials` will be rendered as a fallback.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1521,14 +1523,16 @@
           "name": "size",
           "value": "\"small\" | \"small-200\" | \"base\" | \"large\" | \"large-200\"",
           "description": "The size of the avatar image.\n\n- `small-200`: Extra small avatar, suitable for compact displays or lists with many items.\n- `small`: Small avatar, good for secondary contexts or tight layouts.\n- `base`: Default size that works well in most contexts.\n- `large`: Large avatar for emphasis or when the avatar is a focal point.\n- `large-200`: Extra large avatar for prominent display.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "alt",
           "value": "string",
-          "description": "Alternative text that describes the avatar for accessibility.\n\nProvides a text description of the avatar for users with assistive technology and serves as a fallback when the avatar fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an avatar, it reads this description aloud. When an avatar fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt)."
+          "description": "Alternative text that describes the avatar for accessibility.\n\nProvides a text description of the avatar for users with assistive technology and serves as a fallback when the avatar fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an avatar, it reads this description aloud. When an avatar fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1536,7 +1540,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1544,7 +1549,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1552,7 +1558,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1560,7 +1567,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1568,7 +1576,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1576,7 +1585,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1584,7 +1594,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Avatar extends PreactCustomElement implements AvatarProps {\n  accessor initials: AvatarProps['initials'];\n  accessor src: AvatarProps['src'];\n  accessor size: AvatarProps['size'];\n  accessor alt: AvatarProps['alt'];\n  constructor();\n}"
@@ -1660,14 +1671,16 @@
           "name": "color",
           "value": "\"base\" | \"strong\"",
           "description": "Controls the visual weight and emphasis of the badge.\n\n- `base`: Standard weight with moderate emphasis, suitable for most use cases.\n- `strong`: Increased visual weight for higher emphasis and prominence.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the badge to provide additional visual context or reinforce the badge's meaning. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1675,7 +1688,8 @@
           "name": "size",
           "value": "\"base\" | \"large\" | \"large-100\"",
           "description": "The size of the badge.\n\n- `base`: Default size suitable for most badge use cases.\n- `large`: Larger badge for increased visibility and prominence.\n- `large-100`: Extra large badge for maximum visibility in emphasized contexts.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1683,7 +1697,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.\n- `caution`: Advisory notices that need attention.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1691,7 +1706,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1699,7 +1715,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1707,7 +1724,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1715,7 +1733,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1723,7 +1742,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1731,7 +1751,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1739,7 +1760,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Badge extends PreactCustomElement implements BadgeProps {\n  accessor color: BadgeProps['color'];\n  accessor icon: BadgeProps['icon'];\n  accessor size: BadgeProps['size'];\n  accessor tone: BadgeProps['tone'];\n  constructor();\n}"
@@ -1758,7 +1780,8 @@
           "name": "heading",
           "value": "string",
           "description": "The heading text displayed at the top of the banner.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1766,7 +1789,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1774,7 +1798,8 @@
           "name": "hidden",
           "value": "boolean",
           "description": "Controls whether the banner is visible or hidden.\n\nWhen using a controlled component pattern and the banner is `dismissible`, update this property to `true` when the `dismiss` event fires.\n\nYou can hide the banner programmatically by setting this to `true` even if it's not `dismissible`.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1782,7 +1807,8 @@
           "name": "dismissible",
           "value": "boolean",
           "description": "Whether the banner displays a close button that allows users to dismiss it.\n\nWhen the close button is pressed, the `dismiss` event fires, then `hidden` is set to `true`, any animation completes, and the `afterhide` event fires.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1790,7 +1816,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1798,7 +1825,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1806,7 +1834,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1814,7 +1843,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1822,7 +1852,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1830,7 +1861,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1838,7 +1870,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Banner extends PreactCustomElement implements BannerProps {\n  accessor heading: BannerProps['heading'];\n  accessor tone: BannerProps['tone'];\n  accessor hidden: BannerProps['hidden'];\n  accessor dismissible: BannerProps['dismissible'];\n  constructor();\n}"
@@ -1857,7 +1890,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1865,7 +1899,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1873,7 +1908,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1881,7 +1917,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1889,7 +1926,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1897,7 +1935,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1905,7 +1944,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1913,7 +1953,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1921,7 +1962,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1929,7 +1971,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1937,7 +1980,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1945,7 +1989,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1953,7 +1998,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1961,7 +2007,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1969,7 +2016,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1977,7 +2025,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -1997,7 +2046,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2005,7 +2055,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2013,7 +2064,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2021,7 +2073,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2029,14 +2082,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2044,7 +2099,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2052,7 +2108,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2060,7 +2117,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2068,7 +2126,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2076,7 +2135,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2084,7 +2144,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2092,7 +2153,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2100,7 +2162,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2108,7 +2171,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Box extends BoxElement implements BoxProps {\n  constructor();\n}"
@@ -2287,14 +2351,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the button is disabled, preventing it from being clicked or receiving focus.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the button, typically positioned before the button text. Use icons to help users quickly identify the button's action or to improve scannability. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the button, typically positioned before the button text. Use icons to help users quickly identify the button's action or to improve scannability. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2302,7 +2368,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether to replace the button content with a loading indicator while a background action is being performed.\n\nThis also disables the button component.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2310,7 +2377,8 @@
           "name": "variant",
           "value": "\"auto\" | \"primary\" | \"secondary\" | \"tertiary\"",
           "description": "The visual appearance of the button component.\n\n- `auto`: The variant is automatically determined by the button component's context.\n- `primary`: High emphasis button for the primary action on the page. Should be used sparingly.\n- `secondary`: Medium emphasis button for secondary actions.\n- `tertiary`: Low emphasis button for less important actions.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2318,7 +2386,8 @@
           "name": "tone",
           "value": "\"critical\" | \"auto\" | \"neutral\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2326,21 +2395,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2348,14 +2420,16 @@
           "name": "type",
           "value": "\"button\" | \"reset\" | \"submit\"",
           "description": "The behavior of the button component.\n\n- `button`: Used to indicate the component acts as a button, meaning it has no default action.\n- `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).\n- `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.\n\nThis property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.",
-          "defaultValue": "'button'"
+          "defaultValue": "'button'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2363,7 +2437,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2371,7 +2446,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2379,7 +2455,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2387,7 +2464,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2395,7 +2473,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2403,7 +2482,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2411,7 +2491,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2419,21 +2500,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Button extends Button_base implements ButtonProps {\n  accessor disabled: ButtonProps['disabled'];\n  accessor icon: ButtonProps['icon'];\n  accessor loading: ButtonProps['loading'];\n  accessor variant: ButtonProps['variant'];\n  accessor tone: ButtonProps['tone'];\n  accessor target: ButtonProps['target'];\n  accessor href: ButtonProps['href'];\n  accessor download: ButtonProps['download'];\n  accessor type: ButtonProps['type'];\n  accessor accessibilityLabel: ButtonProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2462,14 +2546,16 @@
           "name": "gap",
           "value": "\"base\" | \"none\"",
           "description": "The spacing between buttons in the group.\n\n- `base`: Standard spacing that provides clear visual separation between buttons.\n- `none`: No spacing, creating a connected button group.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2477,7 +2563,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2485,7 +2572,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2493,7 +2581,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2501,7 +2590,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2509,7 +2599,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2517,7 +2608,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2525,7 +2617,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ButtonGroup\n  extends PreactCustomElement\n  implements ButtonGroupProps\n{\n  accessor gap: ButtonGroupProps['gap'];\n  accessor accessibilityLabel: ButtonGroupProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2543,7 +2636,8 @@
           "syntaxKind": "GetAccessor",
           "name": "indeterminate",
           "value": "boolean",
-          "description": "Whether the checkbox displays in an indeterminate state (neither checked nor unchecked), typically used to indicate partial selection in hierarchical lists.\n\nThis visual state takes priority over the `checked` prop in appearance only. The form submission value is still determined by the `checked` prop.\n\nIf `indeterminate` has not been explicitly set and hasn't been modified by user interaction, it returns the value of `defaultIndeterminate`."
+          "description": "Whether the checkbox displays in an indeterminate state (neither checked nor unchecked), typically used to indicate partial selection in hierarchical lists.\n\nThis visual state takes priority over the `checked` prop in appearance only. The form submission value is still determined by the `checked` prop.\n\nIf `indeterminate` has not been explicitly set and hasn't been modified by user interaction, it returns the value of `defaultIndeterminate`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2551,7 +2645,8 @@
           "name": "defaultIndeterminate",
           "value": "boolean",
           "description": "The initial indeterminate state for uncontrolled components. Use this when you want the checkbox to start in an indeterminate state but don't need to control it afterward.\n\nThis value applies until `indeterminate` is explicitly set or the user changes the checkbox state by clicking.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2559,14 +2654,16 @@
           "name": "checked",
           "value": "boolean",
           "description": "Whether the control is currently checked. Use this for controlled components where you manage the checked state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the checkbox is checked.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2574,35 +2671,40 @@
           "name": "defaultChecked",
           "value": "boolean",
           "description": "The initial checked state for uncontrolled components. Use this when you want the control to start checked but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2610,7 +2712,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field needs a value. This requirement adds semantic value to the field, but it will not cause an error to appear automatically. If you want to present an error when this field is empty, you can do so with the `error` property.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2618,7 +2721,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2626,21 +2730,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2648,7 +2755,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2656,7 +2764,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2664,7 +2773,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2672,7 +2782,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2680,7 +2791,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2688,7 +2800,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2696,7 +2809,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2704,7 +2818,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Checkbox extends PreactCheckboxElement implements CheckboxProps {\n  get indeterminate(): CheckboxProps['indeterminate'];\n  set indeterminate(indeterminate: CheckboxProps['indeterminate']);\n  accessor defaultIndeterminate: CheckboxProps['defaultIndeterminate'];\n  constructor();\n}"
@@ -2723,14 +2838,16 @@
           "name": "color",
           "value": "ColorKeyword",
           "description": "The color emphasis level that controls visual intensity.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2738,7 +2855,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2746,7 +2864,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2754,7 +2873,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2762,7 +2882,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2770,7 +2891,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2778,7 +2900,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2786,7 +2909,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Chip extends PreactCustomElement implements ChipProps {\n  accessor color: ChipProps['color'];\n  accessor accessibilityLabel: ChipProps['accessibilityLabel'];\n  constructor();\n}"
@@ -2805,7 +2929,8 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2813,21 +2938,24 @@
           "name": "selected",
           "value": "boolean",
           "description": "Whether the option is currently selected. Use this for controlled components where you manage the selection state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2835,7 +2963,8 @@
           "name": "defaultSelected",
           "value": "boolean",
           "description": "The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2843,7 +2972,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2851,7 +2981,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2859,7 +2990,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2867,7 +2999,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2875,7 +3008,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2883,7 +3017,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2891,7 +3026,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Choice extends PreactCustomElement implements ChoiceProps {\n  accessor disabled: ChoiceProps['disabled'];\n  get selected(): boolean;\n  set selected(selected: ChoiceProps['selected']);\n  accessor value: ChoiceProps['value'];\n  accessor accessibilityLabel: ChoiceProps['accessibilityLabel'];\n  accessor defaultSelected: ChoiceProps['defaultSelected'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -2910,28 +3046,32 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction. When `true`, the `disabled` property on any child choices is ignored.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2939,14 +3079,16 @@
           "name": "multiple",
           "value": "boolean",
           "description": "Whether multiple choices can be selected.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2954,14 +3096,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "values",
           "value": "string[]",
-          "description": "An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected."
+          "description": "An array of `value` attributes for the currently selected options. When provided, this property automatically sets the `selected` state on child option components that have matching `value` attributes. Options with values included in this array will be marked as selected, while others will be unselected.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2969,7 +3113,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2977,7 +3122,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2985,7 +3131,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2993,7 +3140,8 @@
           "name": "__@internals$3@2409",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3001,7 +3149,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3009,7 +3158,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3017,7 +3167,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3025,7 +3176,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3033,7 +3185,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ChoiceList extends BaseClass$3 implements ChoiceListProps {\n  accessor disabled: ChoiceListProps['disabled'];\n  accessor name: ChoiceListProps['name'];\n  accessor error: ChoiceListProps['error'];\n  accessor details: ChoiceListProps['details'];\n  accessor multiple: ChoiceListProps['multiple'];\n  accessor label: ChoiceListProps['label'];\n  accessor labelAccessibilityVisibility: ChoiceListProps['labelAccessibilityVisibility'];\n  get values(): ChoiceListProps['values'];\n  set values(values: ChoiceListProps['values']);\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -3051,14 +3204,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "disabled",
           "value": "boolean",
-          "description": "Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You shouldapply disabled styling as needed."
+          "description": "Whether the component is disabled, preventing clicks and focus. When disabled, the `click` event won't fire and click events from child elements stop propagating immediately. Interactive child elements can still receive focus and be interacted with. This doesn't apply visual styling by default. You shouldapply disabled styling as needed.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "loading",
           "value": "boolean",
-          "description": "Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction."
+          "description": "Whether the component is in a loading state, which indicates to assistive technology that an action is in progress and prevents interaction.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3066,21 +3221,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3088,7 +3246,8 @@
           "name": "type",
           "value": "\"button\" | \"reset\" | \"submit\"",
           "description": "The behavior of the button component.\n\n- `button`: Used to indicate the component acts as a button, meaning it has no default action.\n- `reset`: Used to indicate the component acts as a reset button, meaning it resets the closest form (returning fields to their default values).\n- `submit`: Used to indicate the component acts as a submit button, meaning it submits the closest form.\n\nThis property is ignored if the component supports `href` or `commandFor`/`command` and one of them is set.",
-          "defaultValue": "'button'"
+          "defaultValue": "'button'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3096,7 +3255,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3104,7 +3264,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3112,7 +3273,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3120,7 +3282,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3128,7 +3291,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3136,7 +3300,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3144,7 +3309,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3152,7 +3318,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3160,7 +3327,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3168,7 +3336,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3176,7 +3345,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3184,7 +3354,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3192,7 +3363,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3200,7 +3372,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3208,7 +3381,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3216,7 +3390,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3236,7 +3411,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3244,7 +3420,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3252,7 +3429,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3260,7 +3438,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3268,14 +3447,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3283,7 +3464,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3291,7 +3473,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3299,7 +3482,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3307,7 +3491,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3315,7 +3500,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3323,7 +3509,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3331,7 +3518,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3339,7 +3527,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3347,7 +3536,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3355,21 +3545,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Clickable extends Clickable_base implements ClickableProps {\n  accessor disabled: ClickableProps['disabled'];\n  accessor loading: ClickableProps['loading'];\n  accessor target: ClickableProps['target'];\n  accessor href: ClickableProps['href'];\n  accessor download: ClickableProps['download'];\n  accessor type: ClickableProps['type'];\n  constructor();\n}"
@@ -3388,14 +3581,16 @@
           "name": "color",
           "value": "ColorKeyword",
           "description": "The color emphasis level that controls visual intensity.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3403,7 +3598,8 @@
           "name": "removable",
           "value": "boolean",
           "description": "Whether the chip displays a remove button for dismissal. When clicked, the `remove` callback fires.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3411,7 +3607,8 @@
           "name": "hidden",
           "value": "boolean",
           "description": "Whether the chip is hidden from view. When using controlled component pattern with `removable` chips, update this property when the `remove` event fires. For non-removable chips, manually toggle this property to show or hide the chip.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3419,14 +3616,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the chip is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3434,7 +3633,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3442,7 +3642,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3450,7 +3651,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3458,7 +3660,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3466,7 +3669,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3474,7 +3678,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3482,7 +3687,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3490,21 +3696,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class ClickableChip\n  extends ClickableChip_base\n  implements ClickableChipProps\n{\n  accessor color: ClickableChipProps['color'];\n  accessor accessibilityLabel: ClickableChipProps['accessibilityLabel'];\n  accessor removable: ClickableChipProps['removable'];\n  accessor hidden: ClickableChipProps['hidden'];\n  accessor disabled: ClickableChipProps['disabled'];\n  accessor href: ClickableChipProps['href'];\n  constructor();\n}"
@@ -3523,14 +3732,16 @@
           "name": "alpha",
           "value": "boolean",
           "description": "Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format."
+          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3538,7 +3749,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3546,7 +3758,8 @@
           "name": "setInternalValue",
           "value": "(value: string, normalize: boolean) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3554,35 +3767,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\"",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3590,14 +3808,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3605,7 +3825,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3613,7 +3834,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3621,7 +3843,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3629,7 +3852,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3637,7 +3861,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3645,7 +3870,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3653,21 +3879,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3675,7 +3904,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3683,7 +3913,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3691,7 +3922,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3699,7 +3931,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3707,7 +3940,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3715,7 +3949,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3723,7 +3958,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ColorField\n  extends PreactFieldElement<ColorFieldProps['autocomplete']>\n  implements ColorFieldProps\n{\n  accessor alpha: ColorFieldProps['alpha'];\n  get value(): string;\n  set value(value: string);\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n  /** @private */\n  setInternalValue(value: string, normalize: boolean): void;\n}"
@@ -3742,35 +3978,40 @@
           "name": "alpha",
           "value": "boolean",
           "description": "Whether to enable alpha (transparency) channel selection in the color picker, allowing users to choose semi-transparent colors.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial color value when the field first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts interacting, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format."
+          "description": "The currently selected color value. Accepts multiple input formats:\n\n- Hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA` (3, 6, or 8 digits)\n- RGB/RGBA: `rgb(255, 0, 0)` or `rgb(255 0 0)` (comma or space-separated)\n- HSL/HSLA: `hsl(0, 100%, 50%)` or `hsl(0 100% 50%)`\n\nReturns an empty string if the value is invalid. The `change` event always emits values in hex format.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "formResetCallback",
           "value": "() => void",
-          "description": "A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`."
+          "description": "A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3778,7 +4019,8 @@
           "name": "__@internals$2@2510",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3786,7 +4028,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3794,7 +4037,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3802,7 +4046,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3810,7 +4055,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3818,7 +4064,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3826,7 +4073,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3834,7 +4082,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ColorPicker extends BaseClass$2 implements ColorPickerProps {\n  accessor alpha: boolean;\n  accessor name: string;\n  accessor defaultValue: string;\n  get value(): string;\n  set value(value: string);\n  /**\n   * A callback that fires when the containing form is reset (using the form's `reset()` method or a reset button). When triggered, the component's `value` reverts to its `defaultValue`.\n   */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -3853,7 +4102,8 @@
           "name": "allow",
           "value": "string",
           "description": "Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `2024-02--2025`: February 2024 through end of 2025\n- `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3861,7 +4111,8 @@
           "name": "disallow",
           "value": "string",
           "description": "Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `--2024-02`: All dates before February 2024\n- `2024-05-09, 2024-05-11`: May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3869,7 +4120,8 @@
           "name": "allowDays",
           "value": "string",
           "description": "Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (only weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3877,21 +4129,24 @@
           "name": "disallowDays",
           "value": "string",
           "description": "Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (no weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "SetAccessor",
           "name": "view",
           "value": "string",
-          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`."
+          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultView",
           "value": "string",
-          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale."
+          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3899,7 +4154,8 @@
           "name": "autocomplete",
           "value": "DateAutocompleteField",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3907,28 +4163,32 @@
           "name": "defaultValue",
           "value": "string",
           "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3936,14 +4196,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3951,7 +4213,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3959,7 +4222,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3967,7 +4231,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3975,7 +4240,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3983,7 +4249,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3991,7 +4258,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3999,7 +4267,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4007,21 +4276,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4029,7 +4301,8 @@
           "name": "value",
           "value": "string",
           "description": "The currently selected date in `YYYY-MM-DD` format. An empty string means no date is selected.",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4037,7 +4310,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4045,7 +4319,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4053,7 +4328,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4061,7 +4337,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4069,7 +4346,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4077,7 +4355,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4085,7 +4364,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DateField\n  extends PreactFieldElement<DateFieldProps['autocomplete']>\n  implements DateFieldProps\n{\n  accessor allow: DateFieldProps['allow'];\n  accessor disallow: DateFieldProps['disallow'];\n  accessor allowDays: DateFieldProps['allowDays'];\n  accessor disallowDays: DateFieldProps['disallowDays'];\n  set view(view: string);\n  get view(): string;\n  accessor defaultView: DateFieldProps['defaultView'];\n  constructor();\n}"
@@ -4113,14 +4393,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultView",
           "value": "string",
-          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale."
+          "description": "The default month to display in `YYYY-MM` format. Used until the `view` callback is set by user interaction or programmatically. Defaults to the current month in the user's locale.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "SetAccessor",
           "name": "view",
           "value": "string",
-          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`."
+          "description": "The currently displayed month in `YYYY-MM` format. When changed, the `viewchange` callback is triggered. Defaults to `defaultView`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4128,7 +4410,8 @@
           "name": "allow",
           "value": "string",
           "description": "Specifies which dates can be selected as a comma-separated list. An empty string (default) allows all dates.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `2024-02--2025`: February 2024 through end of 2025\n- `2024-05-09, 2024-05-11`: Only May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4136,7 +4419,8 @@
           "name": "disallow",
           "value": "string",
           "description": "Specifies which dates can't be selected as a comma-separated list. These dates are excluded from those specified in `allow`. An empty string (default) has no effect.\n\n**Formats:**\n- `YYYY-MM-DD`: Single date\n- `YYYY-MM`: Whole month\n- `YYYY`: Whole year\n- `start--end`: Date range (inclusive, unbounded if start/end omitted)\n\n**Examples:**\n- `--2024-02`: All dates before February 2024\n- `2024-05-09, 2024-05-11`: May 9th and 11th, 2024",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4144,7 +4428,8 @@
           "name": "allowDays",
           "value": "string",
           "description": "Specifies which days of the week can be selected as a comma-separated list. Further restricts dates from `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (only weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4152,7 +4437,8 @@
           "name": "disallowDays",
           "value": "string",
           "description": "Specifies which days of the week can't be selected as a comma-separated list. Excludes days from `allowDays` and intersects with `allow` and `disallow`. An empty string (default) has no effect.\n\n**Valid days**: `sunday`, `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`\n\n**Example:** `saturday, sunday` (no weekends)",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4160,7 +4446,8 @@
           "name": "type",
           "value": "\"single\" | \"range\"",
           "description": "The type of date selection allowed.\n\n- `single`: Select a single date\n- `range`: Select a date range",
-          "defaultValue": "\"single\""
+          "defaultValue": "\"single\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4168,14 +4455,16 @@
           "name": "defaultValue",
           "value": "string",
           "description": "The initially selected date(s) when the component first renders. An empty string means no date is initially selected.\n\n- Single date in `YYYY-MM-DD` format when `type` is set to `\"single\"`\n- Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `\"range\"`",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4183,7 +4472,8 @@
           "name": "value",
           "value": "string",
           "description": "The currently selected date(s). An empty string means no date is selected.\n\n- Single date in `YYYY-MM-DD` format when `type` is set to `\"single\"`\n- Date range in `YYYY-MM-DD--YYYY-MM-DD` format (inclusive) when `type` is set to `\"range\"`",
-          "defaultValue": "\"\""
+          "defaultValue": "\"\"",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4191,7 +4481,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4199,7 +4490,8 @@
           "name": "__@dirtyStateSymbol@2554",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4207,7 +4499,8 @@
           "name": "__@internals$1@2553",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4215,7 +4508,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4223,7 +4517,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4231,7 +4526,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4239,7 +4535,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4247,7 +4544,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4255,7 +4553,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4263,7 +4562,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DatePicker extends BaseClass$1 implements DatePickerProps {\n  accessor defaultView: string;\n  set view(view: string);\n  get view(): string;\n  accessor allow: DatePickerProps['allow'];\n  accessor disallow: DatePickerProps['disallow'];\n  accessor allowDays: DatePickerProps['allowDays'];\n  accessor disallowDays: DatePickerProps['disallowDays'];\n  accessor type: DatePickerProps['type'];\n  accessor defaultValue: DatePickerProps['defaultValue'];\n  accessor name: DatePickerProps['name'];\n  set value(value: string);\n  get value(): string;\n  /** @private */\n  [dirtyStateSymbol]: boolean;\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -4282,14 +4582,16 @@
           "name": "accept",
           "value": "string",
           "description": "A string representing the types of files that are accepted by the drop zone. This string is a comma-separated list of unique file type specifiers which can be one of the following:\n- A file extension starting with a period (\".\") character (e.g. .jpg, .pdf, .doc)\n- A valid MIME type string with no extensions\n\nIf omitted, all file types are accepted.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or contents of the item. When set, it will be announced to buyers using assistive technologies and will provide them with more context."
+          "description": "A label that describes the purpose or contents of the item. When set, it will be announced to buyers using assistive technologies and will provide them with more context.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4297,21 +4599,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4319,7 +4624,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4327,14 +4633,16 @@
           "name": "multiple",
           "value": "boolean",
           "description": "Whether multiple files can be selected or dropped at once.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4342,7 +4650,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4350,7 +4659,8 @@
           "name": "value",
           "value": "string",
           "description": "This sets the input value for a file type, which cannot be set programatically, so it can only be reset.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4358,7 +4668,8 @@
           "name": "files",
           "value": "File[]",
           "description": "An array of File objects representing the files currently selected by the user.\n\nThis property is read-only and cannot be directly modified. To clear the selected files, set the `value` prop to an empty string or null.",
-          "defaultValue": "[]"
+          "defaultValue": "[]",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4366,7 +4677,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4374,7 +4686,8 @@
           "name": "__@setFiles@2589",
           "value": "(files: File[]) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4382,7 +4695,8 @@
           "name": "__@getFileInput@2591",
           "value": "() => HTMLInputElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4390,7 +4704,8 @@
           "name": "__@internals@2590",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4398,7 +4713,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4406,7 +4722,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4414,7 +4731,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4422,7 +4740,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4430,7 +4749,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4438,7 +4758,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4446,7 +4767,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class DropZone extends BaseClass implements DropZoneProps {\n  accessor accept: DropZoneProps['accept'];\n  accessor accessibilityLabel: DropZoneProps['accessibilityLabel'];\n  accessor disabled: DropZoneProps['disabled'];\n  accessor error: DropZoneProps['error'];\n  accessor label: DropZoneProps['label'];\n  accessor labelAccessibilityVisibility: DropZoneProps['labelAccessibilityVisibility'];\n  accessor multiple: DropZoneProps['multiple'];\n  accessor name: DropZoneProps['name'];\n  accessor required: DropZoneProps['required'];\n  get value(): string;\n  /** This sets the input value for a file type, which cannot be set programatically, so it can only be reset. */\n  set value(value: '' | null);\n  get files(): File[];\n  set files(files: File[]);\n  /** @private */\n  [setFiles](files: File[]): void;\n  /** @private */\n  [getFileInput](): ReplaceType<\n    Element | null | undefined,\n    Element,\n    HTMLInputElement\n  >;\n\n  /** @private */\n  formResetCallback(): void;\n  constructor();\n}"
@@ -4465,7 +4787,8 @@
           "name": "direction",
           "value": "\"inline\" | \"block\"",
           "description": "The orientation of the divider line, using [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values).\n\n- `inline`: Horizontal divider for separating vertically stacked content\n- `block`: Vertical divider for separating horizontally arranged content",
-          "defaultValue": "'inline'"
+          "defaultValue": "'inline'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4473,7 +4796,8 @@
           "name": "color",
           "value": "\"base\" | \"strong\"",
           "description": "The visual prominence of the divider line.\n\n- `base`: Standard divider for most separations (default)\n- `strong`: More prominent divider for major section breaks",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4481,7 +4805,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4489,7 +4814,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4497,7 +4823,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4505,7 +4832,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4513,7 +4841,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4521,7 +4850,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4529,7 +4859,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Divider extends PreactCustomElement implements DividerProps {\n  accessor direction: DividerProps['direction'];\n  accessor color: DividerProps['color'];\n  constructor();\n}"
@@ -4548,7 +4879,8 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | EmailAutocompleteField | `section-${string} email` | `section-${string} home email` | `section-${string} mobile email` | `section-${string} fax email` | `section-${string} pager email` | \"shipping email\" | \"shipping home email\" | \"shipping mobile email\" | ... 16 more ... | `section-${string} billing p...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4556,7 +4888,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4564,42 +4897,48 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing."
+          "description": "The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4607,14 +4946,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4622,7 +4963,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4630,7 +4972,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4638,7 +4981,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4646,7 +4990,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4654,7 +4999,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4662,7 +5008,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4670,7 +5017,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4678,21 +5026,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4700,7 +5051,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4708,7 +5060,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4716,7 +5069,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4724,7 +5078,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4732,7 +5087,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4740,7 +5096,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4748,7 +5105,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class EmailField\n  extends PreactFieldElement<EmailFieldProps['autocomplete']>\n  implements EmailFieldProps\n{\n  accessor autocomplete: EmailFieldProps['autocomplete'];\n  accessor maxLength: EmailFieldProps['maxLength'];\n  accessor minLength: EmailFieldProps['minLength'];\n  /**\n   * The current email address value in the field. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as an email address format when the user finishes editing.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -4777,7 +5135,8 @@
           "name": "gridTemplateColumns",
           "value": "string",
           "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4785,7 +5144,8 @@
           "name": "gridTemplateRows",
           "value": "string",
           "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4793,7 +5153,8 @@
           "name": "justifyItems",
           "value": "\"\" | JustifyItemsKeyword",
           "description": "Aligns the grid items along the inline axis.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4801,7 +5162,8 @@
           "name": "alignItems",
           "value": "\"\" | AlignItemsKeyword",
           "description": "Aligns the grid items along the block axis.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4809,7 +5171,8 @@
           "name": "placeItems",
           "value": "AlignItemsKeyword | \"normal normal\" | \"normal stretch\" | \"normal baseline\" | \"normal first baseline\" | \"normal last baseline\" | \"normal start\" | \"normal end\" | ... 188 more ... | \"safe center safe center\"",
           "description": "A shorthand property for `justify-items` and `align-items`.",
-          "defaultValue": "'normal normal'"
+          "defaultValue": "'normal normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4817,7 +5180,8 @@
           "name": "justifyContent",
           "value": "\"\" | JustifyContentKeyword",
           "description": "Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4825,7 +5189,8 @@
           "name": "alignContent",
           "value": "\"\" | AlignContentKeyword",
           "description": "Aligns the grid along the block axis. This overrides the block value of `placeContent`.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4833,7 +5198,8 @@
           "name": "placeContent",
           "value": "\"normal normal\" | \"normal stretch\" | \"normal start\" | \"normal end\" | \"normal center\" | \"normal unsafe start\" | \"normal unsafe end\" | \"normal unsafe center\" | \"normal safe start\" | ... 229 more ... | \"space-evenly space-evenly\"",
           "description": "A shorthand property for `justify-content` and `align-content`.",
-          "defaultValue": "'normal normal'"
+          "defaultValue": "'normal normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4841,7 +5207,8 @@
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
           "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4849,7 +5216,8 @@
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4857,7 +5225,8 @@
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4865,7 +5234,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4873,7 +5243,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4881,7 +5252,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4889,7 +5261,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4897,7 +5270,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4905,7 +5279,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4913,7 +5288,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4921,7 +5297,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4929,7 +5306,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4937,7 +5315,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4945,7 +5324,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4953,7 +5333,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4961,7 +5342,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4969,7 +5351,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4977,7 +5360,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4985,7 +5369,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5005,7 +5390,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5013,7 +5399,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5021,7 +5408,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5029,7 +5417,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5037,14 +5426,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5052,7 +5443,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5060,7 +5452,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5068,7 +5461,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5076,7 +5470,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5084,7 +5479,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5092,7 +5488,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5100,7 +5497,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5108,7 +5506,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5116,7 +5515,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Grid extends BoxElement implements GridProps {\n  constructor();\n  accessor gridTemplateColumns: GridProps['gridTemplateColumns'];\n  accessor gridTemplateRows: GridProps['gridTemplateRows'];\n  accessor justifyItems: GridProps['justifyItems'];\n  accessor alignItems: GridProps['alignItems'];\n  accessor placeItems: GridProps['placeItems'];\n  accessor justifyContent: GridProps['justifyContent'];\n  accessor alignContent: GridProps['alignContent'];\n  accessor placeContent: GridProps['placeContent'];\n  accessor gap: GridProps['gap'];\n  accessor rowGap: GridProps['rowGap'];\n  accessor columnGap: GridProps['columnGap'];\n}"
@@ -5225,7 +5625,8 @@
           "name": "gridColumn",
           "value": "\"auto\" | `span ${number}`",
           "description": "The number of columns the item will span across.\n\nLearn more about the [grid-column property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5233,7 +5634,8 @@
           "name": "gridRow",
           "value": "\"auto\" | `span ${number}`",
           "description": "The number of rows the item will span across.\n\nLearn more about the [grid-row property](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5241,7 +5643,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5249,7 +5652,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5257,7 +5661,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5265,7 +5670,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5273,7 +5679,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5281,7 +5688,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5289,7 +5697,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5297,7 +5706,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5305,7 +5715,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5313,7 +5724,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5321,7 +5733,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5329,7 +5742,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5337,7 +5751,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5345,7 +5760,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5353,7 +5769,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5361,7 +5778,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5381,7 +5799,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5389,7 +5808,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5397,7 +5817,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5405,7 +5826,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5413,14 +5835,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5428,7 +5852,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5436,7 +5861,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5444,7 +5870,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5452,7 +5879,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5460,7 +5888,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5468,7 +5897,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5476,7 +5906,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5484,7 +5915,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5492,7 +5924,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class GridItem extends BoxElement implements GridItemProps {\n  accessor gridColumn: GridItemProps['gridColumn'];\n  accessor gridRow: GridItemProps['gridRow'];\n  constructor();\n}"
@@ -5511,7 +5944,8 @@
           "name": "accessibilityRole",
           "value": "\"none\" | \"presentation\" | \"heading\"",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.\n\n- `none`: Completely hides the element and its content from assistive technologies\n- `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.\n- `img`: Identifies the element as an image that conveys meaningful information to users.",
-          "defaultValue": "'heading'"
+          "defaultValue": "'heading'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5519,7 +5953,8 @@
           "name": "lineClamp",
           "value": "number",
           "description": "The maximum number of lines to display before truncating the text content.\n\nLearn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).",
-          "defaultValue": "Infinity - no truncation is applied"
+          "defaultValue": "Infinity - no truncation is applied",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5527,7 +5962,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5535,7 +5971,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5543,7 +5980,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5551,7 +5989,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5559,7 +5998,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5567,7 +6007,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5575,7 +6016,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5583,7 +6025,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Heading extends PreactCustomElement implements HeadingProps {\n  accessor accessibilityRole: HeadingProps['accessibilityRole'];\n  accessor lineClamp: HeadingProps['lineClamp'];\n  accessor accessibilityVisibility: HeadingProps['accessibilityVisibility'];\n  constructor();\n}"
@@ -5602,7 +6045,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5610,14 +6054,16 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `info`: Informational content or helpful tips.\n- `success`: Positive outcomes or successful states.\n- `warning`: Important warnings about potential issues.\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.\n- `caution`: Advisory notices that need attention.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "type",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "The icon to display from the icon library.\n\nSet to a valid icon name to display that icon. To hide the icon completely, use an empty string `''`. To reserve the icon's space without displaying an icon, use `'empty'`."
+          "description": "The icon to display from the icon library.\n\nSet to a valid icon name to display that icon. To hide the icon completely, use an empty string `''`. To reserve the icon's space without displaying an icon, use `'empty'`.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5625,14 +6071,16 @@
           "name": "size",
           "value": "\"small\" | \"base\"",
           "description": "The size of the icon.\n\n- `small`: Smaller icon suitable for inline use within text or compact UI elements.\n- `base`: Default size that works well for standalone icons and standard use cases.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5640,7 +6088,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5648,7 +6097,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5656,7 +6106,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5664,7 +6115,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5672,7 +6124,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5680,7 +6133,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5688,7 +6142,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Icon extends PreactCustomElement implements IconProps {\n  accessor color: IconProps['color'];\n  accessor tone: IconProps['tone'];\n  accessor type: IconProps['type'];\n  accessor size: IconProps['size'];\n  accessor interestFor: string;\n  constructor();\n}"
@@ -5706,21 +6161,24 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered."
+          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "srcSet",
           "value": "string",
-          "description": "A set of image sources and their width or pixel density descriptors. This overrides the `src` property.\n\nLearn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset)."
+          "description": "A set of image sources and their width or pixel density descriptors. This overrides the `src` property.\n\nLearn more about the [srcset attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "sizes",
           "value": "string",
-          "description": "A set of media conditions and their corresponding sizes.\n\nLearn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes)."
+          "description": "A set of media conditions and their corresponding sizes.\n\nLearn more about the [sizes attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#sizes).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5728,7 +6186,8 @@
           "name": "alt",
           "value": "string",
           "description": "Alternative text that describes the image for accessibility.\n\nProvides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
-          "defaultValue": "``"
+          "defaultValue": "``",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5736,7 +6195,8 @@
           "name": "aspectRatio",
           "value": "`${number}` | `${number}/${number}` | `${number}/ ${number}` | `${number} /${number}` | `${number} / ${number}`",
           "description": "The aspect ratio of the image.\n\nThe rendering of the image will depend on the `inlineSize` value:\n\n- `inlineSize=\"fill\"`: the aspect ratio will be respected and the image will take the necessary space.\n- `inlineSize=\"auto\"`: the image will not render until it has loaded and the aspect ratio will be ignored.\n\nFor example, if the value is set as `50 / 100`, the getter returns `50 / 100`. If the value is set as `0.5`, the getter returns `0.5 / 1`.\n\nLearn more about the [aspect-ratio property](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).",
-          "defaultValue": "'1/1'"
+          "defaultValue": "'1/1'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5744,7 +6204,8 @@
           "name": "objectFit",
           "value": "\"contain\" | \"cover\"",
           "description": "The image resizing behavior to fit within its container.\n\n- `contain`: Scales the image to fit within the container while maintaining its aspect ratio. The entire image is visible, but might leave empty space.\n- `cover`: Scales the image to fill the entire container while maintaining its aspect ratio. The image might be cropped to fit.\n\nThe image is always positioned in the center of the container.\n\nLearn more about the [object-fit property](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit).",
-          "defaultValue": "'contain'"
+          "defaultValue": "'contain'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5752,7 +6213,8 @@
           "name": "loading",
           "value": "\"eager\" | \"lazy\"",
           "description": "The loading strategy for the image.\n\n- `eager`: Immediately loads the image, irrespective of its position within the visible viewport.\n- `lazy`: Delays loading the image until it approaches a specified distance from the viewport.\n\nLearn more about the [loading attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading).",
-          "defaultValue": "'eager'"
+          "defaultValue": "'eager'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5760,7 +6222,8 @@
           "name": "accessibilityRole",
           "value": "\"none\" | \"presentation\" | \"img\"",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.\n\n- `none`: Completely hides the element and its content from assistive technologies\n- `presentation`: Removes semantic meaning, making the image purely decorative and ignored by screen readers.\n- `img`: Identifies the element as an image that conveys meaningful information to users.",
-          "defaultValue": "'img'"
+          "defaultValue": "'img'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5768,7 +6231,8 @@
           "name": "inlineSize",
           "value": "\"auto\" | \"fill\"",
           "description": "The displayed inline width of the image.\n\n- `fill`: the image will takes up 100% of the available inline size.\n- `auto`: the image will be displayed at its natural size.\n\nLearn more about the [width attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width).",
-          "defaultValue": "'fill'"
+          "defaultValue": "'fill'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5788,7 +6252,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5796,7 +6261,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border around the image. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5804,7 +6270,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border around the image, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5812,7 +6279,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border around the image using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5820,7 +6288,8 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the image's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5828,7 +6297,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5836,7 +6306,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5844,7 +6315,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5852,7 +6324,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5860,7 +6333,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5868,7 +6342,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5876,7 +6351,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Image extends PreactCustomElement implements ImageProps {\n  accessor src: ImageProps['src'];\n  accessor srcSet: ImageProps['srcSet'];\n  accessor sizes: ImageProps['sizes'];\n  accessor alt: ImageProps['alt'];\n  accessor aspectRatio: ImageProps['aspectRatio'];\n  accessor objectFit: ImageProps['objectFit'];\n  accessor loading: ImageProps['loading'];\n  accessor accessibilityRole: ImageProps['accessibilityRole'];\n  accessor inlineSize: ImageProps['inlineSize'];\n  /**\n   * A border applied around the image using shorthand syntax to specify width, color, and style in a single property.\n   */\n  accessor border: ImageProps['border'];\n  /**\n   * The thickness of the border around the image. When set, this overrides the width value specified in the `border` property.\n   */\n  accessor borderWidth: ImageProps['borderWidth'];\n  /**\n   * The visual style of the border around the image, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.\n   */\n  accessor borderStyle: ImageProps['borderStyle'];\n  /**\n   * The color of the border around the image using the design system's color scale. When set, this overrides the color value specified in the `border` property.\n   */\n  accessor borderColor: ImageProps['borderColor'];\n  /**\n   * The roundedness of the image's corners using the design system's radius scale.\n   */\n  accessor borderRadius: ImageProps['borderRadius'];\n  constructor();\n}"
@@ -5895,21 +6371,24 @@
           "name": "tone",
           "value": "\"critical\" | \"auto\" | \"neutral\"",
           "description": "The semantic meaning and color treatment of the component.\n\n- `critical`: Urgent problems or destructive actions.\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "href",
           "value": "string",
-          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation."
+          "description": "The URL to navigate to when clicked. The `click` event fires first, then navigation occurs. If `commandFor` is also set, the command executes instead of navigation.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5917,21 +6396,24 @@
           "name": "target",
           "value": "\"auto\" | AnyString | \"_blank\" | \"_self\" | \"_parent\" | \"_top\"",
           "description": "The browsing context where the linked URL should be displayed.\n\n- `auto`: The target is automatically determined based on the origin of the URL.\n- `_blank`: Opens the URL in a new window or tab.\n- `_self`: Opens the URL in the same browsing context as the current one.\n- `_parent`: Opens the URL in the parent browsing context of the current one. If there is no parent, behaves as `_self`.\n- `_top`: Opens the URL in the topmost browsing context (the highest ancestor of the current one). If there is no ancestor, behaves as `_self`.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "download",
           "value": "string",
-          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download)."
+          "description": "Prompts the browser to download the linked URL rather than navigate to it. When set, the value specifies the suggested filename for the downloaded file.\n\nThe filename suggestion is only respected for same-origin URLs, `blob:`, and `data:` schemes. Cross-origin URLs can still trigger downloads, but browsers might ignore the suggested filename.\n\nLearn more about the [download attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "lang",
           "value": "string",
-          "description": "The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry)."
+          "description": "The language of the text content. Use this when the text is in a different language than the rest of the page, allowing assistive technologies such as screen readers to invoke the correct pronunciation. The value should be a valid language subtag from the [IANA language subtag registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5939,7 +6421,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5947,7 +6430,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5955,7 +6439,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5963,7 +6448,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5971,7 +6457,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5979,7 +6466,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5987,7 +6475,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -5995,21 +6484,24 @@
           "name": "command",
           "value": "'--auto' | '--show' | '--hide' | '--toggle'",
           "description": "The action that [command](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#command) should take when this component is activated.\n\n- `--auto`: A default action for the target component.\n- `--show`: Shows the target component.\n- `--hide`: Hides the target component.\n- `--toggle`: Toggles the visibility of the target component.",
-          "defaultValue": "'--auto'"
+          "defaultValue": "'--auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "commandFor",
           "value": "string",
-          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated."
+          "description": "The component that [commandFor](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#commandfor) should act on when this component is activated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         }
       ],
       "value": "declare class Link extends Link_base implements LinkProps {\n  accessor tone: LinkProps['tone'];\n  accessor accessibilityLabel: LinkProps['accessibilityLabel'];\n  accessor href: LinkProps['href'];\n  accessor target: LinkProps['target'];\n  accessor download: LinkProps['download'];\n  accessor lang: LinkProps['lang'];\n  constructor();\n}"
@@ -6028,7 +6520,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6036,7 +6529,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6044,7 +6538,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6052,7 +6547,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6060,7 +6556,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6068,7 +6565,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6076,7 +6574,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class ListItem extends PreactCustomElement implements ListItemProps {\n  constructor();\n}"
@@ -6094,7 +6593,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6102,7 +6602,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6110,7 +6611,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6118,7 +6620,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6126,7 +6629,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6134,7 +6638,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6142,7 +6647,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6150,7 +6656,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6158,7 +6665,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6166,7 +6674,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6174,7 +6683,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Menu extends PreactOverlayElement implements MenuProps {\n  accessor accessibilityLabel: string;\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -6193,7 +6703,8 @@
           "name": "max",
           "value": "number",
           "description": "The highest decimal or integer value accepted for the field. When used with `step`, the value rounds down to the maximum number.\n\nUsers can still type values higher than the maximum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6201,14 +6712,16 @@
           "name": "min",
           "value": "number",
           "description": "The lowest decimal or integer value accepted for the field. When used with `step`, the value rounds up to the minimum number.\n\nUsers can still type values lower than the minimum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "-Infinity"
+          "defaultValue": "-Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency."
+          "description": "The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6216,35 +6729,40 @@
           "name": "autocomplete",
           "value": "string",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6252,14 +6770,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6267,7 +6787,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6275,7 +6796,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6283,7 +6805,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6291,7 +6814,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6299,7 +6823,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6307,7 +6832,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6315,7 +6841,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6323,21 +6850,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6345,7 +6875,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6353,7 +6884,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6361,7 +6893,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6369,7 +6902,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6377,7 +6911,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6385,7 +6920,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6393,7 +6929,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class MoneyField\n  extends PreactFieldElement<MoneyFieldProps['autocomplete']>\n  implements MoneyFieldProps\n{\n  accessor max: MoneyFieldProps['max'];\n  accessor min: MoneyFieldProps['min'];\n  /**\n   * The current monetary value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string representing the amount in the store's currency.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -6411,7 +6948,8 @@
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer)."
+          "description": "The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6419,7 +6957,8 @@
           "name": "inputMode",
           "value": "\"decimal\" | \"numeric\"",
           "description": "The type of virtual keyboard to display on mobile devices.\n\n- `decimal`: Shows a numeric keyboard with a decimal point, suitable for prices or measurements.\n- `numeric`: Shows a numeric keyboard without a decimal point, suitable for whole numbers like quantities.\n\nLearn more about the [inputmode attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).",
-          "defaultValue": "'decimal'"
+          "defaultValue": "'decimal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6427,7 +6966,8 @@
           "name": "step",
           "value": "number",
           "description": "The amount the value can increase or decrease by. This can be an integer or decimal. If a `max` or `min` is specified with `step` when increasing/decreasing the value via the buttons, the final value will always round to the `max` or `min` rather than the closest valid amount.",
-          "defaultValue": "1"
+          "defaultValue": "1",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6435,7 +6975,8 @@
           "name": "max",
           "value": "number",
           "description": "The highest decimal or integer value accepted for the field. When used with `step`, the value rounds down to the maximum number.\n\nUsers can still type values higher than the maximum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6443,7 +6984,8 @@
           "name": "min",
           "value": "number",
           "description": "The lowest decimal or integer value accepted for the field. When used with `step`, the value rounds up to the minimum number.\n\nUsers can still type values lower than the minimum using the keyboard. Implement validation to enforce this constraint.",
-          "defaultValue": "-Infinity"
+          "defaultValue": "-Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6451,7 +6993,8 @@
           "name": "prefix",
           "value": "string",
           "description": "A non-editable text value displayed immediately before the editable portion of the field. This is useful for displaying an implied part of the value, such as `https://` or `+353`.\n\nThis text can't be edited by the user and is not included in the field's value. The prefix might not appear until the user interacts with the field. For example, an inline label might occupy the prefix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6459,7 +7002,8 @@
           "name": "suffix",
           "value": "string",
           "description": "A non-editable text value displayed immediately after the editable portion of the field. This is useful for displaying an implied part of the value, such as `@shopify.com` or `%`.\n\nThis text can't be edited by the user and is not included in the field's value. The suffix might not appear until the user interacts with the field. For example, an inline label might occupy the suffix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6467,35 +7011,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | NumberAutocompleteField | `section-${string} one-time-code` | `section-${string} cc-number` | `section-${string} cc-csc` | \"shipping one-time-code\" | \"shipping cc-number\" | \"shipping cc-csc\" | \"billing one-time-code\" | ... 7 more ... | `section-${string} billing cc-csc`",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6503,14 +7052,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6518,7 +7069,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6526,7 +7078,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6534,7 +7087,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6542,7 +7096,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6550,7 +7105,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6558,7 +7114,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6566,7 +7123,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6574,21 +7132,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6596,7 +7157,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6604,7 +7166,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6612,7 +7175,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6620,7 +7184,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6628,7 +7193,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6636,7 +7202,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6644,7 +7211,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class NumberField\n  extends PreactFieldElement<NumberFieldProps['autocomplete']>\n  implements NumberFieldProps\n{\n  /**\n   * The current numeric value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value should be a numeric string (decimal or integer).\n   */\n  get value(): string;\n  set value(value: string);\n  accessor inputMode: NumberFieldProps['inputMode'];\n  accessor step: NumberFieldProps['step'];\n  accessor max: NumberFieldProps['max'];\n  accessor min: NumberFieldProps['min'];\n  accessor prefix: NumberFieldProps['prefix'];\n  accessor suffix: NumberFieldProps['suffix'];\n  constructor();\n}"
@@ -6673,7 +7241,8 @@
           "name": "selected",
           "value": "boolean",
           "description": "Whether the option is currently selected. Use this for controlled components where you manage the selection state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6681,14 +7250,16 @@
           "name": "defaultSelected",
           "value": "boolean",
           "description": "The initial selected state for uncontrolled components. Use this when you want the option to start selected but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "value",
           "value": "string",
-          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\"."
+          "description": "The value submitted with the form when this checkbox is checked. If not specified, the default value is \"on\".",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6696,7 +7267,8 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the checkbox is disabled, preventing user interaction. Disabled checkboxes appear dimmed and their values aren't submitted with forms.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6704,7 +7276,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6712,7 +7285,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6720,7 +7294,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6728,7 +7303,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6736,7 +7312,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6744,7 +7321,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6752,7 +7330,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Option extends PreactCustomElement implements OptionProps {\n  accessor selected: OptionProps['selected'];\n  accessor defaultSelected: OptionProps['defaultSelected'];\n  accessor value: OptionProps['value'];\n  accessor disabled: OptionProps['disabled'];\n  constructor();\n}"
@@ -6771,14 +7350,16 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the options within this group can be selected or not.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The user-facing label for this group of options."
+          "description": "The user-facing label for this group of options.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6786,7 +7367,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6794,7 +7376,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6802,7 +7385,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6810,7 +7394,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6818,7 +7403,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6826,7 +7412,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6834,7 +7421,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class OptionGroup\n  extends PreactCustomElement\n  implements OptionGroupProps\n{\n  accessor disabled: OptionGroupProps['disabled'];\n  accessor label: OptionGroupProps['label'];\n  constructor();\n}"
@@ -6853,7 +7441,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6861,7 +7450,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6869,7 +7459,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6877,7 +7468,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6885,7 +7477,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6893,7 +7486,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6901,7 +7495,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class OrderedList\n  extends PreactCustomElement\n  implements OrderedListProps\n{\n  constructor();\n}"
@@ -6920,7 +7515,8 @@
           "name": "fontVariantNumeric",
           "value": "\"auto\" | \"normal\" | \"tabular-nums\"",
           "description": "The rendering style for numbers in the font.\n\n- `auto`: Inherits the setting from the parent element.\n- `normal`: Uses the font's default numeric glyphs.\n- `tabular-nums`: Uses fixed-width numeric glyphs, ensuring numbers align vertically in tables or lists.\n\nLearn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6928,7 +7524,8 @@
           "name": "lineClamp",
           "value": "number",
           "description": "The maximum number of lines to display before truncating the text content.\n\nLearn more about the [-webkit-line-clamp property](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp).",
-          "defaultValue": "Infinity - no truncation is applied"
+          "defaultValue": "Infinity - no truncation is applied",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6936,7 +7533,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"caution\"",
           "description": "The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.\n\n- `info`: Informational content or helpful tips (blue).\n- `success`: Positive outcomes or successful states (green).\n- `warning`: Important warnings about potential issues (orange).\n- `critical`: Urgent problems or destructive actions (red).\n- `caution`: Advisory notices that need attention (yellow).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6944,7 +7542,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6952,7 +7551,8 @@
           "name": "dir",
           "value": "\"\" | \"auto\" | \"ltr\" | \"rtl\"",
           "description": "Indicates the directionality of the element’s text.\n\n- `\"\"`: The direction is inherited from parent elements (equivalent to not setting the attribute).\n- `auto`: The user agent determines the direction based on the content.\n- `ltr`: The languages written from left to right (such as English).\n- `rtl`: The languages written from right to left (such as Arabic).\n\nLearn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6960,7 +7560,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6968,7 +7569,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6976,7 +7578,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6984,7 +7587,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6992,7 +7596,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7000,7 +7605,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7008,7 +7614,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7016,7 +7623,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Paragraph extends PreactCustomElement implements ParagraphProps {\n  accessor fontVariantNumeric: ParagraphProps['fontVariantNumeric'];\n  accessor lineClamp: ParagraphProps['lineClamp'];\n  /**\n   * The semantic tone that's applied to the paragraph text, which changes its color to convey meaning.\n   *\n   * - `info`: Informational content or helpful tips (blue).\n   * - `success`: Positive outcomes or successful states (green).\n   * - `warning`: Important warnings about potential issues (orange).\n   * - `critical`: Urgent problems or destructive actions (red).\n   * - `caution`: Advisory notices that need attention (yellow).\n   */\n  accessor tone: ParagraphProps['tone'];\n\n  accessor color: ParagraphProps['color'];\n  accessor dir: ParagraphProps['dir'];\n  accessor accessibilityVisibility: ParagraphProps['accessibilityVisibility'];\n  constructor();\n}"
@@ -7035,7 +7643,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7043,14 +7652,16 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security."
+          "description": "The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7058,35 +7669,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | PasswordAutocompleteField | `section-${string} current-password` | `section-${string} new-password` | \"shipping current-password\" | \"shipping new-password\" | \"billing current-password\" | \"billing new-password\" | `section-${string} shipping current-password` | `section-${string} shipping new-password` | `section-${string} billing current-password` | `section-${string} billing new-password`",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7094,14 +7710,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7109,7 +7727,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7117,7 +7736,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7125,7 +7745,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7133,7 +7754,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7141,7 +7763,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7149,7 +7772,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7157,7 +7781,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7165,21 +7790,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7187,7 +7815,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7195,7 +7824,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7203,7 +7833,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7211,7 +7842,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7219,7 +7851,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7227,7 +7860,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7235,7 +7869,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class PasswordField\n  extends PreactFieldElement<PasswordFieldProps['autocomplete']>\n  implements PasswordFieldProps\n{\n  accessor maxLength: PasswordFieldProps['maxLength'];\n  accessor minLength: PasswordFieldProps['minLength'];\n  /**\n   * The current password value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The value is masked in the UI for security.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -7264,7 +7899,8 @@
           "name": "containerName",
           "value": "string",
           "description": "An identifier for this container that you can reference in CSS container queries to apply styles based on this specific container's size.\n\nAll query container components automatically receive a container name of `s-default`. You can omit the container name in your queries, so `@container (inline-size <= 300px)` is equivalent to `@container s-default (inline-size <= 300px)`.\n\nWhen you provide a custom `containerName`, it's added alongside `s-default`. For example, `containerName=\"product-card\"` results in `s-default product-card` being set on the `container-name` CSS property, allowing you to target this container with `@container product-card (inline-size <= 300px)`.\n\nLearn more about the [container-name property](https://developer.mozilla.org/en-US/docs/Web/CSS/container-name).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7272,7 +7908,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7280,7 +7917,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7288,7 +7926,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7296,7 +7935,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7304,7 +7944,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7312,7 +7953,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7320,7 +7962,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class QueryContainer\n  extends PreactCustomElement\n  implements QueryContainerProps\n{\n  accessor containerName: QueryContainerProps['containerName'];\n  /** @private */\n  static globalStylesApplied: boolean;\n  constructor();\n}"
@@ -7339,7 +7982,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7347,14 +7991,16 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7362,35 +8008,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7398,14 +8049,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7413,7 +8066,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7421,7 +8075,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7429,7 +8084,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7437,7 +8093,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7445,7 +8102,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7453,7 +8111,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7461,7 +8120,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7469,21 +8129,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7491,7 +8154,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7499,7 +8163,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7507,7 +8172,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7515,7 +8181,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7523,7 +8190,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7531,7 +8199,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7539,7 +8208,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class SearchField\n  extends PreactFieldElement<SearchFieldProps['autocomplete']>\n  implements SearchFieldProps\n{\n  accessor maxLength: SearchFieldProps['maxLength'];\n  accessor minLength: SearchFieldProps['minLength'];\n  /**\n   * The current search query value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -7568,21 +8238,24 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure."
+          "description": "The heading text displayed at the top of the section. This heading provides a title for the section's content and automatically uses the appropriate semantic heading level (h2, h3, h4) based on nesting depth to maintain proper document structure.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7590,7 +8263,8 @@
           "name": "padding",
           "value": "\"base\" | \"none\"",
           "description": "The padding applied to all edges of the element.\n\n- `base`: applies padding that is appropriate for the element. Note that it might result in no padding if this is the right design decision in a particular context.\n- `none`: removes all padding from the element. This can be useful when elements inside the section need to span to the edge of the section. For example, a full-width image. In this case, rely on `s-box` with a padding of 'base' to bring back the desired padding for the rest of the content.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7598,7 +8272,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7606,7 +8281,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7614,7 +8290,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7622,7 +8299,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7630,7 +8308,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7638,7 +8317,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Section extends PreactCustomElement implements SectionProps {\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  accessor accessibilityLabel: SectionProps['accessibilityLabel'];\n  accessor heading: SectionProps['heading'];\n  accessor padding: SectionProps['padding'];\n}"
@@ -7656,35 +8336,40 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "icon",
           "value": "\"\" | \"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 541 more ... | \"x-circle-filled\"",
-          "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier."
+          "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7692,7 +8377,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7700,7 +8386,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7708,7 +8395,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7716,14 +8404,16 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "A lifecycle callback that fires when the component is removed from the DOM. Performs cleanup operations.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component."
+          "description": "The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7731,7 +8421,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7739,7 +8430,8 @@
           "name": "__@usedFirstOptionSymbol@3004",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7747,7 +8439,8 @@
           "name": "__@hasInitialValueSymbol@3005",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7755,21 +8448,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7777,7 +8473,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7785,7 +8482,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7793,7 +8491,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7801,7 +8500,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7809,7 +8509,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7817,7 +8518,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Select extends PreactInputElement implements SelectProps {\n  accessor icon: SelectProps['icon'];\n  accessor details: SelectProps['details'];\n  accessor error: SelectProps['error'];\n  accessor label: SelectProps['label'];\n  accessor placeholder: SelectProps['placeholder'];\n  accessor required: SelectProps['required'];\n  accessor labelAccessibilityVisibility: SelectProps['labelAccessibilityVisibility'];\n  /** @private */\n  connectedCallback(): void;\n  /**\n   * A lifecycle callback that fires when the component is removed from the DOM. Performs cleanup operations.\n   * @private\n   */\n  disconnectedCallback(): void;\n  constructor();\n  /**\n   * A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n   *\n   * This is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.\n   * @private\n   */\n  [usedFirstOptionSymbol]: boolean;\n  /**\n   * @private\n   */\n  [hasInitialValueSymbol]: boolean;\n  /**\n   * The value of the currently selected option. When setting this property programmatically, it updates which option appears selected in the dropdown. When reading it, you get the `value` attribute of the currently selected option component.\n   */\n  get value(): string;\n  set value(value: string);\n  /** @private */\n  formResetCallback(): void;\n}"
@@ -7835,7 +8537,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7843,7 +8546,8 @@
           "name": "size",
           "value": "\"base\" | \"large\" | \"large-100\"",
           "description": "The size of the loading spinner.\n\n- `base`: Default size suitable for inline loading indicators or standard UI contexts.\n- `large`: Larger spinner for more prominent loading states.\n- `large-100`: Extra large spinner for full-page or emphasized loading states.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7851,7 +8555,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7859,7 +8564,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7867,7 +8573,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7875,7 +8582,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7883,7 +8591,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7891,7 +8600,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7899,7 +8609,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Spinner extends PreactCustomElement implements SpinnerProps {\n  accessor accessibilityLabel: string;\n  accessor size: SpinnerProps['size'];\n  constructor();\n}"
@@ -7918,7 +8629,8 @@
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
           "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
-          "defaultValue": "'block'"
+          "defaultValue": "'block'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7926,7 +8638,8 @@
           "name": "justifyContent",
           "value": "JustifyContentKeyword",
           "description": "Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n\nUse this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7934,7 +8647,8 @@
           "name": "alignItems",
           "value": "AlignItemsKeyword",
           "description": "Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n\nUse this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7942,7 +8656,8 @@
           "name": "alignContent",
           "value": "AlignContentKeyword",
           "description": "Controls the distribution of lines along the block axis when content wraps into multiple lines.\n\nThis property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.",
-          "defaultValue": "'normal'"
+          "defaultValue": "'normal'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7950,7 +8665,8 @@
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
           "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7958,7 +8674,8 @@
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7966,7 +8683,8 @@
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
           "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7974,7 +8692,8 @@
           "name": "accessibilityRole",
           "value": "AccessibilityRole",
           "description": "The semantic meaning of the component’s content. When set, the role will be used by assistive technologies to help users navigate the page.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7982,7 +8701,8 @@
           "name": "background",
           "value": "BackgroundColorKeyword",
           "description": "The background color of the component.",
-          "defaultValue": "'transparent'"
+          "defaultValue": "'transparent'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7990,7 +8710,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7998,7 +8719,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum height in horizontal writing modes, or minimum width in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8006,7 +8728,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum height in horizontal writing modes, or maximum width in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8014,7 +8737,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The width in horizontal writing modes, or height in vertical writing modes. Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8022,7 +8746,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum width in horizontal writing modes, or minimum height in vertical writing modes. Prevents the element from shrinking below this size.\n\nLearn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8030,7 +8755,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum width in horizontal writing modes, or maximum height in vertical writing modes. Prevents the element from growing beyond this size.\n\nLearn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8038,7 +8764,8 @@
           "name": "overflow",
           "value": "\"visible\" | \"hidden\"",
           "description": "The overflow behavior of the element.\n\n- `visible`: the content that extends beyond the element’s container is visible.\n- `hidden`: clips the content when it is larger than the element’s container. The element will not be scrollable and the users will not be able to access the clipped content by dragging or using a scroll wheel on a mouse.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8046,7 +8773,8 @@
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
           "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8054,7 +8782,8 @@
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8062,7 +8791,8 @@
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8070,7 +8800,8 @@
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8078,7 +8809,8 @@
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
           "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8086,7 +8818,8 @@
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8094,7 +8827,8 @@
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
           "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8114,7 +8848,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8122,7 +8857,8 @@
           "name": "borderWidth",
           "value": "\"\" | MaybeAllValuesShorthandProperty<\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\" | \"none\">",
           "description": "The thickness of the border on all sides. When set, this overrides the width value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8130,7 +8866,8 @@
           "name": "borderStyle",
           "value": "\"\" | MaybeAllValuesShorthandProperty<BoxBorderStyles>",
           "description": "The visual style of the border on all sides, such as solid, dashed, or dotted. When set, this overrides the style value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8138,7 +8875,8 @@
           "name": "borderColor",
           "value": "\"\" | ColorKeyword",
           "description": "The color of the border using the design system's color scale. When set, this overrides the color value specified in the `border` property.",
-          "defaultValue": "'' - meaning no override"
+          "defaultValue": "'' - meaning no override",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8146,14 +8884,16 @@
           "name": "borderRadius",
           "value": "MaybeAllValuesShorthandProperty<BoxBorderRadii>",
           "description": "The roundedness of the element's corners using the design system's radius scale.",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8161,7 +8901,8 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8169,7 +8910,8 @@
           "name": "display",
           "value": "MaybeResponsive<\"auto\" | \"none\">",
           "description": "The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n\n- `auto` the component's initial value. The actual value depends on the component and context.\n- `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8177,7 +8919,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8185,7 +8928,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8193,7 +8937,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8201,7 +8946,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8209,7 +8955,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8217,7 +8964,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8225,7 +8973,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Stack extends BoxElement implements StackProps {\n  constructor();\n  accessor direction: StackProps['direction'];\n  accessor justifyContent: StackProps['justifyContent'];\n  accessor alignItems: StackProps['alignItems'];\n  accessor alignContent: StackProps['alignContent'];\n  accessor gap: StackProps['gap'];\n  accessor rowGap: StackProps['rowGap'];\n  accessor columnGap: StackProps['columnGap'];\n}"
@@ -8244,7 +8993,8 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8252,14 +9002,16 @@
           "name": "checked",
           "value": "boolean",
           "description": "Whether the control is currently checked. Use this for controlled components where you manage the checked state.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The value used in form data when the checkbox is checked."
+          "description": "The value used in form data when the checkbox is checked.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8267,35 +9019,40 @@
           "name": "defaultChecked",
           "value": "boolean",
           "description": "The initial checked state for uncontrolled components. Use this when you want the control to start checked but don't need to control its state afterward.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose."
+          "description": "A label that describes the purpose or content of the component for assistive technologies like screen readers. Use this to provide additional context when the visible content alone doesn't clearly convey the component's purpose.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state."
+          "description": "The text label displayed next to the checkbox that describes what the checkbox controls. Clicking the label will also toggle the checkbox state.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8303,7 +9060,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field needs a value. This requirement adds semantic value to the field, but it will not cause an error to appear automatically. If you want to present an error when this field is empty, you can do so with the `error` property.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8311,7 +9069,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8319,21 +9078,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8341,7 +9103,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8349,7 +9112,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8357,7 +9121,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8365,7 +9130,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8373,7 +9139,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8381,7 +9148,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8389,7 +9157,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8397,7 +9166,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Switch extends PreactCheckboxElement implements SwitchProps {\n  accessor labelAccessibilityVisibility: SwitchProps['labelAccessibilityVisibility'];\n  constructor();\n}"
@@ -8416,7 +9186,8 @@
           "name": "variant",
           "value": "\"auto\" | \"list\"",
           "description": "The layout variant of the table component.\n\n- `list`: Always displays as a list layout.\n- `table`: Always displays as a traditional table layout.\n- `auto`: Automatically displays as a table on wide screens and as a list on narrow screens.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8424,7 +9195,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether the table is in a loading state, such as during initial page load or when loading the next page in a paginated table. When `true`, the table might be in an inert state that prevents user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8432,7 +9204,8 @@
           "name": "paginate",
           "value": "boolean",
           "description": "Whether to use pagination controls.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8440,7 +9213,8 @@
           "name": "hasPreviousPage",
           "value": "boolean",
           "description": "Whether there's a previous page of data.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8448,7 +9222,8 @@
           "name": "hasNextPage",
           "value": "boolean",
           "description": "Whether there's an additional page of data.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8456,7 +9231,8 @@
           "name": "__@actualTableVariantSymbol@3080",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8464,7 +9240,8 @@
           "name": "__@tableHeadersSharedDataSymbol@3081",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8472,7 +9249,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8480,7 +9258,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8488,7 +9267,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8496,7 +9276,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8504,7 +9285,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8512,7 +9294,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8520,7 +9303,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Table extends PreactCustomElement implements TableProps {\n  accessor variant: TableProps['variant'];\n  accessor loading: TableProps['loading'];\n  accessor paginate: TableProps['paginate'];\n  accessor hasPreviousPage: TableProps['hasPreviousPage'];\n  accessor hasNextPage: TableProps['hasNextPage'];\n  /**\n   * @private\n   * The actual table variant, which is either 'table' or 'list'.\n   */\n  [actualTableVariantSymbol]: AddedContext<ActualTableVariant>;\n  /** @private */\n  [tableHeadersSharedDataSymbol]: AddedContext<\n    {\n      listSlot: TableHeaderProps['listSlot'];\n      textContent: string;\n      format: HeaderFormat;\n    }[]\n  >;\n\n  constructor();\n}"
@@ -8607,7 +9391,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8615,7 +9400,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8623,7 +9409,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8631,7 +9418,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8639,7 +9427,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8647,7 +9436,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8655,7 +9445,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableBody extends PreactCustomElement implements TableBodyProps {\n  constructor();\n}"
@@ -8674,7 +9465,8 @@
           "name": "__@headerFormatSymbol@3103",
           "value": "HeaderFormat",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8682,7 +9474,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8690,7 +9483,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8698,7 +9492,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8706,7 +9501,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8714,7 +9510,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8722,7 +9519,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8730,7 +9528,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableCell extends PreactCustomElement implements TableCellProps {\n  constructor();\n  /** @private */\n  get [headerFormatSymbol](): HeaderFormat;\n  /** @private */\n  set [headerFormatSymbol](format: HeaderFormat);\n}"
@@ -8749,14 +9548,16 @@
           "name": "listSlot",
           "value": "ListSlotType",
           "description": "The content designation for this column when the table displays in list variant on mobile devices.",
-          "defaultValue": "'labeled'"
+          "defaultValue": "'labeled'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "format",
           "value": "HeaderFormat",
-          "description": "The format of the column that controls styling and alignment of cell content."
+          "description": "The format of the column that controls styling and alignment of cell content.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8764,7 +9565,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8772,7 +9574,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8780,7 +9583,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8788,7 +9592,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8796,7 +9601,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8804,7 +9610,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8812,7 +9619,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableHeader\n  extends PreactCustomElement\n  implements TableHeaderProps\n{\n  accessor listSlot: TableHeaderProps['listSlot'];\n  accessor format: TableHeaderProps['format'];\n  constructor();\n}"
@@ -8831,7 +9639,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8839,7 +9648,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8847,7 +9657,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8855,7 +9666,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8863,7 +9675,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8871,7 +9684,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8879,7 +9693,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableHeaderRow\n  extends PreactCustomElement\n  implements TableHeaderRowProps\n{\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -8897,7 +9712,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "clickDelegate",
           "value": "string",
-          "description": "The ID of an interactive element, such as `s-link`, in the row that will be the target of the click when the row is clicked. This is the primary action for the row; it should not be used for secondary actions.\n\nThis is a click-only affordance, and does not introduce any keyboard or screen reader affordances. Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally."
+          "description": "The ID of an interactive element, such as `s-link`, in the row that will be the target of the click when the row is clicked. This is the primary action for the row; it should not be used for secondary actions.\n\nThis is a click-only affordance, and does not introduce any keyboard or screen reader affordances. Which is why the target element must be in the table; so that keyboard and screen reader users can interact with it normally.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8905,7 +9721,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8913,7 +9730,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8921,7 +9739,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8929,7 +9748,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8937,7 +9757,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8945,7 +9766,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8953,7 +9775,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TableRow extends PreactCustomElement implements TableRowProps {\n  constructor();\n  accessor clickDelegate: string;\n}"
@@ -8972,7 +9795,8 @@
           "name": "fontVariantNumeric",
           "value": "\"auto\" | \"normal\" | \"tabular-nums\"",
           "description": "The rendering style for numbers in the font.\n\n- `auto`: Inherits the setting from the parent element.\n- `normal`: Uses the font's default numeric glyphs.\n- `tabular-nums`: Uses fixed-width numeric glyphs, ensuring numbers align vertically in tables or lists.\n\nLearn more about the [font-variant-numeric property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8980,7 +9804,8 @@
           "name": "color",
           "value": "\"base\" | \"subdued\"",
           "description": "The color emphasis level that controls visual intensity.\n\n- `base`: Primary color for body text, standard UI elements, and general content with good readability.\n- `subdued`: Deemphasized color for secondary text, supporting labels, and less critical interface elements.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8988,7 +9813,8 @@
           "name": "tone",
           "value": "\"info\" | \"success\" | \"warning\" | \"critical\" | \"auto\" | \"neutral\" | \"caution\"",
           "description": "The semantic tone that's applied to the text, which changes its color to convey meaning.\n\n- `info`: Informational content or helpful tips (blue).\n- `success`: Positive outcomes or successful states (green).\n- `warning`: Important warnings about potential issues (orange).\n- `critical`: Urgent problems or destructive actions (red).\n- `auto`: Automatically determined based on context.\n- `neutral`: General information without specific intent (gray).\n- `caution`: Advisory notices that need attention (yellow).",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8996,7 +9822,8 @@
           "name": "type",
           "value": "\"strong\" | \"generic\" | \"address\" | \"redundant\"",
           "description": "The semantic type and styling treatment for the text content.\n\n- `strong`: Emphasizes the text with strong importance, typically displayed in bold.\n- `generic`: Standard text with no special semantic meaning or styling.\n- `address`: Marks the text as contact information, such as a physical or email address.\n- `redundant`: Indicates the text is redundant or duplicated information for screen reader context.",
-          "defaultValue": "'generic'"
+          "defaultValue": "'generic'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9004,7 +9831,8 @@
           "name": "dir",
           "value": "\"\" | \"auto\" | \"ltr\" | \"rtl\"",
           "description": "Indicates the directionality of the element’s text.\n\n- `\"\"`: The direction is inherited from parent elements (equivalent to not setting the attribute).\n- `auto`: The user agent determines the direction based on the content.\n- `ltr`: The languages written from left to right (such as English).\n- `rtl`: The languages written from right to left (such as Arabic).\n\nLearn more about the [dir attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir).",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9012,14 +9840,16 @@
           "name": "accessibilityVisibility",
           "value": "\"visible\" | \"hidden\" | \"exclusive\"",
           "description": "The visibility mode of the element for both visual and assistive technology users.\n\n- `visible`: The element is visible to all users (both sighted users and screen readers).\n- `hidden`: The element is visually visible but hidden from screen readers. Use this for decorative elements that don't provide meaningful information.\n- `exclusive`: The element is visually hidden but announced by screen readers. Use this for screen-reader-only content like skip links or additional context.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "interestFor",
           "value": "string",
-          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information."
+          "description": "The ID of the component to show when users hover over or focus on this component. Use this to connect interactive components to popovers or tooltips that provide additional context or information.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9027,7 +9857,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9035,7 +9866,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9043,7 +9875,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9051,7 +9884,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9059,7 +9893,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9067,7 +9902,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9075,7 +9911,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Text extends PreactCustomElement implements TextProps {\n  accessor fontVariantNumeric: TextProps['fontVariantNumeric'];\n  accessor color: TextProps['color'];\n  /**\n   * The semantic tone that's applied to the text, which changes its color to convey meaning.\n   *\n   * - `info`: Informational content or helpful tips (blue).\n   * - `success`: Positive outcomes or successful states (green).\n   * - `warning`: Important warnings about potential issues (orange).\n   * - `critical`: Urgent problems or destructive actions (red).\n   * - `auto`: Automatically determined based on context.\n   * - `neutral`: General information without specific intent (gray).\n   * - `caution`: Advisory notices that need attention (yellow).\n   */\n  accessor tone: TextProps['tone'];\n  /**\n   * The semantic type and styling treatment for the text content.\n   *\n   * - `strong`: Emphasizes the text with strong importance, typically displayed in bold.\n   * - `generic`: Standard text with no special semantic meaning or styling.\n   * - `address`: Marks the text as contact information, such as a physical or email address.\n   * - `redundant`: Indicates the text is redundant or duplicated information for screen reader context.\n   */\n  accessor type: TextProps['type'];\n  accessor dir: TextProps['dir'];\n  accessor accessibilityVisibility: TextProps['accessibilityVisibility'];\n  accessor interestFor: string;\n  constructor();\n}"
@@ -9094,7 +9931,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9102,7 +9940,8 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9110,14 +9949,16 @@
           "name": "rows",
           "value": "number",
           "description": "A number of visible text lines.",
-          "defaultValue": "2"
+          "defaultValue": "2",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9125,35 +9966,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9161,14 +10007,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9176,7 +10024,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9184,7 +10033,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9192,7 +10042,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9200,7 +10051,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9208,7 +10060,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9216,7 +10069,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9224,7 +10078,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9232,21 +10087,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9254,7 +10112,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9262,7 +10121,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9270,7 +10130,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9278,7 +10139,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9286,7 +10148,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9294,7 +10157,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9302,7 +10166,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TextArea\n  extends PreactFieldElement<TextAreaProps['autocomplete']>\n  implements TextAreaProps\n{\n  accessor maxLength: TextAreaProps['maxLength'];\n  accessor minLength: TextAreaProps['minLength'];\n  accessor rows: TextAreaProps['rows'];\n  /**\n   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -9321,7 +10186,8 @@
           "name": "icon",
           "value": "\"replace\" | \"search\" | \"split\" | \"link\" | \"edit\" | \"info\" | \"incomplete\" | \"complete\" | \"product\" | \"variant\" | \"collection\" | \"select\" | \"color\" | \"money\" | \"order\" | \"code\" | ... 542 more ... | AnyString",
           "description": "An icon displayed inside the field to provide visual context about the expected input or field purpose. Commonly used for search fields, currency inputs, or to indicate field type. Accepts any icon name from the icon library or a custom string identifier.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9329,7 +10195,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9337,7 +10204,8 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9345,7 +10213,8 @@
           "name": "prefix",
           "value": "string",
           "description": "A non-editable text value displayed immediately before the editable portion of the field. This is useful for displaying an implied part of the value, such as `https://` or `+353`.\n\nThis text can't be edited by the user and is not included in the field's value. The prefix might not appear until the user interacts with the field. For example, an inline label might occupy the prefix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9353,14 +10222,16 @@
           "name": "suffix",
           "value": "string",
           "description": "A non-editable text value displayed immediately after the editable portion of the field. This is useful for displaying an implied part of the value, such as `@shopify.com` or `%`.\n\nThis text can't be edited by the user and is not included in the field's value. The suffix might not appear until the user interacts with the field. For example, an inline label might occupy the suffix position until the user focuses the field.",
-          "defaultValue": "''"
+          "defaultValue": "''",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input."
+          "description": "The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9368,35 +10239,40 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | TextAutocompleteField | `section-${string} one-time-code` | \"shipping one-time-code\" | \"billing one-time-code\" | `section-${string} shipping one-time-code` | `section-${string} billing one-time-code` | `section-${string} language` | `section-${string} organization` | `section-${string} name` | ... 141...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9404,14 +10280,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9419,7 +10297,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9427,7 +10306,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9435,7 +10315,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9443,7 +10324,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9451,7 +10333,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9459,7 +10342,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9467,7 +10351,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9475,21 +10360,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9497,7 +10385,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9505,7 +10394,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9513,7 +10403,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9521,7 +10412,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9529,7 +10421,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9537,7 +10430,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9545,7 +10439,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class TextField\n  extends PreactFieldElement<TextFieldProps['autocomplete']>\n  implements TextFieldProps\n{\n  accessor icon: TextFieldProps['icon'];\n  accessor maxLength: TextFieldProps['maxLength'];\n  accessor minLength: TextFieldProps['minLength'];\n  accessor prefix: TextFieldProps['prefix'];\n  accessor suffix: TextFieldProps['suffix'];\n  /**\n   * The current text value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -9563,7 +10458,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered."
+          "description": "The image source (either a remote URL or a local file resource).\n\nWhen the image is loading or no `src` is provided, a placeholder is rendered.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9571,7 +10467,8 @@
           "name": "alt",
           "value": "string",
           "description": "Alternative text that describes the image for accessibility.\n\nProvides a text description of the image for users with assistive technology and serves as a fallback when the image fails to load. A well-written description enables people with visual impairments to understand non-text content.\n\nWhen a screen reader encounters an image, it reads this description aloud. When an image fails to load, this text displays on screen, helping all users understand what content was intended.\n\nLearn more about [writing effective alt text](https://www.shopify.com/ca/blog/image-alt-text#4) and the [alt attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt).",
-          "defaultValue": "``"
+          "defaultValue": "``",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9579,7 +10476,8 @@
           "name": "size",
           "value": "\"small\" | \"small-200\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
           "description": "The size of the product thumbnail image.\n\n- `small-200`: Smallest thumbnail size, ideal for compact product lists or tables.\n- `small-100`: Very small thumbnail, suitable for dense layouts.\n- `small`: Small thumbnail for space-constrained contexts.\n- `base`: Default size that balances visibility and space efficiency.\n- `large`: Larger thumbnail for featured products or detailed views.\n- `large-100`: Extra large thumbnail for prominent product display.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9587,7 +10485,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9595,7 +10494,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9603,7 +10503,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9611,7 +10512,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9619,7 +10521,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9627,7 +10530,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9635,7 +10539,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Thumbnail extends PreactCustomElement implements ThumbnailProps {\n  accessor src: ThumbnailProps['src'];\n  accessor alt: ThumbnailProps['alt'];\n  accessor size: ThumbnailProps['size'];\n  constructor();\n}"
@@ -9654,7 +10559,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9662,7 +10568,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9670,7 +10577,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9678,7 +10586,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9686,7 +10595,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9694,7 +10604,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9702,7 +10613,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9710,7 +10622,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9718,7 +10631,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9726,7 +10640,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Tooltip extends PreactOverlayElement implements TooltipProps {\n  constructor();\n}"
@@ -9745,7 +10660,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9753,7 +10669,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9761,7 +10678,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9769,7 +10687,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9777,7 +10696,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9785,7 +10705,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9793,7 +10714,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class UnorderedList\n  extends PreactCustomElement\n  implements UnorderedListProps\n{\n  constructor();\n}"
@@ -9812,7 +10734,8 @@
           "name": "autocomplete",
           "value": "\"on\" | \"off\" | `section-${string} url` | `section-${string} photo` | `section-${string} impp` | `section-${string} home impp` | `section-${string} mobile impp` | `section-${string} fax impp` | `section-${string} pager impp` | \"shipping url\" | \"shipping photo\" | \"shipping impp\" | \"shipping home impp\" | \"shipping mobi...",
           "description": "Controls browser autofill behavior for the field.\n\nBasic values:\n- `on` - Enables autofill without specifying content type (default)\n- `off` - Disables autofill for sensitive data or one-time codes\n\nSpecific field values describe the expected data type. You can optionally prefix these with:\n- `section-${string}` - Scopes autofill to a specific form section (when multiple forms exist on the same page)\n- `shipping` or `billing` - Indicates whether the data is for shipping or billing purposes\n- Both section and group (for example, `section-primary shipping email`)\n\nProviding a specific autofill token helps browsers suggest more relevant saved data.\n\nLearn more about the set of [autocomplete values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens) supported in browsers.",
-          "defaultValue": "'on' for everything else"
+          "defaultValue": "'on' for everything else",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9820,7 +10743,8 @@
           "name": "maxLength",
           "value": "number",
           "description": "The maximum number of characters allowed in the field.",
-          "defaultValue": "Infinity"
+          "defaultValue": "Infinity",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9828,42 +10752,48 @@
           "name": "minLength",
           "value": "number",
           "description": "The minimum number of characters required in the field.",
-          "defaultValue": "0"
+          "defaultValue": "0",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
           "name": "value",
           "value": "string",
-          "description": "The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing."
+          "description": "The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "defaultValue",
           "value": "string",
-          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead."
+          "description": "The initial value of the field when it first loads. Unlike `placeholder`, this is a real value that the user can edit and that gets submitted with the form. Once the user starts typing, their input replaces it. Changing this property after the field has loaded has no effect. To update the field value at any time, use `value` instead.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "label",
           "value": "string",
-          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide."
+          "description": "The text displayed as the field label, which identifies the purpose of the field to users. This label is associated with the field for accessibility and helps users understand what information to provide.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9871,14 +10801,16 @@
           "name": "labelAccessibilityVisibility",
           "value": "\"visible\" | \"exclusive\"",
           "description": "Controls whether the label is visible to all users or only to screen readers.\n\n- `visible`: The label is shown to everyone (default).\n- `exclusive`: The label is visually hidden but still announced by screen readers.\n\nUse `exclusive` when the surrounding context makes the label redundant visually, but screen reader users still need it for clarity.",
-          "defaultValue": "'visible'"
+          "defaultValue": "'visible'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "placeholder",
           "value": "string",
-          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value."
+          "description": "The placeholder text displayed in the field when it's empty, providing a hint about the expected input format or value.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9886,7 +10818,8 @@
           "name": "readOnly",
           "value": "boolean",
           "description": "Whether the field is read-only and can't be edited. Read-only fields remain focusable and their content is announced by screen readers.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9894,7 +10827,8 @@
           "name": "required",
           "value": "boolean",
           "description": "Whether the field requires a value before form submission. Displays a visual indicator and adds semantic meaning, but doesn't automatically validate or show errors. Use the `error` property to display validation messages.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9902,7 +10836,8 @@
           "name": "getAttribute",
           "value": "(qualifiedName: string) => string",
           "description": "Global keyboard event handlers for things like key bindings typically ignore keystrokes originating from within input elements. Unfortunately, these never account for a Custom Element being the input element.\n\nTo fix this, we spoof getAttribute & hasAttribute to make a PreactFieldElement appear as a contentEditable \"input\" when it contains a focused input element.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9910,7 +10845,8 @@
           "name": "hasAttribute",
           "value": "(qualifiedName: string) => boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9918,7 +10854,8 @@
           "name": "isContentEditable",
           "value": "boolean",
           "description": "Whether the shadow tree contains a focused input (input, textarea, select, <x contentEditable>).\n\nNote: this does _not_ return true for focussed non-field form elements like buttons.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9926,7 +10863,8 @@
           "name": "formResetCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9934,7 +10872,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9942,21 +10881,24 @@
           "name": "disabled",
           "value": "boolean",
           "description": "Whether the field is disabled, preventing any user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "id",
           "value": "string",
-          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting."
+          "description": "A unique identifier for the element. Use this to reference the element in JavaScript, link labels to form controls, or target specific elements for styling or scripting.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "name",
           "value": "string",
-          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form."
+          "description": "The name attribute for the field, used to identify the field's value when the form is submitted. Must be unique within the nearest containing form.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9964,7 +10906,8 @@
           "name": "__@internals$4@2356",
           "value": "ElementInternals",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9972,7 +10915,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9980,7 +10924,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9988,7 +10933,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9996,7 +10942,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10004,7 +10951,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10012,7 +10960,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class URLField\n  extends PreactFieldElement<URLFieldProps['autocomplete']>\n  implements URLFieldProps\n{\n  accessor autocomplete: URLFieldProps['autocomplete'];\n  accessor maxLength: URLFieldProps['maxLength'];\n  accessor minLength: URLFieldProps['minLength'];\n  /**\n   * The current URL value in the field as a string. When setting this property programmatically, it updates the field's display value. When reading it, you get the user's current input. The field validates this value as a URL format when the user finishes editing.\n   */\n  get value(): string;\n  set value(value: string);\n  constructor();\n}"
@@ -10030,7 +10979,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The text to use as the Action modal's title. If not provided, the name of the extension will be used."
+          "description": "The text to use as the Action modal's title. If not provided, the name of the extension will be used.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10038,7 +10988,8 @@
           "name": "loading",
           "value": "boolean",
           "description": "Whether the action is in a loading state, such as during initial page load or when the action is being opened. When `true`, the action might be in an inert state that prevents user interaction.",
-          "defaultValue": "false"
+          "defaultValue": "false",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10046,7 +10997,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10054,7 +11006,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10062,7 +11015,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10070,7 +11024,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10078,7 +11033,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10086,7 +11042,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10094,7 +11051,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminAction\n  extends PreactCustomElement\n  implements AdminActionProps\n{\n  /**\n   * The text to use as the Action modal's title. If not provided, the name of the extension will be used.\n   */\n  heading: string;\n  /**\n   * Whether the action is in a loading state, such as during initial page load or when the action is being opened.\n   * When `true`, the action might be in an inert state that prevents user interaction.\n   */\n  loading: boolean;\n  constructor();\n}"
@@ -10332,14 +11290,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The text displayed as the block's title in the header. If not provided, the extension name will be used."
+          "description": "The text displayed as the block's title in the header. If not provided, the extension name will be used.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "collapsedSummary",
           "value": "string",
-          "description": "The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated."
+          "description": "The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10347,7 +11307,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10355,7 +11316,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10363,7 +11325,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10371,7 +11334,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10379,7 +11343,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10387,7 +11352,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10395,7 +11361,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminBlock\n  extends PreactCustomElement\n  implements AdminBlockProps\n{\n  /**\n   * The text displayed as the block's title in the header. If not provided, the extension name will be used.\n   */\n  heading: string;\n  /**\n   * The summary text displayed when the app block is collapsed. Summaries longer than 30 characters will be truncated.\n   */\n  collapsedSummary: string;\n  constructor();\n}"
@@ -10414,7 +11381,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10422,7 +11390,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10430,7 +11399,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10438,7 +11408,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10446,7 +11417,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10454,7 +11426,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10462,7 +11435,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Form extends PreactCustomElement implements FormProps {\n  constructor();\n}"
@@ -11001,14 +11975,16 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "accessibilityLabel",
           "value": "string",
-          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers."
+          "description": "A label that describes the purpose of the modal. When set, it will be announced to users using assistive technologies and will provide them with more context.\n\nThis overrides the `heading` prop for screen readers.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "A title that describes the content of the modal."
+          "description": "A title that describes the content of the modal.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11016,7 +11992,8 @@
           "name": "padding",
           "value": "\"base\" | \"none\"",
           "description": "Adjust the padding around the modal content.\n\n`base`: applies padding that is appropriate for the element.\n\n`none`: removes all padding from the element. This can be useful when elements inside the modal need to span to the edge of the modal. For example, a full-width image. In this case, rely on box with a padding of 'base' to bring back the desired padding for the rest of the content.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11024,28 +12001,32 @@
           "name": "size",
           "value": "\"small\" | \"small-100\" | \"base\" | \"large\" | \"large-100\"",
           "description": "The size of the modal component, controlling its width and height. Larger sizes provide more space for content while smaller sizes are more compact.",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "showOverlay",
           "value": "() => void",
-          "description": "A method to programmatically show the overlay."
+          "description": "A method to programmatically show the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "hideOverlay",
           "value": "() => void",
-          "description": "A method to programmatically hide the overlay."
+          "description": "A method to programmatically hide the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
           "name": "toggleOverlay",
           "value": "() => void",
-          "description": "A method to programmatically toggle the visibility of the overlay."
+          "description": "A method to programmatically toggle the visibility of the overlay.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11053,7 +12034,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11061,7 +12043,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11069,7 +12052,8 @@
           "name": "__@abortController@2785",
           "value": "AbortController",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11077,7 +12061,8 @@
           "name": "__@dialog@2779",
           "value": "HTMLDialogElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11085,7 +12070,8 @@
           "name": "__@focusedElement@2781",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11093,7 +12079,8 @@
           "name": "__@nestedModals@2783",
           "value": "Map<Modal, boolean>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11101,7 +12088,8 @@
           "name": "__@childrenRerenderObserver@2787",
           "value": "MutationObserver",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11109,7 +12097,8 @@
           "name": "__@shadowDomRerenderObserver@2788",
           "value": "MutationObserver",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11117,7 +12106,8 @@
           "name": "__@onEscape@2782",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11125,7 +12115,8 @@
           "name": "__@onBackdropClick@2784",
           "value": "(event: MouseEvent) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11133,7 +12124,8 @@
           "name": "__@onChildModalChange@2786",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11141,7 +12133,8 @@
           "name": "__@isOpen@2778",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11149,7 +12142,8 @@
           "name": "__@dismiss@2780",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11157,7 +12151,8 @@
           "name": "__@hasOpenChildModal@2775",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11165,7 +12160,8 @@
           "name": "__@show@2776",
           "value": "() => Promise<void>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11173,7 +12169,8 @@
           "name": "__@hide@2777",
           "value": "() => Promise<void>",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11181,7 +12178,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11189,7 +12187,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11197,7 +12196,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11205,7 +12205,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11213,7 +12214,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11221,7 +12223,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11229,7 +12232,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11237,7 +12241,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Modal extends PreactOverlayElement implements ModalProps {\n  accessor accessibilityLabel: ModalProps['accessibilityLabel'];\n  accessor heading: ModalProps['heading'];\n  accessor padding: ModalProps['padding'];\n  accessor size: ModalProps['size'];\n  /** @private */\n  [abortController]: AbortController;\n  /** @private */\n  [dialog]: HTMLDialogElement | null;\n  /** @private */\n  [focusedElement]: HTMLElement | null;\n  /** @private */\n  [nestedModals]: Map<Modal, boolean>;\n  /** @private */\n  [childrenRerenderObserver]: MutationObserver;\n  /** @private */\n  [shadowDomRerenderObserver]: MutationObserver;\n  /** @private */\n  [onEscape]: (event: KeyboardEvent) => void;\n  /** @private */\n  [onBackdropClick]: (event: MouseEvent) => void;\n  /** @private */\n  [onChildModalChange]: EventListenerOrEventListenerObject;\n  /** @private */\n  get [isOpen](): boolean;\n  /** @private */\n  [dismiss](): void;\n  /** @private */\n  get [hasOpenChildModal](): boolean;\n  /** @private */\n  [show](): Promise<void>;\n  /** @private */\n  [hide](): Promise<void>;\n  showOverlay(): void;\n  hideOverlay(): void;\n  toggleOverlay(): void;\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n  constructor();\n}"
@@ -11256,14 +12261,16 @@
           "name": "inlineSize",
           "value": "\"small\" | \"base\" | \"large\"",
           "description": "The inline size of the page\n- `base` corresponds to a set default inline size\n- `large` full width with whitespace",
-          "defaultValue": "'base'"
+          "defaultValue": "'base'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "heading",
           "value": "string",
-          "description": "The main page heading"
+          "description": "The main page heading",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11271,7 +12278,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11279,7 +12287,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11287,7 +12296,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11295,7 +12305,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11303,7 +12314,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11311,7 +12323,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11319,7 +12332,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Page extends PreactCustomElement implements PageProps {\n  accessor inlineSize: PageProps['inlineSize'];\n  accessor heading: PageProps['heading'];\n  constructor();\n  /** @private */\n  connectedCallback(): void;\n  /** @private */\n  disconnectedCallback(): void;\n}"
@@ -12086,7 +13100,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12094,7 +13109,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12102,7 +13118,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12110,7 +13127,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12118,7 +13136,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12126,7 +13145,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12134,7 +13154,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class FunctionSettings\n  extends PreactCustomElement\n  implements FunctionSettingsProps\n{\n  constructor();\n}"
@@ -12235,7 +13256,8 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "src",
           "value": "string",
-          "description": "The `src` URL of the preview and the document to print. If not provided, the preview will show an empty state and the print button will be disabled. HTML, PDFs, and images are supported."
+          "description": "The `src` URL of the preview and the document to print. If not provided, the preview will show an empty state and the print button will be disabled. HTML, PDFs, and images are supported.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12243,7 +13265,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12251,7 +13274,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12259,7 +13283,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12267,7 +13292,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12275,7 +13301,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12283,7 +13310,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12291,7 +13319,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class AdminPrintAction\n  extends PreactCustomElement\n  implements AdminPrintActionProps\n{\n  /**\n   * The `src` URL of the preview and the document to print.\n   * If not provided, the preview will show an empty state and the print button will be disabled.\n   * HTML, PDFs, and images are supported.\n   */\n  src: string;\n  constructor();\n}"
@@ -13234,8 +14263,8 @@
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "IntentAction",
-      "value": "'create' | 'edit'",
-      "description": "The type of operation to perform: creating a new resource or editing an existing one.",
+      "value": "'create' | 'edit' | 'pick'",
+      "description": "The type of operation to perform: creating a new resource, editing an existing one, or picking existing resources.",
       "isPublicDocs": true
     }
   },
@@ -13244,7 +14273,7 @@
       "filePath": "src/surfaces/admin/api/intents/intents.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "IntentType",
-      "value": "'shopify/Article' | 'shopify/Catalog' | 'shopify/Collection' | 'shopify/Customer' | 'shopify/Discount' | 'shopify/Location' | 'shopify/Market' | 'shopify/Menu' | 'shopify/MetafieldDefinition' | 'shopify/Metaobject' | 'shopify/MetaobjectDefinition' | 'shopify/Page' | 'shopify/Product' | 'shopify/ProductVariant'",
+      "value": "'shopify/Article' | 'shopify/Catalog' | 'shopify/Collection' | 'shopify/Customer' | 'shopify/Discount' | 'shopify/File' | 'shopify/Location' | 'shopify/Market' | 'shopify/Menu' | 'shopify/MetafieldDefinition' | 'shopify/Metaobject' | 'shopify/MetaobjectDefinition' | 'shopify/Page' | 'shopify/Product' | 'shopify/ProductVariant'",
       "description": "The types of Shopify resources that support intent-based creation and editing workflows.",
       "isPublicDocs": true
     }
@@ -19732,7 +20761,8 @@
           "name": "blockSize",
           "value": "SizeUnitsOrAuto",
           "description": "The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n\nBlock size adjusts based on the writing direction: in horizontal layouts, it controls the height; in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n\nLearn more about the [block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n\n- `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.\n- `auto`: Automatically sizes based on content and layout constraints.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19740,7 +20770,8 @@
           "name": "minBlockSize",
           "value": "SizeUnits",
           "description": "The minimum vertical size of the element in standard layouts (min-height in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming smaller than this size along the block axis.\n\nLearn more about the [min-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19748,7 +20779,8 @@
           "name": "maxBlockSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum vertical size of the element in standard layouts (max-height in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming larger than this size along the block axis.\n\nLearn more about the [max-block-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19756,7 +20788,8 @@
           "name": "inlineSize",
           "value": "SizeUnitsOrAuto",
           "description": "The horizontal size of the element in standard layouts (width in left-to-right or right-to-left writing modes).\n\nInline size adjusts based on the writing direction: in horizontal layouts, it controls the width; in vertical layouts, it controls the height. This ensures consistent behavior across different text directions.\n\nLearn more about the [inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n\n- `SizeUnits`: Specific size values in pixels, percentages, or zero for precise control.\n- `auto`: Automatically sizes based on content and layout constraints.",
-          "defaultValue": "'auto'"
+          "defaultValue": "'auto'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19764,7 +20797,8 @@
           "name": "minInlineSize",
           "value": "SizeUnits",
           "description": "The minimum horizontal size of the element in standard layouts (min-width in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming smaller than this size along the inline axis.\n\nLearn more about the [min-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).",
-          "defaultValue": "'0'"
+          "defaultValue": "'0'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19772,7 +20806,8 @@
           "name": "maxInlineSize",
           "value": "SizeUnitsOrNone",
           "description": "The maximum horizontal size of the element in standard layouts (max-width in left-to-right or right-to-left writing modes).\n\nPrevents the element from becoming larger than this size along the inline axis.\n\nLearn more about the [max-inline-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).",
-          "defaultValue": "'none'"
+          "defaultValue": "'none'",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19780,7 +20815,8 @@
           "name": "__@overlayHidden@2725",
           "value": "boolean",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19788,7 +20824,8 @@
           "name": "__@overlayActivator@2726",
           "value": "HTMLElement",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19796,7 +20833,8 @@
           "name": "__@overlayHideFrameId@2727",
           "value": "number",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19804,7 +20842,8 @@
           "name": "setAttribute",
           "value": "(name: string, value: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19812,7 +20851,8 @@
           "name": "attributeChangedCallback",
           "value": "(name: string) => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19820,7 +20860,8 @@
           "name": "connectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19828,7 +20869,8 @@
           "name": "disconnectedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19836,7 +20878,8 @@
           "name": "adoptedCallback",
           "value": "() => void",
           "description": "",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19844,7 +20887,8 @@
           "name": "queueRender",
           "value": "() => void",
           "description": "A method that queues a run of the render function. You shouldn't need to call this manually - it should be handled by changes to",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -19852,7 +20896,8 @@
           "name": "click",
           "value": "({ sourceEvent }?: ClickOptions) => void",
           "description": "A method like the standard `element.click()`, but you can influence the behavior with a `sourceEvent`.\n\nFor example, if the `sourceEvent` was a middle click, or has particular keys held down, components will attempt to produce the desired behavior on links, such as opening the page in the background tab.",
-          "isPrivate": true
+          "isPrivate": true,
+          "isOptional": true
         }
       ],
       "value": "declare class Popover\n  extends PreactPopoverElement<typeof tagName$p>\n  implements PopoverProps\n{\n  constructor();\n}"
@@ -20419,14 +21464,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the avatar image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the avatar image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the avatar image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the avatar image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface AvatarEvents {\n  /**\n   * A callback fired when the avatar image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the avatar image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -20463,14 +21510,16 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the banner is hidden."
+          "description": "A callback fired after the banner is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "dismiss",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the banner is dismissed."
+          "description": "A callback fired when the banner is dismissed.",
+          "isOptional": true
         }
       ],
       "value": "export interface BannerEvents {\n  /**\n   * A callback fired when the banner is dismissed.\n   */\n  dismiss: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the banner is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20534,21 +21583,24 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the button loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the button is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the button receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the button receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ButtonEvents {\n  /**\n   * A callback fired when the button is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the button loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the button receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20620,14 +21672,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the checkbox value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the checkbox value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the checkbox.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the checkbox.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface CheckboxEvents {\n  /**\n   * A callback fired when the checkbox value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the checkbox.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -20699,14 +21753,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the choice list selection changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the choice list selection changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the choice list.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the choice list.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ChoiceListEvents {\n  /**\n   * A callback fired when the choice list selection changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the choice list.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20743,21 +21799,24 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the component loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the component is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the component receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the component receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ClickableEvents {\n  /**\n   * A callback fired when the component is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the component loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the component receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20794,21 +21853,24 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the chip is hidden."
+          "description": "A callback fired after the chip is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the chip is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the chip is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "remove",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the chip is removed."
+          "description": "A callback fired when the chip is removed.",
+          "isOptional": true
         }
       ],
       "value": "export interface ClickableChipEvents {\n  /**\n   * A callback fired when the chip is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the chip is removed.\n   */\n  remove: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the chip is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20853,28 +21915,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the color field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the color field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the color field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the color field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the color field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the color field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ColorFieldEvents {\n  /**\n   * A callback fired when the color field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the color field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the color field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the color field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -20892,14 +21958,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the color picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the color picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the color picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the color picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ColorPickerEvents {\n  /**\n   * A callback fired when the color picker value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the color picker.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20917,42 +21985,48 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the date field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the date field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the date field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the date field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the date field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the date field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "invalid",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date field value is invalid.\n\nLearn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event)."
+          "description": "A callback fired when the date field value is invalid.\n\nLearn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "viewchange",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the calendar view changes (such as when navigating between months)."
+          "description": "A callback fired when the calendar view changes (such as when navigating between months).",
+          "isOptional": true
         }
       ],
       "value": "export interface DateFieldEvents {\n  /**\n   * A callback fired when the date field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the date field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the date field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the date field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the calendar view changes (such as when navigating between months).\n   */\n  viewchange: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date field value is invalid.\n   *\n   * Learn more about the [invalid event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/invalid_event).\n   */\n  invalid: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -20970,35 +22044,40 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the date picker loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the date picker value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the date picker receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the date picker receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user inputs data into the date picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the date picker.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "viewchange",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the calendar view changes, such as when navigating between months."
+          "description": "A callback fired when the calendar view changes, such as when navigating between months.",
+          "isOptional": true
         }
       ],
       "value": "export interface DatePickerEvents {\n  /**\n   * A callback fired when the calendar view changes, such as when navigating between months.\n   */\n  viewchange: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user inputs data into the date picker.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the date picker value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21016,21 +22095,24 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when the drop zone value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the drop zone value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "droprejected",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when a dropped file is rejected due to file type or size restrictions."
+          "description": "A callback fired when a dropped file is rejected due to file type or size restrictions.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<typeof tagName>",
-          "description": "A callback fired when the user inputs data into the drop zone.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the drop zone.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface DropZoneEvents {\n  /**\n   * A callback fired when the drop zone value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<typeof tagName> = null;\n  /**\n   * A callback fired when the user inputs data into the drop zone.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<typeof tagName> = null;\n  /**\n   * A callback fired when a dropped file is rejected due to file type or size restrictions.\n   */\n  droprejected: CallbackEventListener<typeof tagName> = null;\n}"
@@ -21067,28 +22149,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the email field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the email field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the email field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the email field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the email field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the email field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface EmailFieldEvents {\n  /**\n   * A callback fired when the email field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the email field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the email field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the email field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21163,14 +22249,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ImageEvents {\n  /**\n   * A callback fired when the image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -21188,7 +22276,8 @@
           "syntaxKind": "PropertySignature",
           "name": "click",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the link is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)."
+          "description": "A callback fired when the link is clicked.\n\nLearn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface LinkEvents {\n  /**\n   * A callback fired when the link is clicked.\n   *\n   * Learn more about the [click event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event).\n   */\n  click: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21263,28 +22352,32 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the modal is hidden."
+          "description": "A callback fired after the modal is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftershow",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired after the modal is shown."
+          "description": "A callback fired after the modal is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "hide",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the modal is hidden."
+          "description": "A callback fired when the modal is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "show",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the modal is shown."
+          "description": "A callback fired when the modal is shown.",
+          "isOptional": true
         }
       ],
       "value": "export interface ModalEvents {\n  /**\n   * A callback fired when the modal is hidden.\n   */\n  hide: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the modal is shown.\n   */\n  show: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the modal is hidden.\n   */\n  afterhide: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired after the modal is shown.\n   */\n  aftershow: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21337,28 +22430,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the money field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the money field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the money field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the money field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the money field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the money field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface MoneyFieldEvents {\n  /**\n   * A callback fired when the money field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the money field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the money field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the money field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21376,28 +22473,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the number field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the number field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the number field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the number field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the number field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the number field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface NumberFieldEvents {\n  /**\n   * A callback fired when the number field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the number field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the number field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the number field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21542,28 +22643,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the password field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the password field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the password field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the password field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the password field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the password field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface PasswordFieldEvents {\n  /**\n   * A callback fired when the password field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the password field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the password field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the password field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21581,42 +22686,48 @@
           "syntaxKind": "PropertySignature",
           "name": "afterhide",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is hidden."
+          "description": "A callback fired after the popover is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftershow",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is shown."
+          "description": "A callback fired after the popover is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "aftertoggle",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired after the popover is toggled."
+          "description": "A callback fired after the popover is toggled.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "hide",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is hidden."
+          "description": "A callback fired when the popover is hidden.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "show",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is shown."
+          "description": "A callback fired when the popover is shown.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "toggle",
           "value": "CallbackEventListener<TTagName> | null",
-          "description": "A callback fired when the popover is toggled."
+          "description": "A callback fired when the popover is toggled.",
+          "isOptional": true
         }
       ],
       "value": "export interface PopoverEvents {\n  /**\n   * A callback fired when the popover is shown.\n   */\n  show: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired when the popover is hidden.\n   */\n  hide: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is shown.\n   */\n  aftershow: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is hidden.\n   */\n  afterhide: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired when the popover is toggled.\n   */\n  toggle: CallbackEventListener<TTagName> | null;\n  /**\n   * A callback fired after the popover is toggled.\n   */\n  aftertoggle: CallbackEventListener<TTagName> | null;\n}"
@@ -21672,28 +22783,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the search field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the search field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the search field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the search field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the search field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the search field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SearchFieldEvents {\n  /**\n   * A callback fired when the search field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the search field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the search field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the search field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -21730,14 +22845,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the select value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the select value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the select.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the select.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SelectEvents {\n  /**\n   * A callback fired when the select value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the select.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -21793,14 +22910,16 @@
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the switch value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the switch value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the switch.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the switch.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface SwitchEvents {\n  /**\n   * A callback fired when the switch value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the switch.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n}"
@@ -21818,14 +22937,16 @@
           "syntaxKind": "PropertySignature",
           "name": "nextpage",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user navigates to the next page."
+          "description": "A callback fired when the user navigates to the next page.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "previouspage",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the user navigates to the previous page."
+          "description": "A callback fired when the user navigates to the previous page.",
+          "isOptional": true
         }
       ],
       "value": "export interface TableEvents {\n  /**\n   * A callback fired when the user navigates to the previous page.\n   */\n  previouspage: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the user navigates to the next page.\n   */\n  nextpage: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -21984,28 +23105,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the text area loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the text area value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text area receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the text area receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the text area.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the text area.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface TextAreaEvents {\n  /**\n   * A callback fired when the text area value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the text area.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text area loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text area receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22023,28 +23148,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the text field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the text field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the text field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the text field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the text field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the text field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface TextFieldEvents {\n  /**\n   * A callback fired when the text field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the text field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the text field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22081,14 +23210,16 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "OnErrorEventHandler",
-          "description": "A callback fired when the thumbnail image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)."
+          "description": "A callback fired when the thumbnail image fails to load.\n\nLearn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "load",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback fired when the thumbnail image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event)."
+          "description": "A callback fired when the thumbnail image successfully loads.\n\nLearn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface ThumbnailEvents {\n  /**\n   * A callback fired when the thumbnail image successfully loads.\n   *\n   * Learn more about the [load event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event).\n   */\n  load: CallbackEventListener<typeof tagName> | null = null;\n  /**\n   * A callback fired when the thumbnail image fails to load.\n   *\n   * Learn more about the [error event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event).\n   */\n  error: OnErrorEventHandler = null;\n}"
@@ -22125,28 +23256,32 @@
           "syntaxKind": "PropertySignature",
           "name": "blur",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event)."
+          "description": "A callback fired when the URL field loses focus.\n\nLearn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "change",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event)."
+          "description": "A callback fired when the URL field value changes.\n\nLearn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "focus",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the URL field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event)."
+          "description": "A callback fired when the URL field receives focus.\n\nLearn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "input",
           "value": "CallbackEventListener<'input'>",
-          "description": "A callback fired when the user inputs data into the URL field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event)."
+          "description": "A callback fired when the user inputs data into the URL field.\n\nLearn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).",
+          "isOptional": true
         }
       ],
       "value": "export interface URLFieldEvents {\n  /**\n   * A callback fired when the URL field value changes.\n   *\n   * Learn more about the [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event).\n   */\n  change: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the user inputs data into the URL field.\n   *\n   * Learn more about the [input event](https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event).\n   */\n  input: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the URL field loses focus.\n   *\n   * Learn more about the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event).\n   */\n  blur: CallbackEventListener<'input'>;\n  /**\n   * A callback fired when the URL field receives focus.\n   *\n   * Learn more about the [focus event](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event).\n   */\n  focus: CallbackEventListener<'input'>;\n}"
@@ -22208,14 +23343,16 @@
           "syntaxKind": "PropertySignature",
           "name": "reset",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the form is reset."
+          "description": "A callback that is run when the form is reset.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "submit",
           "value": "CallbackExtendableEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the form is submitted."
+          "description": "A callback that is run when the form is submitted.",
+          "isOptional": true
         }
       ],
       "value": "export interface FormEvents {\n  /**\n   * A callback that is run when the form is submitted.\n   */\n  submit: CallbackExtendableEventListener<typeof tagName> | null = null;\n  /**\n   * A callback that is run when the form is reset.\n   */\n  reset: CallbackEventListener<typeof tagName> | null = null;\n}"
@@ -22233,21 +23370,24 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "CallbackErrorEventListener<\n    typeof tagName,\n    FunctionSettingsErrorEvent['error']['errors'][0]\n  > | null",
-          "description": "An optional callback function that will be run by the admin when committing the changes to Shopify’s servers fails. The error event you receive includes an `error` property that is an `AggregateError` object. This object includes an array of errors that were caused by data your extension provided. Network errors and user errors that are out of your control will not be reported here.\n\nIn the `onError` callback, you should update your extension’s UI to highlight the fields that caused the errors, and display the error messages to the user."
+          "description": "An optional callback function that will be run by the admin when committing the changes to Shopify’s servers fails. The error event you receive includes an `error` property that is an `AggregateError` object. This object includes an array of errors that were caused by data your extension provided. Network errors and user errors that are out of your control will not be reported here.\n\nIn the `onError` callback, you should update your extension’s UI to highlight the fields that caused the errors, and display the error messages to the user.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "reset",
           "value": "CallbackEventListener<typeof tagName> | null",
-          "description": "A callback that is run when the function settings form is reset."
+          "description": "A callback that is run when the function settings form is reset.",
+          "isOptional": true
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertySignature",
           "name": "submit",
           "value": "CallbackExtendableEventListener<typeof tagName> | null",
-          "description": "An optional callback function that will be run by the admin when the user commits their changes in the admin-rendered part of the function settings experience. If `event.waitUntil` is called with a promise, the admin will wait for the promise to resolve before committing any changes to Shopify’s servers. If the promise rejects, the admin will abort the changes and display an error, using the `message` property of the error you reject with."
+          "description": "An optional callback function that will be run by the admin when the user commits their changes in the admin-rendered part of the function settings experience. If `event.waitUntil` is called with a promise, the admin will wait for the promise to resolve before committing any changes to Shopify’s servers. If the promise rejects, the admin will abort the changes and display an error, using the `message` property of the error you reject with.",
+          "isOptional": true
         }
       ],
       "value": "export interface FunctionSettingsEvents {\n  /**\n   * An optional callback function that will be run by the admin when the user\n   * commits their changes in the admin-rendered part of the function settings\n   * experience. If `event.waitUntil` is called with a promise, the admin will wait for the\n   * promise to resolve before committing any changes to Shopify’s servers. If\n   * the promise rejects, the admin will abort the changes and display an error,\n   * using the `message` property of the error you reject with.\n   */\n  submit: CallbackExtendableEventListener<typeof tagName> | null = null;\n  /**\n   * An optional callback function that will be run by the admin when\n   * committing the changes to Shopify’s servers fails. The error event you receive includes\n   * an `error` property that is an `AggregateError` object. This object includes\n   * an array of errors that were caused by data your extension provided.\n   * Network errors and user errors that are out of your control will not be reported here.\n   *\n   * In the `onError` callback, you should update your extension’s UI to\n   * highlight the fields that caused the errors, and display the error messages\n   * to the user.\n   */\n  error: CallbackErrorEventListener<\n    typeof tagName,\n    FunctionSettingsErrorEvent['error']['errors'][0]\n  > | null = null;\n  /**\n   * A callback that is run when the function settings form is reset.\n   */\n  reset: CallbackEventListener<typeof tagName> | null = null;\n}"


### PR DESCRIPTION
Runs `docs:admin 2026-07-rc` to bring the admin-surface generated docs current with source — including the `pick` action and `shopify/File` resource type added in #4499. Same pattern as #4457 (checkout regen).

Needed so the File-picker reference (`pick:shopify/File`) renders correctly in the `<TypeDefinition>` on shopify.dev — the App Home UI Extension 2026-07-rc page (and the upcoming admin-extensions 2026-07-rc version). Without this, the generated type data still shows `IntentAction = 'create' | 'edit'`, contradicting the hand-authored docs.

Large diff is regeneration drift (generated artifacts were behind source), consistent with #4457.

## Related
- UI Extensions types: #4499 (merged)
- shopify.dev docs + paths.json sync: shop/world#805918
- Part of File Picker Intent epic: shop/issues-workflows#1518