### PR TITLE
feat(point-of-sale): add POS intercept API types

### DIFF
--- a/.changeset/pos-intercept-api.md
+++ b/.changeset/pos-intercept-api.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add `shopify.intercept()` types for POS blocking workflows.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -3,6 +3,7 @@ import type {
   CashTrackingSessionStartEvent,
   CashTrackingSessionCompleteEvent,
 } from './events/cash-tracking-session-events';
+import type {Cart} from './types/cart';
 
 /**
  * Canonical event-name constants for POS host events. Prefer these over string
@@ -14,6 +15,16 @@ export const POS_EVENT_NAMES = {
   TRANSACTION_COMPLETE: 'transactioncomplete',
   CASH_TRACKING_SESSION_START: 'cashtrackingsessionstart',
   CASH_TRACKING_SESSION_COMPLETE: 'cashtrackingsessioncomplete',
+} as const;
+
+/**
+ * Canonical workflow-name constants for POS host interceptions. Prefer these
+ * over string literals when calling `shopify.intercept`.
+ *
+ * @private
+ */
+export const POS_INTERCEPT_NAMES = {
+  BEFORE_CHECKOUT: 'beforecheckout',
 } as const;
 
 /**
@@ -34,6 +45,89 @@ export interface ShopifyEventMap {
   [POS_EVENT_NAMES.CASH_TRACKING_SESSION_START]: CashTrackingSessionStartEvent;
   /** Dispatched when a cash tracking session closes after reconciliation. */
   [POS_EVENT_NAMES.CASH_TRACKING_SESSION_COMPLETE]: CashTrackingSessionCompleteEvent;
+}
+
+/**
+ * Maps POS interceptable workflow names to their corresponding `Event` types.
+ *
+ * Used as the generic type parameter for `shopify.intercept`.
+ *
+ * @private
+ */
+export interface ShopifyInterceptMap {
+  [POS_INTERCEPT_NAMES.BEFORE_CHECKOUT]: BeforeCheckoutEvent;
+}
+
+/**
+ * Dispatched when staff attempts to leave the active cart for checkout.
+ *
+ * @private
+ */
+export interface BeforeCheckoutEvent extends Event {
+  readonly type: typeof POS_INTERCEPT_NAMES.BEFORE_CHECKOUT;
+  /** The POS cart at the point checkout was requested. */
+  readonly cart: Cart;
+}
+
+/** @private */
+export type ShopifyInterceptor<TEvent extends Event> = (
+  event: TEvent,
+) => InterceptResult;
+
+/**
+ * The result an interceptor returns. An empty `operations` list allows the
+ * workflow; an `ERROR` validation blocks it.
+ *
+ * @private
+ */
+export interface InterceptResult {
+  operations: Operation[];
+}
+
+/**
+ * A single host operation produced by an interceptor.
+ *
+ * @private
+ */
+export interface Operation {
+  validationAdd?: ValidationAdd;
+}
+
+/** @private */
+export type ValidationLevel = 'INFO' | 'WARNING' | 'ERROR';
+
+/**
+ * Adds a validation to the workflow being intercepted.
+ *
+ * @private
+ */
+export interface ValidationAdd {
+  /** `ERROR` blocks the workflow. `WARNING` and `INFO` do not. */
+  level: ValidationLevel;
+
+  /** Stable identifier for this validation. */
+  handle: string;
+
+  /** Host-facing message for support, observability, or staff UX. */
+  message: string;
+
+  /** JSON-path locator for where the validation applies. Defaults to `$.cart`. */
+  target?: string;
+
+  /** Optional structured data for custom UX or order metadata. */
+  metafields?: Metafield[];
+}
+
+/**
+ * Metafield input attached to a validation.
+ *
+ * @private
+ */
+export interface Metafield {
+  namespace: string;
+  key: string;
+  value: string;
+  type: string;
 }
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -3,6 +3,7 @@ import type {
   CashTrackingSessionStartEvent,
   CashTrackingSessionCompleteEvent,
 } from './events/cash-tracking-session-events';
+import type {Cart} from './types/cart';
 
 /**
  * Canonical event-name constants for POS host events. Prefer these over string
@@ -28,6 +29,89 @@ export interface ShopifyEventMap {
   [POS_EVENT_NAMES.TRANSACTION_COMPLETE]: TransactionCompleteEvent;
   [POS_EVENT_NAMES.CASH_TRACKING_SESSION_START]: CashTrackingSessionStartEvent;
   [POS_EVENT_NAMES.CASH_TRACKING_SESSION_COMPLETE]: CashTrackingSessionCompleteEvent;
+}
+
+/**
+ * Maps POS interceptable workflow names to their corresponding `Event` types.
+ *
+ * Used as the generic type parameter for `shopify.intercept`.
+ *
+ * @publicDocs
+ */
+export interface ShopifyInterceptMap {
+  beforecheckout: BeforeCheckoutEvent;
+}
+
+/**
+ * Dispatched when staff attempts to leave the active cart for checkout.
+ *
+ * @publicDocs
+ */
+export interface BeforeCheckoutEvent extends Event {
+  readonly type: 'beforecheckout';
+  /** The POS cart at the point checkout was requested. */
+  readonly cart: Cart;
+}
+
+/** @publicDocs */
+export type ShopifyInterceptor<TEvent extends Event> = (
+  event: TEvent,
+) => InterceptResult;
+
+/**
+ * The result an interceptor returns. An empty `operations` list allows the
+ * workflow; an `ERROR` validation blocks it.
+ *
+ * @publicDocs
+ */
+export interface InterceptResult {
+  operations: Operation[];
+}
+
+/**
+ * A single host operation produced by an interceptor.
+ *
+ * @publicDocs
+ */
+export interface Operation {
+  validationAdd?: ValidationAdd;
+}
+
+/** @publicDocs */
+export type ValidationLevel = 'INFO' | 'WARNING' | 'ERROR';
+
+/**
+ * Adds a validation to the workflow being intercepted.
+ *
+ * @publicDocs
+ */
+export interface ValidationAdd {
+  /** `ERROR` blocks the workflow. `WARNING` and `INFO` do not. */
+  level: ValidationLevel;
+
+  /** Stable identifier for this validation. */
+  handle: string;
+
+  /** Host-facing message for support, observability, or staff UX. */
+  message: string;
+
+  /** JSON-path locator for where the validation applies. Defaults to `$.cart`. */
+  target?: string;
+
+  /** Optional structured data for custom UX or order metadata. */
+  metafields?: Metafield[];
+}
+
+/**
+ * Metafield input attached to a validation.
+ *
+ * @publicDocs
+ */
+export interface Metafield {
+  namespace: string;
+  key: string;
+  value: string;
+  type: string;
 }
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -18,6 +18,16 @@ export const POS_EVENT_NAMES = {
 } as const;
 
 /**
+ * Canonical workflow-name constants for POS host interceptions. Prefer these
+ * over string literals when calling `shopify.intercept`.
+ *
+ * @publicDocs
+ */
+export const POS_INTERCEPT_NAMES = {
+  BEFORE_CHECKOUT: 'beforecheckout',
+} as const;
+
+/**
  * Maps Shopify POS event names to their corresponding `Event` subclass types.
  *
  * Used as the generic type parameter for `shopify.addEventListener` and
@@ -39,7 +49,7 @@ export interface ShopifyEventMap {
  * @publicDocs
  */
 export interface ShopifyInterceptMap {
-  beforecheckout: BeforeCheckoutEvent;
+  [POS_INTERCEPT_NAMES.BEFORE_CHECKOUT]: BeforeCheckoutEvent;
 }
 
 /**
@@ -48,7 +58,7 @@ export interface ShopifyInterceptMap {
  * @publicDocs
  */
 export interface BeforeCheckoutEvent extends Event {
-  readonly type: 'beforecheckout';
+  readonly type: typeof POS_INTERCEPT_NAMES.BEFORE_CHECKOUT;
   /** The POS cart at the point checkout was requested. */
   readonly cart: Cart;
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -94,7 +94,7 @@ export interface Operation {
 }
 
 /** @private */
-export type ValidationLevel = 'INFO' | 'WARNING' | 'ERROR';
+export type ValidationLevel = 'WARNING' | 'ERROR';
 
 /**
  * Adds a validation to the workflow being intercepted.
@@ -102,32 +102,14 @@ export type ValidationLevel = 'INFO' | 'WARNING' | 'ERROR';
  * @private
  */
 export interface ValidationAdd {
-  /** `ERROR` blocks the workflow. `WARNING` and `INFO` do not. */
+  /** `ERROR` blocks the workflow. `WARNING` does not. */
   level: ValidationLevel;
 
   /** Stable identifier for this validation. */
   handle: string;
 
-  /** Host-facing message for support, observability, or staff UX. */
-  message: string;
-
   /** JSON-path locator for where the validation applies. Defaults to `$.cart`. */
   target?: string;
-
-  /** Optional structured data for custom UX or order metadata. */
-  metafields?: Metafield[];
-}
-
-/**
- * Metafield input attached to a validation.
- *
- * @private
- */
-export interface Metafield {
-  namespace: string;
-  key: string;
-  value: string;
-  type: string;
 }
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -108,7 +108,7 @@ export interface ValidationAdd {
   /** Stable identifier for this validation. */
   handle: string;
 
-  /** JSON-path locator for where the validation applies. Defaults to `$.cart`. */
+  /** JSON-path locator for where the validation applies. */
   target?: string;
 }
 

--- a/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
@@ -1,5 +1,9 @@
 import type {Navigation} from './api/navigation-api/navigation-api';
-import type {ShopifyEventMap} from './events';
+import type {
+  ShopifyEventMap,
+  ShopifyInterceptMap,
+  ShopifyInterceptor,
+} from './events';
 
 /**
  * The `shopify` global provides APIs that are available to all POS extensions
@@ -36,6 +40,17 @@ export interface BackgroundShopifyGlobal extends ShopifyGlobal {
     type: K,
     listener: (event: ShopifyEventMap[K]) => void,
   ): void;
+
+  /**
+   * Register an interceptor for a POS host workflow that can be blocked.
+   * Returns a function that unregisters the interceptor.
+   *
+   * @private
+   */
+  intercept<K extends keyof ShopifyInterceptMap>(
+    type: K,
+    interceptor: ShopifyInterceptor<ShopifyInterceptMap[K]>,
+  ): () => void;
 }
 
 declare global {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/globals.ts
@@ -1,5 +1,9 @@
 import type {Navigation} from './api/navigation-api/navigation-api';
-import type {ShopifyEventMap} from './events';
+import type {
+  ShopifyEventMap,
+  ShopifyInterceptMap,
+  ShopifyInterceptor,
+} from './events';
 
 /**
  * The `shopify` global provides APIs that are available to all POS extensions
@@ -36,6 +40,15 @@ export interface BackgroundShopifyGlobal extends ShopifyGlobal {
     type: K,
     listener: (event: ShopifyEventMap[K]) => void,
   ): void;
+
+  /**
+   * Register an interceptor for a POS host workflow that can be blocked.
+   * Returns a function that unregisters the interceptor.
+   */
+  intercept<K extends keyof ShopifyInterceptMap>(
+    type: K,
+    interceptor: ShopifyInterceptor<ShopifyInterceptMap[K]>,
+  ): () => void;
 }
 
 declare global {


### PR DESCRIPTION
## What changed

- Adds POS `shopify.intercept()` typing to the background `ShopifyGlobal` used by `pos.app.ready.data`.
- Adds the first interceptable POS workflow, `beforecheckout`, with a cart-bearing event payload.
- Adds the interceptor result shape from the UI API Design proposal: `operations` with optional `validationAdd` entries (`WARNING` / `ERROR`, `handle`, optional `target`).
- Leaves types private as the work is in progress.