### PR TITLE
Remove dangling buyer-journey #examples link from buyerJourney JSDoc (2026-01)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
@@ -1,356 +1,39 @@
 {
-  "DataGeneratedType": {
-    "docs/surfaces/checkout/reference/apis/address.doc.ts": {
-      "filePath": "docs/surfaces/checkout/reference/apis/address.doc.ts",
-      "name": "DataGeneratedType",
-      "description": "Template schema for reference entity documentation pages.",
-      "isPublicDocs": true,
-      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'Addresses API',\n  description: 'The API for interacting with addresses.',\n  isVisualComponent: false,\n  requires: REQUIRES_PROTECTED_CUSTOMER_DATA_LEVEL_2,\n  category: 'Target APIs',\n  subCategory: 'Checkout APIs',\n  type: 'API',\n  definitions: [\n    {\n      title: 'StandardApi',\n      description: STANDARD_API_PROPERTIES_DESCRIPTION,\n      type: 'Docs_Standard_AddressApi',\n    },\n    {\n      title: 'CheckoutApi',\n      description: CHECKOUT_API_PROPERTIES_DESCRIPTION,\n      type: 'Docs_Checkout_AddressApi',\n    },\n    {\n      title: 'useBillingAddress',\n      description:\n        'Returns the proposed `billingAddress` applied to the checkout.',\n      type: 'UseBillingAddressGeneratedType',\n    },\n    {\n      title: 'useShippingAddress',\n      description:\n        'Returns the proposed `shippingAddress` applied to the checkout.',\n      type: 'UseShippingAddressGeneratedType',\n    },\n    {\n      title: 'useApplyShippingAddressChange',\n      description:\n        'Returns a function to mutate the `shippingAddress` property of checkout.',\n      type: 'UseApplyShippingAddressChangeGeneratedType',\n    },\n  ],\n  related: getLinksByTag('apis'),\n}"
-    }
-  },
-  "StandardApi": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "StandardApi",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "analytics",
-          "value": "Analytics",
-          "description": "Tracks custom events and sends visitor information to [Web Pixels](/docs/apps/marketing). Use `publish()` to emit events and `visitor()` to submit buyer contact details."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "appliedGiftCards",
-          "value": "SubscribableSignalLike<AppliedGiftCard[]>",
-          "description": "The gift cards that have been applied to the checkout. Each entry includes the last four characters of the gift card code, the amount used at checkout, and the card's remaining balance."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "applyTrackingConsentChange",
-          "value": "ApplyTrackingConsentChangeType",
-          "description": "Enables setting and updating customer privacy consent settings and tracking consent metafields.\n\n> Note: Requires the [`collect_buyer_consent` capability](/docs/apps/build/customer-accounts/capabilities#collect-buyer-consent) to be set to `true`.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "appMetafields",
-          "value": "SubscribableSignalLike<AppMetafieldEntry[]>",
-          "description": "The metafields requested in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file. These metafields are updated when there's a change in the merchandise items being purchased by the customer.\n\nApp owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` isn't supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "attributes",
-          "value": "SubscribableSignalLike<Attribute[]>",
-          "description": "The custom key-value attributes attached to the cart or checkout. These are set by the buyer or by an extension using `applyAttributeChange()`. The list is empty if no attributes have been added."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "availablePaymentOptions",
-          "value": "SubscribableSignalLike<PaymentOption[]>",
-          "description": "All payment options available to the buyer for this checkout, such as credit cards, wallets, and local payment methods. The list depends on the shop's payment configuration and the buyer's region.\n\nThe set of payment options can change when the buyer updates their address or cart, so subscribe to changes rather than reading once during initialization. Each option exposes `handle` and `type` only. Provider names, logos, fees, and installment terms aren't available."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "billingAddress",
-          "value": "SubscribableSignalLike<MailingAddress | undefined>",
-          "description": "The proposed customer billing address. The address updates when the field is committed (on change) rather than every keystroke. The property is available only if the extension has access to protected customer data. The subscribable value is `undefined` if the billing address hasn't been provided yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "buyerIdentity",
-          "value": "BuyerIdentity",
-          "description": "Information about the buyer that's interacting with the checkout. The property is available only if the extension has access to protected customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "buyerJourney",
-          "value": "BuyerJourney",
-          "description": "Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.\n\nRefer to [buyer journey](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/buyer-journey#examples) examples for more information."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "checkoutSettings",
-          "value": "SubscribableSignalLike<CheckoutSettings>",
-          "description": "Settings applied to the buyer's checkout."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "checkoutToken",
-          "value": "SubscribableSignalLike<CheckoutToken | undefined>",
-          "description": "A stable ID that represents the current checkout.\n\nThe value is `undefined` when the checkout hasn't been created on the server yet.\n\nUse this to correlate checkout sessions across your extension, web pixels, and backend systems.\n\nThis matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data) and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).\n\nCan be `undefined`. Handle the `undefined` state before using the value."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "cost",
-          "value": "CartCost",
-          "description": "The cost breakdown for the current checkout, including subtotal, shipping, tax, and total amounts. These values update as the buyer progresses through checkout and costs like shipping and tax are calculated."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "customerPrivacy",
-          "value": "SubscribableSignalLike<CustomerPrivacy>",
-          "description": "Customer privacy consent settings and a flag denoting if consent has previously been collected."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "deliveryGroups",
-          "value": "SubscribableSignalLike<DeliveryGroup[]>",
-          "description": "The delivery groups for this checkout. Each group contains one or more cart lines and the available delivery options (shipping, pickup point, or pickup location) for those items.\n\nEmpty until the buyer enters enough address information for Shopify to calculate shipping rates."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "discountAllocations",
-          "value": "SubscribableSignalLike<CartDiscountAllocation[]>",
-          "description": "The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from [Shopify Functions](/docs/apps/build/functions). Each allocation indicates how much was discounted and how the discount was triggered."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "discountCodes",
-          "value": "SubscribableSignalLike<CartDiscountCode[]>",
-          "description": "The discount codes currently applied to the checkout. The list is empty if no discount codes have been applied. Use `applyDiscountCodeChange()` to add or remove codes."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "extension",
-          "value": "Extension<Target>",
-          "description": "Metadata about the running extension, including the current target, API version, capabilities, and editor context. Use this to conditionally render content based on where the extension is running."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "extensionPoint",
-          "value": "Target",
-          "description": "The identifier that specifies where in Shopify's UI your code is being injected. This is one of the targets you've included in your extension's configuration file.",
-          "deprecationMessage": "Use `extension.target` instead.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'purchase.checkout.block.render'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "i18n",
-          "value": "I18n",
-          "description": "Utilities for translating strings, formatting currencies, numbers, and dates according to the buyer's locale. Use alongside [`localization`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization) to build fully localized extensions."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "instructions",
-          "value": "SubscribableSignalLike<CartInstructions>",
-          "description": "The cart instructions used to create the checkout and possibly limit extension capabilities.\n\nThese instructions should be checked before performing any actions that might be affected by them.\n\nFor example, if you intend to add a discount code via the `applyDiscountCodeChange` method, check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.\n\n> Caution: Check cart instructions before calling select APIs, as > some may not be available. See the > [Cart Instructions API](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples) > for more information."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "lines",
-          "value": "SubscribableSignalLike<CartLine[]>",
-          "description": "The list of line items the buyer intends to purchase. Each entry includes the merchandise, quantity, cost, and any custom attributes. Use `applyCartLinesChange()` to add, remove, or update line items."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "localization",
-          "value": "Localization",
-          "description": "The buyer's language, country, currency, and timezone context. For formatting and translation helpers, use the [`i18n`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization#properties-propertydetail-i18n) object instead."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "localizedFields",
-          "value": "SubscribableSignalLike<LocalizedField[]>",
-          "description": "Additional region-specific fields required during checkout, such as tax identification numbers (Brazil's CPF/CNPJ) or customs credentials. The property is available only if the extension has access to protected customer data. The array is empty if the current checkout doesn't require any localized fields.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "metafields",
-          "value": "SubscribableSignalLike<Metafield[]>",
-          "description": "The metafields that apply to the current checkout.\n\nMetafields are stored locally on the client and are applied to the order object after the checkout completes.\n\nThese metafields are shared by all extensions running on checkout, and persist for as long as the customer is working on this checkout.\n\nOnce the order is created, you can query these metafields using the [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n\n> Caution: `metafields` is deprecated. Use `appMetafields` with cart metafields instead.",
-          "deprecationMessage": "Use `appMetafields` with cart metafields instead."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "note",
-          "value": "SubscribableSignalLike<string | undefined>",
-          "description": "A note left by the customer to the merchant, either in their cart or during checkout.\n\nThe value is `undefined` if the buyer hasn't entered a note. Use this to display or react to order-level instructions such as delivery preferences or gift messages."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "query",
-          "value": "<Data = unknown, Variables = Record<string, unknown>>(query: string, options?: { variables?: Variables; version?: StorefrontApiVersion; }) => Promise<{ data?: Data; errors?: GraphQLError[]; }>",
-          "description": "The method used to query the Storefront GraphQL API with a prefetched token."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "selectedPaymentOptions",
-          "value": "SubscribableSignalLike<SelectedPaymentOption[]>",
-          "description": "The payment options the buyer has currently selected. This updates as the buyer changes their payment method. The array can contain multiple entries when the buyer splits payment across methods (for example, a gift card and a credit card).\n\nEach option exposes `handle` and `type` only. Provider names, logos, fees, and installment terms aren't available."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "sessionToken",
-          "value": "SessionToken",
-          "description": "The session token providing a set of claims as a signed JSON Web Token (JWT).\n\nThe token has a TTL of five minutes.\n\nIf the previous token expires, this value reflects a new session token with a new signature and expiry.\n\nLearn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "settings",
-          "value": "SubscribableSignalLike<ExtensionSettings>",
-          "description": "The settings matching the settings definition written in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file.\n\n Refer to [settings examples](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/settings#examples) for more information.\n\n> Note: When an extension is being installed in the editor, the settings are empty until a merchant sets a value. In that case, this object updates in real time as a merchant fills in the settings."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "shippingAddress",
-          "value": "SubscribableSignalLike<ShippingAddress | undefined>",
-          "description": "The proposed customer shipping address. During the information step, the address updates when the field is committed (on change) rather than every keystroke. The property is available only if the extension has access to protected customer data. When available, the subscribable value is `undefined` if delivery isn't required.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "shop",
-          "value": "Shop",
-          "description": "The store where the checkout is taking place, including the shop name, storefront URL, `.myshopify.com` subdomain, and a globally-unique ID."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "storage",
-          "value": "Storage",
-          "description": "Key-value storage that persists across page loads within the current checkout session. Data is shared across all activated targets associated with this extension.\n\n> Caution: Data persistence isn't guaranteed and storage is cleared when the buyer starts a new checkout."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "version",
-          "value": "Version",
-          "description": "The renderer version being used for the extension.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'2025-10'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {\n  /**\n   * Tracks custom events and sends visitor information to\n   * [Web Pixels](/docs/apps/marketing). Use `publish()` to emit events\n   * and `visitor()` to submit buyer contact details.\n   */\n  analytics: Analytics;\n\n  /**\n   * The gift cards that have been applied to the checkout. Each entry includes\n   * the last four characters of the gift card code, the amount used at\n   * checkout, and the card's remaining balance.\n   */\n  appliedGiftCards: SubscribableSignalLike<AppliedGiftCard[]>;\n\n  /**\n   * The cart instructions used to create the checkout and possibly limit extension capabilities.\n   *\n   * These instructions should be checked before performing any actions that might be affected by them.\n   *\n   * For example, if you intend to add a discount code via the `applyDiscountCodeChange` method,\n   * check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.\n   *\n   * > Caution: Check cart instructions before calling select APIs, as\n   * > some may not be available. See the\n   * > [Cart Instructions API](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples)\n   * > for more information.\n   *\n   */\n  instructions: SubscribableSignalLike<CartInstructions>;\n\n  /**\n   * The metafields requested in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration)\n   * file. These metafields are updated when there's a change in the merchandise items\n   * being purchased by the customer.\n   *\n   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` isn't supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  appMetafields: SubscribableSignalLike<AppMetafieldEntry[]>;\n\n  /**\n   * The custom key-value attributes attached to the cart or checkout. These are set by the buyer or by an extension using `applyAttributeChange()`. The list is empty if no attributes have been added.\n   */\n  attributes: SubscribableSignalLike<Attribute[]>;\n\n  /**\n   * All payment options available to the buyer for this checkout, such as\n   * credit cards, wallets, and local payment methods. The list depends on\n   * the shop's payment configuration and the buyer's region.\n   *\n   * The set of payment options can change when the buyer updates their\n   * address or cart, so subscribe to changes rather than reading once\n   * during initialization. Each option exposes `handle` and `type` only.\n   * Provider names, logos, fees, and installment terms aren't available.\n   */\n  availablePaymentOptions: SubscribableSignalLike<PaymentOption[]>;\n\n  /**\n   * Information about the buyer that's interacting with the checkout. The property is available only if the extension has access to protected customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  buyerIdentity?: BuyerIdentity;\n\n  /**\n   * Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.\n   *\n   * Refer to [buyer journey](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/buyer-journey#examples)\n   * examples for more information.\n   */\n  buyerJourney: BuyerJourney;\n\n  /**\n   * Settings applied to the buyer's checkout.\n   */\n  checkoutSettings: SubscribableSignalLike<CheckoutSettings>;\n\n  /**\n   * A stable ID that represents the current checkout.\n   *\n   * The value is `undefined` when the checkout hasn't been created on the server yet.\n   *\n   * Use this to correlate checkout sessions across your extension, web pixels, and backend systems.\n   *\n   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)\n   * and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).\n   *\n   * Can be `undefined`. Handle the `undefined` state before using the value.\n   */\n  checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;\n\n  /**\n   * The cost breakdown for the current checkout, including subtotal, shipping, tax, and total amounts. These values update as the buyer progresses through checkout and costs like shipping and tax are calculated.\n   */\n  cost: CartCost;\n\n  /**\n   * The delivery groups for this checkout. Each group contains one or more cart lines and the available delivery options (shipping, pickup point, or pickup location) for those items.\n   *\n   * Empty until the buyer enters enough address information for Shopify to\n   * calculate shipping rates.\n   */\n  deliveryGroups: SubscribableSignalLike<DeliveryGroup[]>;\n\n  /**\n   * The discount codes currently applied to the checkout. The list is empty if no discount codes have been applied. Use `applyDiscountCodeChange()` to add or remove codes.\n   */\n  discountCodes: SubscribableSignalLike<CartDiscountCode[]>;\n\n  /**\n   * The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from [Shopify Functions](/docs/apps/build/functions). Each allocation indicates how much was discounted and how the discount was triggered.\n   */\n  discountAllocations: SubscribableSignalLike<CartDiscountAllocation[]>;\n\n  /**\n   * Metadata about the running extension, including the current target, API version,\n   * capabilities, and editor context. Use this to conditionally render content\n   * based on where the extension is running.\n   */\n  extension: Extension<Target>;\n\n  /**\n   * The identifier that specifies where in Shopify's UI your code is being\n   * injected. This is one of the targets you've included in your\n   * extension's configuration file.\n   *\n   * @example 'purchase.checkout.block.render'\n   * @see /docs/api/checkout-ui-extensions/{API_VERSION}/extension-targets-overview\n   * @see /docs/apps/app-extensions/configuration#targets\n   *\n   * @deprecated Use `extension.target` instead.\n   */\n  extensionPoint: Target;\n\n  /**\n   * Utilities for translating strings, formatting currencies, numbers, and dates\n   * according to the buyer's locale. Use alongside\n   * [`localization`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization)\n   * to build fully localized extensions.\n   */\n  i18n: I18n;\n\n  /**\n   * The list of line items the buyer intends to purchase. Each entry includes the merchandise, quantity, cost, and any custom attributes. Use `applyCartLinesChange()` to add, remove, or update line items.\n   */\n  lines: SubscribableSignalLike<CartLine[]>;\n\n  /**\n   * The buyer's language, country, currency, and timezone context. For\n   * formatting and translation helpers, use the\n   * [`i18n`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization#properties-propertydetail-i18n)\n   * object instead.\n   */\n  localization: Localization;\n\n  /**\n   * The metafields that apply to the current checkout.\n   *\n   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.\n   *\n   * These metafields are shared by all extensions running on checkout, and\n   * persist for as long as the customer is working on this checkout.\n   *\n   * Once the order is created, you can query these metafields using the\n   * [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n   *\n   * > Caution:\n   * `metafields` is deprecated. Use `appMetafields` with cart metafields instead.\n   *\n   * @deprecated Use `appMetafields` with cart metafields instead.\n   */\n  metafields: SubscribableSignalLike<Metafield[]>;\n\n  /**\n   * A note left by the customer to the merchant, either in their cart or during checkout.\n   *\n   * The value is `undefined` if the buyer hasn't entered a note. Use this to display or react to order-level instructions such as delivery preferences or gift messages.\n   */\n  note: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The method used to query the Storefront GraphQL API with a prefetched token.\n   *\n   */\n  query: <Data = unknown, Variables = Record<string, unknown>>(\n    query: string,\n    options?: {variables?: Variables; version?: StorefrontApiVersion},\n  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;\n\n  /**\n   * The payment options the buyer has currently selected. This updates as\n   * the buyer changes their payment method. The array can contain multiple\n   * entries when the buyer splits payment across methods (for example, a\n   * gift card and a credit card).\n   *\n   * Each option exposes `handle` and `type` only. Provider names, logos,\n   * fees, and installment terms aren't available.\n   */\n  selectedPaymentOptions: SubscribableSignalLike<SelectedPaymentOption[]>;\n\n  /**\n   * The session token providing a set of claims as a signed JSON Web Token (JWT).\n   *\n   * The token has a TTL of five minutes.\n   *\n   * If the previous token expires, this value reflects a new session token with a new signature and expiry.\n   *\n   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).\n   */\n  sessionToken: SessionToken;\n\n  /**\n   * The settings matching the settings definition written in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file.\n   *\n   *  Refer to [settings examples](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/settings#examples) for more information.\n   *\n   * > Note: When an extension is being installed in the editor, the settings are empty until\n   * a merchant sets a value. In that case, this object updates in real time as a merchant fills in the settings.\n   */\n  settings: SubscribableSignalLike<ExtensionSettings>;\n\n  /**\n   * The proposed customer shipping address. During the information step, the address\n   * updates when the field is committed (on change) rather than every keystroke.\n   * The property is available only if the extension has access to protected customer\n   * data. When available, the subscribable value is `undefined` if delivery isn't required.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  shippingAddress?: SubscribableSignalLike<ShippingAddress | undefined>;\n\n  /**\n   * The proposed customer billing address. The address updates when the field is\n   * committed (on change) rather than every keystroke. The property is available only\n   * if the extension has access to protected customer data. The subscribable value is\n   * `undefined` if the billing address hasn't been provided yet.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  billingAddress?: SubscribableSignalLike<MailingAddress | undefined>;\n\n  /**\n   * The store where the checkout is taking place, including the shop name,\n   * storefront URL, `.myshopify.com` subdomain, and a globally-unique ID.\n   */\n  shop: Shop;\n\n  /**\n   * Key-value storage that persists across page loads within the current checkout\n   * session. Data is shared across all activated targets associated with\n   * this extension.\n   *\n   * > Caution: Data persistence isn't guaranteed and storage is cleared when the\n   * buyer starts a new checkout.\n   */\n  storage: Storage;\n\n  /**\n   * The renderer version being used for the extension.\n   *\n   * @example '2025-10'\n   */\n  version: Version;\n\n  /**\n   * Customer privacy consent settings and a flag denoting if consent has previously been collected.\n   */\n  customerPrivacy: SubscribableSignalLike<CustomerPrivacy>;\n\n  /**\n   * Enables setting and updating customer privacy consent settings and tracking consent metafields.\n   *\n   * > Note: Requires the [`collect_buyer_consent` capability](/docs/apps/build/customer-accounts/capabilities#collect-buyer-consent) to be set to `true`.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  applyTrackingConsentChange: ApplyTrackingConsentChangeType;\n\n  /**\n   * Additional region-specific fields required during checkout, such as tax identification numbers (Brazil's CPF/CNPJ) or customs credentials. The property is available only if the extension has access to protected customer data. The array is empty if the current checkout doesn't require any localized fields.\n   */\n  localizedFields?: SubscribableSignalLike<LocalizedField[]>;\n}"
-    }
-  },
-  "Analytics": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "Analytics",
-      "description": "Tracks custom events and sends visitor information to [Web Pixels](/docs/apps/marketing). Use `publish()` to emit events and `visitor()` to submit buyer contact details.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "MethodSignature",
-          "name": "publish",
-          "value": "(name: string, data: Record<string, unknown>) => Promise<boolean>",
-          "description": "Publishes a custom event to [Web Pixels](/docs/apps/marketing). Returns `true` when the event is successfully dispatched.\n\nThe Promise resolves to `true` when the event was dispatched. The boolean indicates dispatch confirmation only. It doesn't indicate whether any specific web pixel processed the event."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "MethodSignature",
-          "name": "visitor",
-          "value": "(data: { email?: string; phone?: string; }) => Promise<VisitorResult>",
-          "description": "Submits buyer contact details for attribution and analytics purposes."
-        }
-      ],
-      "value": "export interface Analytics {\n  /**\n   * Publishes a custom event to [Web Pixels](/docs/apps/marketing).\n   * Returns `true` when the event is successfully dispatched.\n   *\n   * The Promise resolves to `true` when the event was dispatched. The boolean\n   * indicates dispatch confirmation only. It doesn't indicate whether any\n   * specific web pixel processed the event.\n   */\n  publish(name: string, data: Record<string, unknown>): Promise<boolean>;\n\n  /**\n   * Submits buyer contact details for attribution and analytics purposes.\n   */\n  visitor(data: {email?: string; phone?: string}): Promise<VisitorResult>;\n}"
-    }
-  },
-  "VisitorResult": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+  "AnyComponent": {
+    "src/surfaces/checkout/shared.ts": {
+      "filePath": "src/surfaces/checkout/shared.ts",
       "syntaxKind": "TypeAliasDeclaration",
-      "name": "VisitorResult",
-      "value": "VisitorSuccess | VisitorError",
-      "description": "Represents a visitor result."
+      "name": "AnyComponent",
+      "value": "(typeof SUPPORTED_COMPONENTS)[number] | PrivateComponent",
+      "description": "",
+      "isPublicDocs": true
     }
   },
-  "VisitorSuccess": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "VisitorSuccess",
-      "description": "Represents a successful visitor result.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'success'",
-          "description": "Indicates that the visitor information was validated and submitted."
-        }
-      ],
-      "value": "export interface VisitorSuccess {\n  /**\n   * Indicates that the visitor information was validated and submitted.\n   */\n  type: 'success';\n}"
+  "PrivateComponent": {
+    "src/surfaces/checkout/shared.ts": {
+      "filePath": "src/surfaces/checkout/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "PrivateComponent",
+      "value": "'Chat'",
+      "description": "Note: Chat is not supported in the 2025-10 release candidate, but it is tied to a target, and we don't want to remove the target documentation. Once Chat is supported, you can remove this note."
     }
   },
-  "VisitorError": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "VisitorError",
-      "description": "Represents an unsuccessful visitor result.",
+  "CartLineItemApi": {
+    "src/surfaces/checkout/api/cart-line/cart-line-item.ts": {
+      "filePath": "src/surfaces/checkout/api/cart-line/cart-line-item.ts",
+      "name": "CartLineItemApi",
+      "description": "",
+      "isPublicDocs": true,
       "members": [
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/cart-line/cart-line-item.ts",
           "syntaxKind": "PropertySignature",
-          "name": "message",
-          "value": "string",
-          "description": "A message that explains the error. This message is useful for debugging. It isn't localized and shouldn't be displayed to the buyer."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'error'",
-          "description": "Indicates that the visitor information is invalid and wasn't submitted. Common causes include using the wrong data type or omitting a required property."
+          "name": "target",
+          "value": "SubscribableSignalLike<CartLine>",
+          "description": "The cart line that this extension is attached to. Use this to read the line item's merchandise, quantity, cost, and attributes.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties.\n\n> Note: Until version `2023-04`, this property was a `ReadonlySignalLike<PresentmentCartLine>`."
         }
       ],
-      "value": "export interface VisitorError {\n  /**\n   * Indicates that the visitor information is invalid and wasn't submitted.\n   * Common causes include using the wrong data type or omitting a required property.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It isn't localized and shouldn't be displayed to the buyer.\n   */\n  message: string;\n}"
+      "value": "export interface CartLineItemApi {\n  /**\n   * The cart line that this extension is attached to. Use this to read the\n   * line item's merchandise, quantity, cost, and attributes.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   *\n   * > Note: Until version `2023-04`, this property was a `ReadonlySignalLike<PresentmentCartLine>`.\n   */\n  target: SubscribableSignalLike<CartLine>;\n}"
     }
   },
   "SubscribableSignalLike": {
@@ -393,377 +76,46 @@
       "value": "export interface SubscribableSignalLike<T> extends ReadonlySignalLike<T> {\n  /**\n   * The current value of the signal. Equivalent to `.value`, accessing this property\n   * subscribes to changes when used in a reactive context.\n   *\n   * @deprecated Use `.value` instead.\n   */\n  readonly current: T;\n  /**\n   * Cleans up the subscription and releases any resources held by this signal. After calling\n   * `destroy()`, the signal stops receiving updates from the main thread.\n   *\n   * @deprecated No longer needed. Use [Preact Signals](https://preactjs.com/guide/v10/signals) to manage reactive state instead.\n   */\n  destroy(): Promise<void>;\n}"
     }
   },
-  "AppliedGiftCard": {
+  "CartLine": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "AppliedGiftCard",
+      "name": "CartLine",
       "description": "",
       "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "amountUsed",
-          "value": "Money",
-          "description": "The amount of the applied gift card that's used when the checkout is completed. This might be less than `balance` if the order total is lower than the card's remaining balance."
+          "name": "attributes",
+          "value": "Attribute[]",
+          "description": "Custom key-value attributes attached to this cart line, such as gift messages or engraving text. Use `applyCartLinesChange()` to update these values."
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "balance",
-          "value": "Money",
-          "description": "The current balance of the applied gift card before checkout completion. This reflects the full remaining value on the card, not just the amount being applied to this order."
+          "name": "cost",
+          "value": "CartLineCost",
+          "description": "The cost breakdown for this line item, including the total price after any line-level discounts have been applied."
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "lastCharacters",
-          "value": "string",
-          "description": "The last four characters of the applied gift card's code. The full code isn't exposed for security reasons. Use this value to display which card is applied."
-        }
-      ],
-      "value": "export interface AppliedGiftCard {\n  /**\n   * The last four characters of the applied gift card's code. The full code isn't exposed for security reasons. Use this value to display which card is applied.\n   */\n  lastCharacters: string;\n\n  /**\n   * The amount of the applied gift card that's used when the checkout is completed. This might be less than `balance` if the order total is lower than the card's remaining balance.\n   */\n  amountUsed: Money;\n\n  /**\n   * The current balance of the applied gift card before checkout completion. This reflects the full remaining value on the card, not just the amount being applied to this order.\n   */\n  balance: Money;\n}"
-    }
-  },
-  "Money": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "Money",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "amount",
-          "value": "number",
-          "description": "The decimal amount of the price. For example, `29.99` represents twenty-nine dollars and ninety-nine cents."
+          "name": "discountAllocations",
+          "value": "CartDiscountAllocation[]",
+          "description": "Discounts applied to this cart line, including code-based, automatic, and custom discounts. Each allocation shows the discounted amount and how the discount was triggered."
         },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "currencyCode",
-          "value": "CurrencyCode",
-          "description": "The three-letter currency code in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) format.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'CAD' for Canadian dollar",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface Money {\n  /**\n   * The decimal amount of the price. For example, `29.99` represents twenty-nine dollars and ninety-nine cents.\n   */\n  amount: number;\n  /**\n   * The three-letter currency code in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) format.\n   *\n   * @example 'CAD' for Canadian dollar\n   */\n  currencyCode: CurrencyCode;\n}"
-    }
-  },
-  "CurrencyCode": {
-    "src/shared.ts": {
-      "filePath": "src/shared.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "CurrencyCode",
-      "value": "'AED' | 'AFN' | 'ALL' | 'AMD' | 'ANG' | 'AOA' | 'ARS' | 'AUD' | 'AWG' | 'AZN' | 'BAM' | 'BBD' | 'BDT' | 'BGN' | 'BHD' | 'BIF' | 'BMD' | 'BND' | 'BOB' | 'BOV' | 'BRL' | 'BSD' | 'BTN' | 'BWP' | 'BYN' | 'BZD' | 'CAD' | 'CDF' | 'CHE' | 'CHF' | 'CHW' | 'CLF' | 'CLP' | 'CNY' | 'COP' | 'COU' | 'CRC' | 'CUC' | 'CUP' | 'CVE' | 'CZK' | 'DJF' | 'DKK' | 'DOP' | 'DZD' | 'EGP' | 'ERN' | 'ETB' | 'EUR' | 'FJD' | 'FKP' | 'GBP' | 'GEL' | 'GHS' | 'GIP' | 'GMD' | 'GNF' | 'GTQ' | 'GYD' | 'HKD' | 'HNL' | 'HRK' | 'HTG' | 'HUF' | 'IDR' | 'ILS' | 'INR' | 'IQD' | 'IRR' | 'ISK' | 'JMD' | 'JOD' | 'JPY' | 'KES' | 'KGS' | 'KHR' | 'KMF' | 'KPW' | 'KRW' | 'KWD' | 'KYD' | 'KZT' | 'LAK' | 'LBP' | 'LKR' | 'LRD' | 'LSL' | 'LYD' | 'MAD' | 'MDL' | 'MGA' | 'MKD' | 'MMK' | 'MNT' | 'MOP' | 'MRU' | 'MUR' | 'MVR' | 'MWK' | 'MXN' | 'MXV' | 'MYR' | 'MZN' | 'NAD' | 'NGN' | 'NIO' | 'NOK' | 'NPR' | 'NZD' | 'OMR' | 'PAB' | 'PEN' | 'PGK' | 'PHP' | 'PKR' | 'PLN' | 'PYG' | 'QAR' | 'RON' | 'RSD' | 'RUB' | 'RWF' | 'SAR' | 'SBD' | 'SCR' | 'SDG' | 'SEK' | 'SGD' | 'SHP' | 'SLL' | 'SOS' | 'SRD' | 'SSP' | 'STN' | 'SVC' | 'SYP' | 'SZL' | 'THB' | 'TJS' | 'TMT' | 'TND' | 'TOP' | 'TRY' | 'TTD' | 'TWD' | 'TZS' | 'UAH' | 'UGX' | 'USD' | 'USN' | 'UYI' | 'UYU' | 'UYW' | 'UZS' | 'VES' | 'VND' | 'VUV' | 'WST' | 'XAF' | 'XAG' | 'XAU' | 'XBA' | 'XBB' | 'XBC' | 'XBD' | 'XCD' | 'XDR' | 'XOF' | 'XPD' | 'XPF' | 'XPT' | 'XSU' | 'XTS' | 'XUA' | 'XXX' | 'YER' | 'ZAR' | 'ZMW' | 'ZWL'",
-      "description": ""
-    }
-  },
-  "ApplyTrackingConsentChangeType": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "ApplyTrackingConsentChangeType",
-      "description": "",
-      "params": [
-        {
-          "name": "visitorConsent",
-          "description": "",
-          "value": "VisitorConsentChange",
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts"
-        }
-      ],
-      "returns": {
-        "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-        "description": "",
-        "name": "Promise<TrackingConsentChangeResult>",
-        "value": "Promise<TrackingConsentChangeResult>"
-      },
-      "value": "(\n  visitorConsent: VisitorConsentChange,\n) => Promise<TrackingConsentChangeResult>"
-    }
-  },
-  "VisitorConsentChange": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "VisitorConsentChange",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "analytics",
-          "value": "boolean",
-          "description": "The visitor's consent for analytics tracking. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "marketing",
-          "value": "boolean",
-          "description": "The visitor's consent for marketing and targeted advertising. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "metafields",
-          "value": "TrackingConsentMetafieldChange[]",
-          "description": "Tracking consent metafield data to be saved.\n\nIf the value is `null`, the metafield is deleted.",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "`[{key: 'granularAnalytics', value: 'true'}, {key: 'granularMarketing', value: 'false'}]`",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "preferences",
-          "value": "boolean",
-          "description": "The visitor's consent for storing preferences such as language and currency. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "saleOfData",
-          "value": "boolean",
-          "description": "The visitor's consent for the sale or sharing of their personal data with third parties. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'changeVisitorConsent'",
-          "description": "Identifies this as a visitor consent change. This is the only supported change type for `applyTrackingConsentChange()`."
-        }
-      ],
-      "value": "export interface VisitorConsentChange extends VisitorConsent {\n  /**\n   * Tracking consent metafield data to be saved.\n   *\n   * If the value is `null`, the metafield is deleted.\n   *\n   * @example `[{key: 'granularAnalytics', value: 'true'}, {key: 'granularMarketing', value: 'false'}]`\n   */\n  metafields?: TrackingConsentMetafieldChange[];\n  /**\n   * Identifies this as a visitor consent change. This is the only supported change type for `applyTrackingConsentChange()`.\n   */\n  type: 'changeVisitorConsent';\n}"
-    }
-  },
-  "TrackingConsentMetafieldChange": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "TrackingConsentMetafieldChange",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "key",
-          "value": "string",
-          "description": "The identifier for the tracking consent metafield to update."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string | null",
-          "description": "The new value to store in the metafield. Set to `null` to delete the metafield.\n\nConsent metafield values are strings, not booleans. Pass `null` to delete a tracking consent metafield."
-        }
-      ],
-      "value": "export interface TrackingConsentMetafieldChange {\n  /**\n   * The identifier for the tracking consent metafield to update.\n   */\n  key: string;\n  /**\n   * The new value to store in the metafield. Set to `null` to delete the metafield.\n   *\n   * Consent metafield values are strings, not booleans. Pass `null` to delete\n   * a tracking consent metafield.\n   */\n  value: string | null;\n}"
-    }
-  },
-  "VisitorConsent": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "VisitorConsent",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "analytics",
-          "value": "boolean",
-          "description": "The visitor's consent for analytics tracking. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "marketing",
-          "value": "boolean",
-          "description": "The visitor's consent for marketing and targeted advertising. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "preferences",
-          "value": "boolean",
-          "description": "The visitor's consent for storing preferences such as language and currency. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "saleOfData",
-          "value": "boolean",
-          "description": "The visitor's consent for the sale or sharing of their personal data with third parties. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
-          "isOptional": true
-        }
-      ],
-      "value": "export interface VisitorConsent {\n  /**\n   * The visitor's consent for analytics tracking. `true` means the visitor\n   * actively granted consent, `false` means actively denied, and `undefined`\n   * means no decision has been made yet.\n   */\n  analytics?: boolean;\n  /**\n   * The visitor's consent for marketing and targeted advertising. `true` means\n   * the visitor actively granted consent, `false` means actively denied, and\n   * `undefined` means no decision has been made yet.\n   */\n  marketing?: boolean;\n  /**\n   * The visitor's consent for storing preferences such as language and currency.\n   * `true` means the visitor actively granted consent, `false` means actively\n   * denied, and `undefined` means no decision has been made yet.\n   */\n  preferences?: boolean;\n  /**\n   * The visitor's consent for the sale or sharing of their personal data with\n   * third parties. `true` means the visitor actively granted consent, `false`\n   * means actively denied, and `undefined` means no decision has been made yet.\n   */\n  saleOfData?: boolean;\n}"
-    }
-  },
-  "TrackingConsentChangeResult": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "TrackingConsentChangeResult",
-      "value": "TrackingConsentChangeResultSuccess | TrackingConsentChangeResultError",
-      "description": ""
-    }
-  },
-  "TrackingConsentChangeResultSuccess": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "TrackingConsentChangeResultSuccess",
-      "description": "The returned result of a successful tracking consent preference update.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'success'",
-          "description": "Indicates that the tracking consent update was applied successfully."
-        }
-      ],
-      "value": "export interface TrackingConsentChangeResultSuccess {\n  /**\n   * Indicates that the tracking consent update was applied successfully.\n   */\n  type: 'success';\n}"
-    }
-  },
-  "TrackingConsentChangeResultError": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "TrackingConsentChangeResultError",
-      "description": "The returned result of an unsuccessful tracking consent preference update with a message detailing the type of error that occurred.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "message",
-          "value": "string",
-          "description": "A message that explains the error. This message is useful for debugging. It isn't localized and shouldn't be displayed to the buyer."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'error'",
-          "description": "Indicates that the tracking consent update couldn't be applied. Check the `message` property for details."
-        }
-      ],
-      "value": "export interface TrackingConsentChangeResultError {\n  /**\n   * Indicates that the tracking consent update couldn't be applied. Check the `message` property for details.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It isn't localized and shouldn't be displayed to the buyer.\n   */\n  message: string;\n}"
-    }
-  },
-  "AppMetafieldEntry": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "AppMetafieldEntry",
-      "description": "An entry that pairs a Shopify resource with one of its [metafields](/docs/apps/build/custom-data/metafields). Each entry contains a `target` identifying which resource the metafield belongs to and a `metafield` object with the actual data.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "metafield",
-          "value": "AppMetafield",
-          "description": "The metafield data, including the namespace, key, value, and content type. Use the `namespace` and `key` together to uniquely identify the metafield within its resource."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "AppMetafieldEntryTarget",
-          "description": "The Shopify resource that this metafield is attached to, including the resource type (such as `'product'` or `'customer'`) and its globally-unique ID.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`."
-        }
-      ],
-      "value": "export interface AppMetafieldEntry {\n  /**\n   * The Shopify resource that this metafield is attached to, including the resource type (such as `'product'` or `'customer'`) and its globally-unique ID.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.\n   */\n  target: AppMetafieldEntryTarget;\n\n  /**\n   * The metafield data, including the namespace, key, value, and content type. Use the `namespace` and `key` together to uniquely identify the metafield within its resource.\n   */\n  metafield: AppMetafield;\n}"
-    }
-  },
-  "AppMetafield": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "AppMetafield",
-      "description": "Represents a custom [metafield](/docs/apps/build/custom-data/metafields) attached to a resource such as a product, variant, customer, or shop.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "key",
-          "value": "string",
-          "description": "The identifier for the metafield within its namespace, such as `'ingredients'` or `'shipping_weight'`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "namespace",
-          "value": "string",
-          "description": "The namespace that the metafield belongs to. Namespaces group related metafields and prevent naming collisions between different apps.\n\nApp owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "string",
-          "description": "The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`. This is the full type identifier, whereas `valueType` is a simplified category."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string",
-          "description": "The value of a metafield, stored as a string regardless of the underlying type. For JSON metafields, parse the string to access structured data."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "valueType",
-          "value": "'boolean' | 'float' | 'integer' | 'json_string' | 'string'",
-          "description": "The metafield's information type.\n\n- `'boolean'`: A true or false value.\n- `'float'`: A decimal number value.\n- `'integer'`: A whole number value.\n- `'json_string'`: A JSON-encoded string value.\n- `'string'`: A plain text value."
-        }
-      ],
-      "value": "export interface AppMetafield {\n  /**\n   * The identifier for the metafield within its namespace, such as `'ingredients'` or `'shipping_weight'`.\n   */\n  key: string;\n\n  /**\n   * The namespace that the metafield belongs to. Namespaces group related metafields and prevent naming collisions between different apps.\n   *\n   * App owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   */\n  namespace: string;\n\n  /**\n   * The value of a metafield, stored as a string regardless of the underlying type. For JSON metafields, parse the string to access structured data.\n   */\n  value: string;\n\n  /**\n   * The metafield's information type.\n   *\n   * - `'boolean'`: A true or false value.\n   * - `'float'`: A decimal number value.\n   * - `'integer'`: A whole number value.\n   * - `'json_string'`: A JSON-encoded string value.\n   * - `'string'`: A plain text value.\n   */\n  valueType: 'boolean' | 'float' | 'integer' | 'json_string' | 'string';\n\n  /**\n   * The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`. This is the full type identifier, whereas `valueType` is a simplified category.\n   */\n  type: string;\n}"
-    }
-  },
-  "AppMetafieldEntryTarget": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "AppMetafieldEntryTarget",
-      "description": "The Shopify resource that a metafield is attached to. Each entry identifies a specific resource by its type and globally-unique ID, so you can trace where the data comes from.",
-      "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "id",
           "value": "string",
-          "description": "The globally-unique identifier of the Shopify resource, in [GID](/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the [Storefront API](/docs/api/storefront).",
+          "description": "A unique identifier for the cart line in the format `gid://shopify/CartLine/<id>`. This ID isn't stable and can change after any cart operation, so avoid persisting it. Always look up the current ID before calling `applyCartLinesChange()`, because you'll need it to create a `CartLineChange` object.",
           "examples": [
             {
               "title": "Example",
               "description": "",
               "tabs": [
                 {
-                  "code": "'gid://shopify/Product/123'",
+                  "code": "'gid://shopify/CartLine/123'",
                   "title": "Example"
                 }
               ]
@@ -773,12 +125,33 @@
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "| 'customer'\n    | 'product'\n    | 'shop'\n    | 'shopUser'\n    | 'variant'\n    | 'company'\n    | 'companyLocation'\n    | 'cart'",
-          "description": "The kind of Shopify resource this metafield belongs to:\n\n- `'customer'`: The customer who placed the order.\n- `'product'`: A product in the merchant's catalog.\n- `'shop'`: The merchant's shop.\n- `'shopUser'`: A staff member or collaborator account on the shop.\n- `'variant'`: A specific variant of a product.\n- `'company'`: A [B2B](/docs/apps/build/b2b) company associated with the order.\n- `'companyLocation'`: A location belonging to a [B2B](/docs/apps/build/b2b) company.\n- `'cart'`: The cart associated with the checkout.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`."
+          "name": "lineComponents",
+          "value": "CartBundleLineComponent[]",
+          "description": "The individual components of a [bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component represents a separate product within the bundle. Returns an empty array if the line item isn't a bundle."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "merchandise",
+          "value": "Merchandise",
+          "description": "The product variant or other merchandise associated with this line item. Use this to access product details such as the title, image, SKU, and selected options."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "parentRelationship",
+          "value": "CartLineParentRelationship | null",
+          "description": "The parent line item that this line belongs to, or `null` if this is a top-level line item. Used to identify lines added as children of a bundle or other grouped product."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "quantity",
+          "value": "number",
+          "description": "The number of units of this merchandise that the buyer purchased."
         }
       ],
-      "value": "export interface AppMetafieldEntryTarget {\n  /**\n   * The kind of Shopify resource this metafield belongs to:\n   *\n   * - `'customer'`: The customer who placed the order.\n   * - `'product'`: A product in the merchant's catalog.\n   * - `'shop'`: The merchant's shop.\n   * - `'shopUser'`: A staff member or collaborator account on the shop.\n   * - `'variant'`: A specific variant of a product.\n   * - `'company'`: A [B2B](/docs/apps/build/b2b) company associated with the order.\n   * - `'companyLocation'`: A location belonging to a [B2B](/docs/apps/build/b2b) company.\n   * - `'cart'`: The cart associated with the checkout.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.\n   */\n  type:\n    | 'customer'\n    | 'product'\n    | 'shop'\n    | 'shopUser'\n    | 'variant'\n    | 'company'\n    | 'companyLocation'\n    | 'cart';\n\n  /**\n   * The globally-unique identifier of the Shopify resource, in [GID](/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the [Storefront API](/docs/api/storefront).\n   *\n   * @example 'gid://shopify/Product/123'\n   */\n  id: string;\n}"
+      "value": "export interface CartLine {\n  /**\n   * A unique identifier for the cart line in the format `gid://shopify/CartLine/<id>`. This ID isn't stable and can change after any cart operation, so avoid persisting it. Always look up the current ID before calling `applyCartLinesChange()`, because you'll need it to create a `CartLineChange` object.\n   *\n   * @example 'gid://shopify/CartLine/123'\n   */\n  id: string;\n\n  /**\n   * The product variant or other merchandise associated with this line item. Use this to access product details such as the title, image, SKU, and selected options.\n   */\n  merchandise: Merchandise;\n\n  /**\n   * The number of units of this merchandise that the buyer purchased.\n   */\n  quantity: number;\n\n  /**\n   * The cost breakdown for this line item, including the total price after any line-level discounts have been applied.\n   */\n  cost: CartLineCost;\n\n  /**\n   * Custom key-value attributes attached to this cart line, such as gift messages or engraving text. Use `applyCartLinesChange()` to update these values.\n   */\n  attributes: Attribute[];\n\n  /**\n   * Discounts applied to this cart line, including code-based, automatic, and custom discounts. Each allocation shows the discounted amount and how the discount was triggered.\n   */\n  discountAllocations: CartDiscountAllocation[];\n\n  /**\n   * The individual components of a [bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component represents a separate product within the bundle. Returns an empty array if the line item isn't a bundle.\n   */\n  lineComponents: CartLineComponentType[];\n\n  /**\n   * The parent line item that this line belongs to, or `null` if this is a\n   * top-level line item. Used to identify lines added as children of a bundle\n   * or other grouped product.\n   */\n  parentRelationship: CartLineParentRelationship | null;\n}"
     }
   },
   "Attribute": {
@@ -829,28 +202,657 @@
       "value": "export interface Attribute {\n  /**\n   * The identifier for the attribute. Each key must be unique within the\n   * set of attributes on the cart or checkout. If you call\n   * `applyAttributeChange()` with a key that already exists, then the\n   * existing value is replaced.\n   *\n   * @example 'gift_wrapping'\n   */\n  key: string;\n\n  /**\n   * The value associated with the attribute key. This is a freeform string\n   * that can store any information the buyer or app provides.\n   *\n   * Attribute values are always strings. To store structured data, serialize\n   * it to JSON and parse it when reading.\n   *\n   * @example 'Please use red wrapping paper'\n   */\n  value: string;\n}"
     }
   },
-  "PaymentOption": {
+  "CartLineCost": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "PaymentOption",
-      "description": "A payment option presented to the buyer.",
+      "name": "CartLineCost",
+      "description": "",
       "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "handle",
+          "name": "totalAmount",
+          "value": "Money",
+          "description": "The total price the buyer pays for this line item after all line-level discounts have been applied, but before order-level discounts, taxes, and shipping."
+        }
+      ],
+      "value": "export interface CartLineCost {\n  /**\n   * The total price the buyer pays for this line item after all line-level discounts have been applied, but before order-level discounts, taxes, and shipping.\n   */\n  totalAmount: Money;\n}"
+    }
+  },
+  "Money": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Money",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amount",
+          "value": "number",
+          "description": "The decimal amount of the price. For example, `29.99` represents twenty-nine dollars and ninety-nine cents."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currencyCode",
+          "value": "CurrencyCode",
+          "description": "The three-letter currency code in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) format.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CAD' for Canadian dollar",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface Money {\n  /**\n   * The decimal amount of the price. For example, `29.99` represents twenty-nine dollars and ninety-nine cents.\n   */\n  amount: number;\n  /**\n   * The three-letter currency code in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) format.\n   *\n   * @example 'CAD' for Canadian dollar\n   */\n  currencyCode: CurrencyCode;\n}"
+    }
+  },
+  "CurrencyCode": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CurrencyCode",
+      "value": "'AED' | 'AFN' | 'ALL' | 'AMD' | 'ANG' | 'AOA' | 'ARS' | 'AUD' | 'AWG' | 'AZN' | 'BAM' | 'BBD' | 'BDT' | 'BGN' | 'BHD' | 'BIF' | 'BMD' | 'BND' | 'BOB' | 'BOV' | 'BRL' | 'BSD' | 'BTN' | 'BWP' | 'BYN' | 'BZD' | 'CAD' | 'CDF' | 'CHE' | 'CHF' | 'CHW' | 'CLF' | 'CLP' | 'CNY' | 'COP' | 'COU' | 'CRC' | 'CUC' | 'CUP' | 'CVE' | 'CZK' | 'DJF' | 'DKK' | 'DOP' | 'DZD' | 'EGP' | 'ERN' | 'ETB' | 'EUR' | 'FJD' | 'FKP' | 'GBP' | 'GEL' | 'GHS' | 'GIP' | 'GMD' | 'GNF' | 'GTQ' | 'GYD' | 'HKD' | 'HNL' | 'HRK' | 'HTG' | 'HUF' | 'IDR' | 'ILS' | 'INR' | 'IQD' | 'IRR' | 'ISK' | 'JMD' | 'JOD' | 'JPY' | 'KES' | 'KGS' | 'KHR' | 'KMF' | 'KPW' | 'KRW' | 'KWD' | 'KYD' | 'KZT' | 'LAK' | 'LBP' | 'LKR' | 'LRD' | 'LSL' | 'LYD' | 'MAD' | 'MDL' | 'MGA' | 'MKD' | 'MMK' | 'MNT' | 'MOP' | 'MRU' | 'MUR' | 'MVR' | 'MWK' | 'MXN' | 'MXV' | 'MYR' | 'MZN' | 'NAD' | 'NGN' | 'NIO' | 'NOK' | 'NPR' | 'NZD' | 'OMR' | 'PAB' | 'PEN' | 'PGK' | 'PHP' | 'PKR' | 'PLN' | 'PYG' | 'QAR' | 'RON' | 'RSD' | 'RUB' | 'RWF' | 'SAR' | 'SBD' | 'SCR' | 'SDG' | 'SEK' | 'SGD' | 'SHP' | 'SLL' | 'SOS' | 'SRD' | 'SSP' | 'STN' | 'SVC' | 'SYP' | 'SZL' | 'THB' | 'TJS' | 'TMT' | 'TND' | 'TOP' | 'TRY' | 'TTD' | 'TWD' | 'TZS' | 'UAH' | 'UGX' | 'USD' | 'USN' | 'UYI' | 'UYU' | 'UYW' | 'UZS' | 'VES' | 'VND' | 'VUV' | 'WST' | 'XAF' | 'XAG' | 'XAU' | 'XBA' | 'XBB' | 'XBC' | 'XBD' | 'XCD' | 'XDR' | 'XOF' | 'XPD' | 'XPF' | 'XPT' | 'XSU' | 'XTS' | 'XUA' | 'XXX' | 'YER' | 'ZAR' | 'ZMW' | 'ZWL'",
+      "description": ""
+    }
+  },
+  "CartDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CartDiscountAllocation",
+      "value": "CartCodeDiscountAllocation | CartAutomaticDiscountAllocation | CartCustomDiscountAllocation",
+      "description": "A discount allocation applied to the cart. Use the `type` property to determine how the discount was triggered:\n\n- `CartCodeDiscountAllocation` (`type: 'code'`): Triggered by a discount code the buyer entered.\n- `CartAutomaticDiscountAllocation` (`type: 'automatic'`): Applied automatically based on merchant-configured rules.\n- `CartCustomDiscountAllocation` (`type: 'custom'`): Applied by a [Shopify Function](/docs/api/functions/latest/discount)."
+    }
+  },
+  "CartCodeDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartCodeDiscountAllocation",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
           "value": "string",
-          "description": "A session-scoped identifier for this payment option. This handle isn't globally unique; it's specific to the current checkout session or the shop."
+          "description": "The discount code string that the buyer entered during checkout, such as `\"SAVE10\"` or `\"FREESHIP\"`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountedAmount",
+          "value": "Money",
+          "description": "The monetary value that was deducted from the line item or order total by this discount allocation."
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "type",
-          "value": "| 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite'",
-          "description": "The type of the payment option.\n\nShops can be configured to support many different payment options. Some options are available only to buyers in specific regions.\n\n| Type  | Description  |\n|---|---|\n| `creditCard`  |  A vaulted or manually entered credit card.  |\n| `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n| `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n| `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n| `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n| `other`  |  Another type of payment not defined here.  |\n| `paymentOnDelivery`  |  A payment collected on delivery.  |\n| `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n| `wallet`  |  An integrated wallet such as PayPal, Google Pay, or Apple Pay.  |\n| `customOnsite` | A custom payment option that's processed through a checkout extension with a payments app. |"
+          "value": "'code'",
+          "description": "Identifies this as a code-based discount, triggered by a discount code the buyer entered at checkout."
         }
       ],
-      "value": "export interface PaymentOption {\n  /**\n   * The type of the payment option.\n   *\n   * Shops can be configured to support many different payment options. Some options are available only to buyers in specific regions.\n   *\n   * | Type  | Description  |\n   * |---|---|\n   * | `creditCard`  |  A vaulted or manually entered credit card.  |\n   * | `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n   * | `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n   * | `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n   * | `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n   * | `other`  |  Another type of payment not defined here.  |\n   * | `paymentOnDelivery`  |  A payment collected on delivery.  |\n   * | `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n   * | `wallet`  |  An integrated wallet such as PayPal, Google Pay, or Apple Pay.  |\n   * | `customOnsite` | A custom payment option that's processed through a checkout extension with a payments app. |\n   */\n  type:\n    | 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite';\n\n  /**\n   * A session-scoped identifier for this payment option. This handle isn't globally unique; it's specific to the current checkout session or the shop.\n   */\n  handle: string;\n}"
+      "value": "export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {\n  /**\n   * The discount code string that the buyer entered during checkout, such as `\"SAVE10\"` or `\"FREESHIP\"`.\n   */\n  code: string;\n\n  /**\n   * Identifies this as a code-based discount, triggered by a discount code the buyer entered at checkout.\n   */\n  type: 'code';\n}"
+    }
+  },
+  "CartAutomaticDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartAutomaticDiscountAllocation",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountedAmount",
+          "value": "Money",
+          "description": "The monetary value that was deducted from the line item or order total by this discount allocation."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The merchant-defined title of the automatic discount as displayed to the buyer, such as \"Summer Sale 10% Off\"."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'automatic'",
+          "description": "Identifies this as an automatic discount, applied based on merchant-configured rules without a code."
+        }
+      ],
+      "value": "export interface CartAutomaticDiscountAllocation\n  extends CartDiscountAllocationBase {\n  /**\n   * The merchant-defined title of the automatic discount as displayed to the buyer, such as \"Summer Sale 10% Off\".\n   */\n  title: string;\n\n  /**\n   * Identifies this as an automatic discount, applied based on merchant-configured rules without a code.\n   */\n  type: 'automatic';\n}"
+    }
+  },
+  "CartCustomDiscountAllocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartCustomDiscountAllocation",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountedAmount",
+          "value": "Money",
+          "description": "The monetary value that was deducted from the line item or order total by this discount allocation."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The title of the custom discount, typically applied by a [Shopify Function](/docs/api/functions/latest/discount)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'custom'",
+          "description": "Identifies this as a custom discount applied by a [Shopify Function](/docs/api/functions/latest/discount)."
+        }
+      ],
+      "value": "export interface CartCustomDiscountAllocation\n  extends CartDiscountAllocationBase {\n  /**\n   * The title of the custom discount, typically applied by a [Shopify Function](/docs/api/functions/latest/discount).\n   */\n  title: string;\n\n  /**\n   * Identifies this as a custom discount applied by a [Shopify Function](/docs/api/functions/latest/discount).\n   */\n  type: 'custom';\n}"
+    }
+  },
+  "CartBundleLineComponent": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartBundleLineComponent",
+      "description": "An individual component within a bundled cart line. Each `CartLine` that represents a bundle has a `lineComponents` array containing these components.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "Attribute[]",
+          "description": "Custom key-value pairs attached to this bundle component, such as personalization options specific to this item within the bundle.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "[{key: 'engraving', value: 'hello world'}]",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "CartLineCost",
+          "description": "The cost breakdown for this bundle component, including the total amount after any per-item discounts."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A unique identifier for this component within the bundle, in the format `gid://shopify/CartLineComponent/<id>`. This ID isn't stable and might change after any operation that updates the line items.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/CartLineComponent/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "merchandise",
+          "value": "Merchandise",
+          "description": "The product variant included in this bundle component. Use this to display product details for individual items within a bundle."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "quantity",
+          "value": "number",
+          "description": "The number of units of this component included in the bundle."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'bundle'",
+          "description": "Identifies this as a bundle line component. This is currently the only component type."
+        }
+      ],
+      "value": "export interface CartBundleLineComponent {\n  /**\n   * Identifies this as a bundle line component. This is currently the only component type.\n   */\n  type: 'bundle';\n\n  /**\n   * A unique identifier for this component within the bundle, in the format `gid://shopify/CartLineComponent/<id>`. This ID isn't stable and might change after any operation that updates the line items.\n   *\n   * @example 'gid://shopify/CartLineComponent/123'\n   */\n  id: string;\n\n  /**\n   * The product variant included in this bundle component. Use this to display product details for individual items within a bundle.\n   */\n  merchandise: Merchandise;\n\n  /**\n   * The number of units of this component included in the bundle.\n   */\n  quantity: number;\n\n  /**\n   * The cost breakdown for this bundle component, including the total amount after any per-item discounts.\n   */\n  cost: CartLineCost;\n\n  /**\n   * Custom key-value pairs attached to this bundle component, such as personalization options specific to this item within the bundle.\n   *\n   * @example [{key: 'engraving', value: 'hello world'}]\n   */\n  attributes: Attribute[];\n}"
+    }
+  },
+  "Merchandise": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "Merchandise",
+      "value": "ProductVariant",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for the product variant in the format `gid://shopify/ProductVariant/<id>`.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/ProductVariant/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "image",
+          "value": "ImageDetails",
+          "description": "The image associated with the product variant. Falls back to the product image if the variant doesn't have its own. The value is `undefined` if neither the variant nor the product has an image.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "product",
+          "value": "Product",
+          "description": "The parent product that this variant belongs to. Use this to access the product's ID, vendor, and type."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "requiresShipping",
+          "value": "boolean",
+          "description": "Whether this product variant requires physical shipping. When `true`, the buyer must provide a shipping address. Returns `false` for digital products, gift cards, and services."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedOptions",
+          "value": "SelectedOption[]",
+          "description": "The product options applied to this variant, such as size, color, or material. Each entry contains the option name and the selected value."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sellingPlan",
+          "value": "SellingPlan",
+          "description": "The [selling plan](/docs/apps/build/purchase-options/subscriptions) associated with this variant, such as a subscription or pre-order plan. The value is `undefined` if the item isn't being purchased through a selling plan.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sku",
+          "value": "string",
+          "description": "The stock keeping unit (SKU) assigned to this variant by the merchant, used for inventory tracking. The value is `undefined` if no SKU has been set.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subtitle",
+          "value": "string",
+          "description": "A secondary description for the variant that provides additional context, such as a color or size combination. The value is `undefined` if no subtitle is available.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The display title of the product variant, such as \"Small\" or \"Red / Large\". This is the variant-specific label, not the parent product title."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'variant'",
+          "description": "Identifies the merchandise as a product variant. This is currently the only merchandise type in checkout."
+        }
+      ]
+    }
+  },
+  "ImageDetails": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ImageDetails",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "altText",
+          "value": "string",
+          "description": "The alternative text for the image, used for accessibility. The value is `undefined` if the merchant hasn't provided alt text.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "url",
+          "value": "string",
+          "description": "The fully-qualified URL of the image. Use this to render the product or variant image in your extension."
+        }
+      ],
+      "value": "export interface ImageDetails {\n  /**\n   * The fully-qualified URL of the image. Use this to render the product or variant image in your extension.\n   */\n  url: string;\n\n  /**\n   * The alternative text for the image, used for accessibility. The value is `undefined` if the merchant hasn't provided alt text.\n   */\n  altText?: string;\n}"
+    }
+  },
+  "Product": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Product",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for the product in the format `gid://shopify/Product/<id>`.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/Product/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "productType",
+          "value": "string",
+          "description": "A merchant-defined categorization for the product, such as \"Accessories\" or \"Clothing\". Commonly used for filtering and organizing products in a storefront."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "vendor",
+          "value": "string",
+          "description": "The name of the product's vendor or manufacturer, as set by the merchant in Shopify admin."
+        }
+      ],
+      "value": "export interface Product {\n  /**\n   * A globally-unique identifier for the product in the format `gid://shopify/Product/<id>`.\n   *\n   * @example 'gid://shopify/Product/123'\n   */\n  id: string;\n\n  /**\n   * The name of the product's vendor or manufacturer, as set by the merchant in Shopify admin.\n   */\n  vendor: string;\n\n  /**\n   * A merchant-defined categorization for the product, such as \"Accessories\" or \"Clothing\". Commonly used for filtering and organizing products in a storefront.\n   */\n  productType: string;\n}"
+    }
+  },
+  "SelectedOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "SelectedOption",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the product option, such as \"Color\" or \"Size\".",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Size'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The selected value for the product option, such as \"Red\" or \"Large\".",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Large'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface SelectedOption {\n  /**\n   * The name of the product option, such as \"Color\" or \"Size\".\n   *\n   * @example 'Size'\n   */\n  name: string;\n\n  /**\n   * The selected value for the product option, such as \"Red\" or \"Large\".\n   *\n   * @example 'Large'\n   */\n  value: string;\n}"
+    }
+  },
+  "SellingPlan": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "SellingPlan",
+      "description": "A [selling plan](/docs/apps/build/purchase-options/subscriptions) represents a recurring or deferred purchasing option for a product, such as a subscription, pre-order, or try-before-you-buy plan. The merchant configures selling plans to define how and when the buyer is charged.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for the selling plan in the format `gid://shopify/SellingPlan/<id>`. Use this to reference the specific selling plan associated with a line item.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/SellingPlan/1'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "recurringDeliveries",
+          "value": "boolean",
+          "description": "Whether purchasing through this selling plan results in multiple deliveries. `true` for subscription plans with recurring fulfillment, `false` for one-time pre-orders or try-before-you-buy plans."
+        }
+      ],
+      "value": "export interface SellingPlan {\n  /**\n   * A globally-unique identifier for the selling plan in the format\n   * `gid://shopify/SellingPlan/<id>`. Use this to reference the specific\n   * selling plan associated with a line item.\n   *\n   * @example 'gid://shopify/SellingPlan/1'\n   */\n  id: string;\n\n  /**\n   * Whether purchasing through this selling plan results in multiple\n   * deliveries. `true` for subscription plans with recurring fulfillment,\n   * `false` for one-time pre-orders or try-before-you-buy plans.\n   */\n  recurringDeliveries: boolean;\n}"
+    }
+  },
+  "CartLineParentRelationship": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartLineParentRelationship",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "parent",
+          "value": "{ id: string; }",
+          "description": "The parent cart line that a cart line is associated with."
+        }
+      ],
+      "value": "export interface CartLineParentRelationship {\n  /**\n   * The parent cart line that a cart line is associated with.\n   */\n  parent: {\n    /**\n     * These line item IDs aren't stable at the moment, and they might change after\n     * any operations on the line items. Always look up an updated\n     * ID before any call to `applyCartLinesChange` because you'll need the ID to\n     * create a `CartLineChange` object.\n     * @example 'gid://shopify/CartLine/123'\n     */\n    id: string;\n  };\n}"
+    }
+  },
+  "PickupLocationListApi": {
+    "src/surfaces/checkout/api/pickup/pickup-location-list.ts": {
+      "filePath": "src/surfaces/checkout/api/pickup/pickup-location-list.ts",
+      "name": "PickupLocationListApi",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/pickup/pickup-location-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isLocationFormVisible",
+          "value": "SubscribableSignalLike<boolean>",
+          "description": "Whether the location search form is currently visible to the buyer. Use this to conditionally render UI that depends on the buyer actively searching for pickup locations."
+        }
+      ],
+      "value": "export interface PickupLocationListApi {\n  /**\n   * Whether the location search form is currently visible to the buyer.\n   * Use this to conditionally render UI that depends on the buyer actively\n   * searching for pickup locations.\n   */\n  isLocationFormVisible: SubscribableSignalLike<boolean>;\n}"
+    }
+  },
+  "PickupPointListApi": {
+    "src/surfaces/checkout/api/pickup/pickup-point-list.ts": {
+      "filePath": "src/surfaces/checkout/api/pickup/pickup-point-list.ts",
+      "name": "PickupPointListApi",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/pickup/pickup-point-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isLocationFormVisible",
+          "value": "SubscribableSignalLike<boolean>",
+          "description": "Reflects which view was active when the extension loaded. When the buyer moves to the next view, the extension restarts with the current value rather than updating in place."
+        }
+      ],
+      "value": "export interface PickupPointListApi {\n  /**\n   * Reflects which view was active when the extension loaded. When the\n   * buyer moves to the next view, the extension restarts with the\n   * current value rather than updating in place.\n   */\n  isLocationFormVisible: SubscribableSignalLike<boolean>;\n}"
+    }
+  },
+  "PickupLocationItemApi": {
+    "src/surfaces/checkout/api/pickup/pickup-location-item.ts": {
+      "filePath": "src/surfaces/checkout/api/pickup/pickup-location-item.ts",
+      "name": "PickupLocationItemApi",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/pickup/pickup-location-item.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTargetSelected",
+          "value": "SubscribableSignalLike<boolean>",
+          "description": "Whether the buyer has selected the target pickup location. When `true`, the target location is the buyer's active choice. When `false`, the buyer has chosen a different pickup location.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/pickup/pickup-location-item.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "SubscribableSignalLike<PickupLocationOption>",
+          "description": "The pickup location that this extension is attached to. Use this to read the location's name, address, and other details.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
+        }
+      ],
+      "value": "export interface PickupLocationItemApi {\n  /**\n   * The pickup location that this extension is attached to. Use this to read the location's name, address, and other details.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  target: SubscribableSignalLike<PickupLocationOption>;\n\n  /**\n   * Whether the buyer has selected the target pickup location. When `true`, the target location is the buyer's active choice. When `false`, the buyer has chosen a different pickup location.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  isTargetSelected: SubscribableSignalLike<boolean>;\n}"
+    }
+  },
+  "PickupLocationOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PickupLocationOption",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The carrier service code or rate identifier for this delivery option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "description",
+          "value": "string",
+          "description": "Additional details about the delivery option provided by the carrier or merchant, such as estimated delivery windows or service level notes.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "The unique identifier of the delivery option. Use this to match against `DeliveryOptionReference.handle` or `DeliverySelectionGroup` entries."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "location",
+          "value": "PickupLocation",
+          "description": "The merchant's store or warehouse where the buyer picks up their order, including the address and display name."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "Metafield[]",
+          "description": "Custom [metafields](/docs/apps/build/custom-data/metafields) attached to this delivery option by the carrier or a [Shopify Function](/docs/apps/build/functions). Use these to display additional information about the option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The merchant-facing or carrier-provided display name for the delivery option, such as \"Standard Shipping\" or \"Express\".",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'pickup'",
+          "description": "Identifies this as a pickup location option, where the buyer picks up items directly from a merchant's store or warehouse."
+        }
+      ],
+      "value": "export interface PickupLocationOption extends DeliveryOptionBase {\n  /**\n   * Identifies this as a pickup location option, where the buyer picks up items directly from a merchant's store or warehouse.\n   */\n  type: 'pickup';\n\n  /**\n   * The merchant's store or warehouse where the buyer picks up their order, including the address and display name.\n   */\n  location: PickupLocation;\n}"
+    }
+  },
+  "PickupLocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PickupLocation",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address",
+          "value": "MailingAddress",
+          "description": "The physical address of the pickup location."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The merchant-defined display name of the pickup location, such as a store name or warehouse label.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface PickupLocation {\n  /**\n   * The merchant-defined display name of the pickup location, such as a\n   * store name or warehouse label.\n   */\n  name?: string;\n\n  /**\n   * The physical address of the pickup location.\n   */\n  address: MailingAddress;\n}"
     }
   },
   "MailingAddress": {
@@ -1092,1045 +1094,115 @@
       "description": ""
     }
   },
-  "BuyerIdentity": {
+  "Metafield": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "BuyerIdentity",
-      "description": "Information about the buyer who is completing the checkout.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data). The `customer` and `purchasingCompany` properties require level 1 access. The `email` and `phone` properties require level 2 access.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "customer",
-          "value": "SubscribableSignalLike<Customer | undefined>",
-          "description": "The buyer's customer account, including their ID and whether they've accepted marketing. The value is `undefined` if the buyer isn't a known customer for this shop or if they haven't logged in yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "email",
-          "value": "SubscribableSignalLike<string | undefined>",
-          "description": "The email address the buyer provided during checkout. The value is `undefined` if the app doesn't have access to customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "phone",
-          "value": "SubscribableSignalLike<string | undefined>",
-          "description": "The phone number the buyer provided during checkout. The value is `undefined` if no phone number was provided or the app doesn't have access to customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchasingCompany",
-          "value": "SubscribableSignalLike<PurchasingCompany | undefined>",
-          "description": "The company and company location that a B2B (business-to-business) customer is purchasing on behalf of. Use this to identify the business context of the order. The value is `undefined` if the buyer isn't a B2B customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        }
-      ],
-      "value": "export interface BuyerIdentity {\n  /**\n   * The buyer's customer account, including their ID and whether they've accepted marketing. The value is `undefined` if the buyer isn't a\n   * known customer for this shop or if they haven't logged in yet.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  customer: SubscribableSignalLike<Customer | undefined>;\n\n  /**\n   * The email address the buyer provided during checkout. The value is `undefined` if the app doesn't have access to customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  email: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The phone number the buyer provided during checkout. The value is `undefined` if no phone number was provided or the app doesn't have access to customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  phone: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The company and company location that a B2B (business-to-business) customer is purchasing on behalf of. Use this to identify the business context of the order. The value is `undefined` if the buyer isn't a B2B customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  purchasingCompany: SubscribableSignalLike<PurchasingCompany | undefined>;\n}"
-    }
-  },
-  "Customer": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "Customer",
-      "description": "Information about a customer who has previously purchased from this shop.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "acceptsEmailMarketing",
-          "value": "boolean",
-          "description": "Whether the customer has opted in to email marketing.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "acceptsMarketing",
-          "value": "boolean",
-          "description": "Whether the customer has opted in to receiving marketing communications from the merchant, such as email campaigns and promotional offers.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n\n> Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.",
-          "deprecationMessage": "Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "acceptsSmsMarketing",
-          "value": "boolean",
-          "description": "Whether the customer has opted in to SMS marketing.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "email",
-          "value": "string",
-          "description": "The email address associated with the customer's account. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "firstName",
-          "value": "string",
-          "description": "The customer's first name. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "fullName",
-          "value": "string",
-          "description": "The customer's full name, typically a combination of first and last name. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "An identifier for the customer in the format `gid://shopify/Customer/<id>`. This value is unique per shop.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/Customer/123'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "image",
-          "value": "ImageDetails",
-          "description": "The customer's profile image, such as a Gravatar avatar. Use this to personalize the extension UI for the logged-in buyer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "lastName",
-          "value": "string",
-          "description": "The customer's last name. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "ordersCount",
-          "value": "number",
-          "description": "The number of orders the customer has previously placed with this shop.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "phone",
-          "value": "string",
-          "description": "The phone number associated with the customer's account. The value is `undefined` if no phone number is on file or the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "storeCreditAccounts",
-          "value": "StoreCreditAccount[]",
-          "description": "The store credit accounts owned by this customer that can be used as payment during checkout. Each account has a balance representing available store credit.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isPrivate": true
-        }
-      ],
-      "value": "export interface Customer {\n  /**\n   * An identifier for the customer in the format `gid://shopify/Customer/<id>`. This value is unique per shop.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'gid://shopify/Customer/123'\n   */\n  id: string;\n  /**\n   * The email address associated with the customer's account. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  email?: string;\n  /**\n   * The phone number associated with the customer's account. The value is `undefined` if no phone number is on file or the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  phone?: string;\n  /**\n   * The customer's full name, typically a combination of first and last name. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  fullName?: string;\n  /**\n   * The customer's first name. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  firstName?: string;\n  /**\n   * The customer's last name. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  lastName?: string;\n  /**\n   * The customer's profile image, such as a Gravatar avatar. Use this to personalize the extension UI for the logged-in buyer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  image: ImageDetails;\n  /**\n   * Whether the customer has opted in to receiving marketing communications from the merchant, such as email campaigns and promotional offers.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * > Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.\n   *\n   * @deprecated Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.\n   */\n  acceptsMarketing: boolean;\n  /**\n   * Whether the customer has opted in to email marketing.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  acceptsEmailMarketing: boolean;\n  /**\n   * Whether the customer has opted in to SMS marketing.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  acceptsSmsMarketing: boolean;\n  /**\n   * The store credit accounts owned by this customer that can be used as payment during checkout. Each account has a balance representing available store credit.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @private\n   */\n  storeCreditAccounts: StoreCreditAccount[];\n  /**\n   * The number of orders the customer has previously placed with this shop.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  ordersCount: number;\n}"
-    }
-  },
-  "ImageDetails": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "ImageDetails",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "altText",
-          "value": "string",
-          "description": "The alternative text for the image, used for accessibility. The value is `undefined` if the merchant hasn't provided alt text.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "url",
-          "value": "string",
-          "description": "The fully-qualified URL of the image. Use this to render the product or variant image in your extension."
-        }
-      ],
-      "value": "export interface ImageDetails {\n  /**\n   * The fully-qualified URL of the image. Use this to render the product or variant image in your extension.\n   */\n  url: string;\n\n  /**\n   * The alternative text for the image, used for accessibility. The value is `undefined` if the merchant hasn't provided alt text.\n   */\n  altText?: string;\n}"
-    }
-  },
-  "StoreCreditAccount": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "StoreCreditAccount",
-      "description": "A store credit account owned by the customer. Store credit is a form of payment that merchants can issue to customers for returns, refunds, or promotional purposes.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "balance",
-          "value": "Money",
-          "description": "The remaining balance available in this store credit account. This reflects the amount that can still be applied toward purchases."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A globally-unique identifier for the store credit account in the format `gid://shopify/StoreCreditAccount/<id>`.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/StoreCreditAccount/1'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface StoreCreditAccount {\n  /**\n   * A globally-unique identifier for the store credit account in the format `gid://shopify/StoreCreditAccount/<id>`.\n   *\n   * @example 'gid://shopify/StoreCreditAccount/1'\n   */\n  id: string;\n  /**\n   * The remaining balance available in this store credit account. This reflects the amount that can still be applied toward purchases.\n   */\n  balance: Money;\n}"
-    }
-  },
-  "PurchasingCompany": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "PurchasingCompany",
-      "description": "The company and location that the [B2B](/docs/apps/build/b2b) customer is purchasing on behalf of. This is present only when the buyer is logged in as a business customer.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "company",
-          "value": "Company",
-          "description": "The company the B2B customer belongs to.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "location",
-          "value": "CompanyLocation",
-          "description": "The specific company location associated with this B2B purchase.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        }
-      ],
-      "value": "export interface PurchasingCompany {\n  /**\n   * The company the B2B customer belongs to.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  company: Company;\n  /**\n   * The specific company location associated with this B2B purchase.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  location: CompanyLocation;\n}"
-    }
-  },
-  "Company": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "Company",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "externalId",
-          "value": "string",
-          "description": "A merchant-defined external identifier for the company. The value is `undefined` if the merchant hasn't set one.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A globally-unique identifier for the company in the format `gid://shopify/Company/<id>`.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/Company/123'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "name",
-          "value": "string",
-          "description": "The company's display name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        }
-      ],
-      "value": "export interface Company {\n  /**\n   * A globally-unique identifier for the company in the format `gid://shopify/Company/<id>`.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'gid://shopify/Company/123'\n   */\n  id: string;\n  /**\n   * The company's display name.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  name: string;\n  /**\n   * A merchant-defined external identifier for the company. The value is `undefined` if the merchant hasn't set one.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  externalId?: string;\n}"
-    }
-  },
-  "CompanyLocation": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CompanyLocation",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "externalId",
-          "value": "string",
-          "description": "A merchant-defined external identifier for the company location. The value is `undefined` if the merchant hasn't set one.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A globally-unique identifier for the company location in the format `gid://shopify/CompanyLocation/<id>`.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/CompanyLocation/123'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "name",
-          "value": "string",
-          "description": "The display name of the company location.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        }
-      ],
-      "value": "export interface CompanyLocation {\n  /**\n   * A globally-unique identifier for the company location in the format `gid://shopify/CompanyLocation/<id>`.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'gid://shopify/CompanyLocation/123'\n   */\n  id: string;\n  /**\n   * The display name of the company location.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  name: string;\n  /**\n   * A merchant-defined external identifier for the company location. The value is `undefined` if the merchant hasn't set one.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  externalId?: string;\n}"
-    }
-  },
-  "BuyerJourney": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "BuyerJourney",
-      "description": "Provides details on the buyer's progression through the checkout.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "activeStep",
-          "value": "SubscribableSignalLike<BuyerJourneyStepReference | undefined>",
-          "description": "The step of checkout the buyer is currently on. The value is `undefined` if the current step can't be determined."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "completed",
-          "value": "SubscribableSignalLike<boolean>",
-          "description": "Whether the buyer has completed submitting their order. When `true`, the buyer is on the order status page after submitting payment. When `false`, the buyer is still in the checkout flow."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "MethodSignature",
-          "name": "intercept",
-          "value": "(interceptor: Interceptor) => Promise<() => void>",
-          "description": "Installs a function for intercepting and preventing progress on checkout.\n\nThis returns a promise that resolves to a teardown function. Calling the teardown function removes the interceptor.\n\nTo block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#block-progress) capability in your extension's configuration.\n\nIf you do, then you're expected to inform the buyer why navigation was blocked, either by passing validation errors to the checkout UI or rendering the errors in your extension.\n\nIf the merchant hasn't allowed your extension to block checkout progress, show a warning in the [checkout editor](/docs/apps/build/checkout/test-checkout-ui-extensions#test-the-extension-in-the-checkout-editor)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "steps",
-          "value": "SubscribableSignalLike<BuyerJourneyStep[]>",
-          "description": "All possible steps the buyer can take to complete checkout. These steps vary depending on whether the checkout is one-page or three-page, and on the shop's configuration."
-        }
-      ],
-      "value": "export interface BuyerJourney {\n  /**\n   * Installs a function for intercepting and preventing progress on checkout.\n   *\n   * This returns a promise that resolves to a teardown function. Calling the\n   * teardown function removes the interceptor.\n   *\n   * To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#block-progress)\n   * capability in your extension's configuration.\n   *\n   * If you do, then you're expected to inform the buyer why navigation was blocked,\n   * either by passing validation errors to the checkout UI or rendering the errors in your extension.\n   *\n   * If the merchant hasn't allowed your extension to block checkout progress, show a warning in the [checkout editor](/docs/apps/build/checkout/test-checkout-ui-extensions#test-the-extension-in-the-checkout-editor).\n   */\n  intercept(interceptor: Interceptor): Promise<() => void>;\n\n  /**\n   * Whether the buyer has completed submitting their order. When `true`, the buyer is on the order status page after submitting payment. When `false`, the buyer is still in the checkout flow.\n   */\n  completed: SubscribableSignalLike<boolean>;\n  /**\n   * All possible steps the buyer can take to complete checkout. These steps vary depending on whether the checkout is one-page or three-page, and on the shop's configuration.\n   */\n  steps: SubscribableSignalLike<BuyerJourneyStep[]>;\n  /**\n   * The step of checkout the buyer is currently on. The value is `undefined` if the current step can't be determined.\n   */\n  activeStep: SubscribableSignalLike<BuyerJourneyStepReference | undefined>;\n}"
-    }
-  },
-  "BuyerJourneyStepReference": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "BuyerJourneyStepReference",
-      "description": "What step of checkout the buyer is currently on.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "handle",
-          "value": "BuyerJourneyStepHandle",
-          "description": "The handle identifying which step the buyer is on, such as `'information'`, `'shipping'`, or `'payment'`. See `BuyerJourneyStepHandle` for all values."
-        }
-      ],
-      "value": "interface BuyerJourneyStepReference {\n  /**\n   * The handle identifying which step the buyer is on, such as `'information'`,\n   * `'shipping'`, or `'payment'`. See `BuyerJourneyStepHandle` for all values.\n   */\n  handle: BuyerJourneyStepHandle;\n}"
-    }
-  },
-  "BuyerJourneyStepHandle": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "BuyerJourneyStepHandle",
-      "value": "'cart' | 'checkout' | 'information' | 'shipping' | 'payment' | 'review' | 'thank-you' | 'unknown'",
-      "description": "| handle  | Description  |\n|---|---|\n| `cart`  |  The cart page.  |\n| `checkout`  |  A one-page checkout, including Shop Pay.  |\n| `information`  |  The contact information step of a three-page checkout.  |\n| `shipping`  |  The shipping step of a three-page checkout.  |\n| `payment`  |  The payment step of a three-page checkout.  |\n| `review`  |  The step after payment where the buyer confirms the purchase. Not all shops are configured to have a review step.  |\n| `thank-you`  |  The page displayed after the purchase, thanking the buyer.  |\n| `unknown` |  An unknown step in the buyer journey.  |"
-    }
-  },
-  "Interceptor": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "Interceptor",
-      "description": "A function for intercepting and preventing navigation on checkout. You can block navigation by returning an object with `{behavior: 'block', reason: 'your reason here', errors?: ValidationError[]}`. If you do, then you're expected to also update some part of your UI to reflect the reason why navigation was blocked, either by targeting checkout UI fields, passing errors to the page level, or rendering the errors in your extension.",
-      "params": [
-        {
-          "name": "interceptorProps",
-          "description": "",
-          "value": "InterceptorProps",
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts"
-        }
-      ],
-      "returns": {
-        "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-        "description": "",
-        "name": "InterceptorRequest | Promise<InterceptorRequest>",
-        "value": "InterceptorRequest | Promise<InterceptorRequest>"
-      },
-      "value": "(\n  interceptorProps: InterceptorProps,\n) => InterceptorRequest | Promise<InterceptorRequest>"
-    }
-  },
-  "InterceptorProps": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "InterceptorProps",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canBlockProgress",
-          "value": "boolean",
-          "description": "Whether the interceptor can block the buyer's progress through checkout. When `true`, the merchant has granted your extension the `block_progress` capability. When `false`, you can still validate but can't prevent the buyer from continuing."
-        }
-      ],
-      "value": "export interface InterceptorProps {\n  /**\n   * Whether the interceptor can block the buyer's progress through checkout. When `true`, the merchant has granted your extension the `block_progress` capability. When `false`, you can still validate but can't prevent the buyer from continuing.\n   */\n  canBlockProgress: boolean;\n}"
-    }
-  },
-  "InterceptorRequest": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "InterceptorRequest",
-      "value": "InterceptorRequestAllow | InterceptorRequestBlock",
-      "description": ""
-    }
-  },
-  "InterceptorRequestAllow": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "InterceptorRequestAllow",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "behavior",
-          "value": "'allow'",
-          "description": "Indicates that the interceptor allows the buyer's journey to continue."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "MethodSignature",
-          "name": "perform",
-          "value": "(result: InterceptorResult) => void | Promise<void>",
-          "description": "This callback is called when all interceptors finish. We recommend setting errors or reasons for blocking at this stage, so that all the errors in the UI show up at once.\n\nRuns after all intercept results are collected. Use it for local state updates such as setting an error flag. By the time it runs, the navigation decision is final, so blocking logic belongs in the intercept handler itself, not here.",
-          "isOptional": true
-        }
-      ],
-      "value": "interface InterceptorRequestAllow {\n  /**\n   * Indicates that the interceptor allows the buyer's journey to continue.\n   */\n  behavior: 'allow';\n\n  /**\n   * This callback is called when all interceptors finish. We recommend\n   * setting errors or reasons for blocking at this stage, so that all the errors in\n   * the UI show up at once.\n   *\n   * Runs after all intercept results are collected. Use it for local state\n   * updates such as setting an error flag. By the time it runs, the navigation\n   * decision is final, so blocking logic belongs in the intercept handler\n   * itself, not here.\n   * @param result InterceptorResult with behavior as either 'allow' or 'block'\n   */\n  perform?(result: InterceptorResult): void | Promise<void>;\n}"
-    }
-  },
-  "InterceptorResult": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "InterceptorResult",
-      "value": "InterceptorResultAllow | InterceptorResultBlock",
-      "description": ""
-    }
-  },
-  "InterceptorResultAllow": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "InterceptorResultAllow",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "behavior",
-          "value": "'allow'",
-          "description": "Indicates that the buyer was allowed to progress through checkout."
-        }
-      ],
-      "value": "interface InterceptorResultAllow {\n  /**\n   * Indicates that the buyer was allowed to progress through checkout.\n   */\n  behavior: 'allow';\n}"
-    }
-  },
-  "InterceptorResultBlock": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "InterceptorResultBlock",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "behavior",
-          "value": "'block'",
-          "description": "Indicates that some part of the checkout UI intercepted and prevented the buyer's progress. The buyer typically needs to take some action to resolve this issue and to move on to the next step."
-        }
-      ],
-      "value": "interface InterceptorResultBlock {\n  /**\n   * Indicates that some part of the checkout UI intercepted and prevented\n   * the buyer's progress. The buyer typically needs to take some action\n   * to resolve this issue and to move on to the next step.\n   */\n  behavior: 'block';\n}"
-    }
-  },
-  "InterceptorRequestBlock": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "InterceptorRequestBlock",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "behavior",
-          "value": "'block'",
-          "description": "Indicates that the interceptor blocks the buyer's journey from continuing."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "errors",
-          "value": "ValidationError[]",
-          "description": "Used to pass errors to the checkout UI, outside your extension's UI boundaries.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "MethodSignature",
-          "name": "perform",
-          "value": "(result: InterceptorResult) => void | Promise<void>",
-          "description": "This callback is called when all interceptors finish. We recommend setting errors or reasons for blocking at this stage, so that all the errors in the UI show up at once.\n\nRuns after all intercept results are collected. Use it for local state updates such as setting an error flag. By the time it runs, the navigation decision is final, so blocking logic belongs in the intercept handler itself, not here.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "reason",
-          "value": "string",
-          "description": "The reason for blocking the interceptor request. This value isn't presented to the buyer, so it doesn't need to be localized. The value is used only for Shopify's own internal debugging and metrics."
-        }
-      ],
-      "value": "interface InterceptorRequestBlock {\n  /**\n   * Indicates that the interceptor blocks the buyer's journey from continuing.\n   */\n  behavior: 'block';\n\n  /**\n   * The reason for blocking the interceptor request. This value isn't presented to\n   * the buyer, so it doesn't need to be localized. The value is used only for Shopify's\n   * own internal debugging and metrics.\n   */\n  reason: string;\n\n  /**\n   * Used to pass errors to the checkout UI, outside your extension's UI boundaries.\n   */\n  errors?: ValidationError[];\n\n  /**\n   * This callback is called when all interceptors finish. We recommend\n   * setting errors or reasons for blocking at this stage, so that all the errors in\n   * the UI show up at once.\n   *\n   * Runs after all intercept results are collected. Use it for local state\n   * updates such as setting an error flag. By the time it runs, the navigation\n   * decision is final, so blocking logic belongs in the intercept handler\n   * itself, not here.\n   * @param result InterceptorResult with behavior as either 'allow' or 'block'\n   */\n  perform?(result: InterceptorResult): void | Promise<void>;\n}"
-    }
-  },
-  "ValidationError": {
-    "src/surfaces/checkout/api/shared.ts": {
-      "filePath": "src/surfaces/checkout/api/shared.ts",
-      "name": "ValidationError",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "message",
-          "value": "string",
-          "description": "The error message to display to the buyer. Use this to explain what went wrong and how to fix it."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "string",
-          "description": "The checkout UI field that the error is associated with. When provided, checkout highlights the matching field so the buyer knows where to fix the issue. The value is `undefined` if the error isn't tied to a specific field.",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'$.cart.deliveryGroups[0].deliveryAddress.countryCode'\n\nSee the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)\nfor more information.",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface ValidationError {\n  /**\n   * The error message to display to the buyer. Use this to explain what\n   * went wrong and how to fix it.\n   */\n  message: string;\n  /**\n   * The checkout UI field that the error is associated with. When provided,\n   * checkout highlights the matching field so the buyer knows where to fix\n   * the issue. The value is `undefined` if the error isn't tied to a\n   * specific field.\n   *\n   * @example '$.cart.deliveryGroups[0].deliveryAddress.countryCode'\n   *\n   * See the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)\n   * for more information.\n   */\n  target?: string;\n}"
-    }
-  },
-  "BuyerJourneyStep": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "BuyerJourneyStep",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "disabled",
-          "value": "boolean",
-          "description": "Whether this step is disabled. When `true`, the buyer hasn't reached this step yet and can't navigate to it. When `false`, the step is accessible.\n\nFor example, if the buyer hasn't reached the `shipping` step yet, then `shipping` is disabled."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "handle",
-          "value": "BuyerJourneyStepHandle",
-          "description": "The handle that uniquely identifies the buyer journey step, such as `'information'`, `'shipping'`, or `'payment'`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "label",
-          "value": "string",
-          "description": "The localized label of the buyer journey step, suitable for rendering in navigation UI."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "to",
-          "value": "string",
-          "description": "The URL of the buyer journey step, using the `shopify:` protocol.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'shopify:cart'",
-                  "title": "Example"
-                }
-              ]
-            },
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'shopify:checkout/information'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface BuyerJourneyStep {\n  /**\n   * The handle that uniquely identifies the buyer journey step, such as `'information'`, `'shipping'`, or `'payment'`.\n   */\n  handle: BuyerJourneyStepHandle;\n  /**\n   * The localized label of the buyer journey step, suitable for rendering in navigation UI.\n   */\n  label: string;\n  /**\n   * The URL of the buyer journey step, using the `shopify:` protocol.\n   *\n   * @example 'shopify:cart'\n   * @example 'shopify:checkout/information'\n   */\n  to: string;\n  /**\n   * Whether this step is disabled. When `true`, the buyer hasn't reached this step yet and can't navigate to it. When `false`, the step is accessible.\n   *\n   * For example, if the buyer hasn't reached the `shipping` step yet, then `shipping` is disabled.\n   */\n  disabled: boolean;\n}"
-    }
-  },
-  "CheckoutSettings": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CheckoutSettings",
-      "description": "Settings describing the behavior of the buyer's checkout.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "orderSubmission",
-          "value": "'DRAFT_ORDER' | 'ORDER'",
-          "description": "The type of order created when the buyer completes checkout.\n\n- `'DRAFT_ORDER'`: The checkout creates a draft order that the merchant must manually confirm before fulfillment. Common for B2B checkouts with deferred payment terms.\n- `'ORDER'`: The checkout creates a confirmed order immediately upon completion."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "paymentTermsTemplate",
-          "value": "PaymentTermsTemplate",
-          "description": "The payment terms configured by the merchant for B2B orders, such as net-30 or net-60. The value is `undefined` if no payment terms are configured.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "shippingAddress",
-          "value": "ShippingAddressSettings",
-          "description": "Settings that control how the shipping address behaves during checkout, such as whether the buyer can edit the address."
-        }
-      ],
-      "value": "export interface CheckoutSettings {\n  /**\n   * The type of order created when the buyer completes checkout.\n   *\n   * - `'DRAFT_ORDER'`: The checkout creates a draft order that the merchant must manually confirm before fulfillment. Common for B2B checkouts with deferred payment terms.\n   * - `'ORDER'`: The checkout creates a confirmed order immediately upon completion.\n   */\n  orderSubmission: 'DRAFT_ORDER' | 'ORDER';\n  /**\n   * The payment terms configured by the merchant for B2B orders, such as net-30 or net-60. The value is `undefined` if no payment terms are configured.\n   */\n  paymentTermsTemplate?: PaymentTermsTemplate;\n  /**\n   * Settings that control how the shipping address behaves during checkout, such as whether the buyer can edit the address.\n   */\n  shippingAddress: ShippingAddressSettings;\n}"
-    }
-  },
-  "PaymentTermsTemplate": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "PaymentTermsTemplate",
-      "description": "A payment terms template configured by the merchant, defining when payment is due for B2B orders. Common examples include \"Net 30\" (due in 30 days) or \"Due on receipt\".",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "dueDate",
-          "value": "string",
-          "description": "The due date for payment in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DDTHH:mm:ss.sssZ`). The value is `undefined` if the payment terms don't have a fixed due date.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "dueInDays",
-          "value": "number",
-          "description": "The number of days the buyer has to pay after the order is placed, such as `30` for \"Net 30\" terms. The value is `undefined` if the payment terms aren't net-based.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A globally-unique identifier for the payment terms template in the format `gid://shopify/PaymentTermsTemplate/<id>`.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/PaymentTermsTemplate/1'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "name",
-          "value": "string",
-          "description": "The name of the payment terms translated to the buyer's current language, such as \"Net 30\" or \"Due on receipt\"."
-        }
-      ],
-      "value": "export interface PaymentTermsTemplate {\n  /**\n   * A globally-unique identifier for the payment terms template in the format `gid://shopify/PaymentTermsTemplate/<id>`.\n   *\n   * @example 'gid://shopify/PaymentTermsTemplate/1'\n   */\n  id: string;\n  /**\n   * The name of the payment terms translated to the buyer's current language, such as \"Net 30\" or \"Due on receipt\".\n   */\n  name: string;\n  /**\n   * The due date for payment in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DDTHH:mm:ss.sssZ`). The value is `undefined` if the payment terms don't have a fixed due date.\n   */\n  dueDate?: string;\n  /**\n   * The number of days the buyer has to pay after the order is placed, such as `30` for \"Net 30\" terms. The value is `undefined` if the payment terms aren't net-based.\n   */\n  dueInDays?: number;\n}"
-    }
-  },
-  "ShippingAddressSettings": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "ShippingAddressSettings",
-      "description": "Settings describing the behavior of the shipping address.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "isEditable",
-          "value": "boolean",
-          "description": "Whether the buyer is allowed to edit the shipping address during checkout. When `false`, the shipping address is locked and can't be changed, which is common for B2B orders with a predefined ship-to address."
-        }
-      ],
-      "value": "export interface ShippingAddressSettings {\n  /**\n   * Whether the buyer is allowed to edit the shipping address during checkout. When `false`, the shipping address is locked and can't be changed, which is common for B2B orders with a predefined ship-to address.\n   */\n  isEditable: boolean;\n}"
-    }
-  },
-  "CheckoutToken": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "CheckoutToken",
-      "value": "string",
-      "description": ""
-    }
-  },
-  "CartCost": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartCost",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "subtotalAmount",
-          "value": "SubscribableSignalLike<Money>",
-          "description": "The sum of all line item prices at the current step of checkout, before shipping and taxes are applied. Use this value to display the base cost of the items the buyer purchased."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "totalAmount",
-          "value": "SubscribableSignalLike<Money>",
-          "description": "The minimum total at the current step of checkout. Costs not yet calculated, such as shipping on the information step, aren't included. Gift cards and store credits are excluded from this total."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "totalShippingAmount",
-          "value": "SubscribableSignalLike<Money | undefined>",
-          "description": "The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been calculated yet, such as when the buyer is still on the information step.\n\n`undefined` until the buyer selects a shipping method (typically after the information step)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "totalTaxAmount",
-          "value": "SubscribableSignalLike<Money | undefined>",
-          "description": "The total tax the buyer can expect to pay, or the total tax already included in product and shipping prices (for tax-inclusive regions). The value is `undefined` if taxes haven't been calculated yet.\n\n`undefined` when taxes haven't been calculated or aren't available for the buyer's region."
-        }
-      ],
-      "value": "export interface CartCost {\n  /**\n   * The sum of all line item prices at the current step of checkout, before shipping and taxes are applied. Use this value to display the base cost of the items the buyer purchased.\n   */\n  subtotalAmount: SubscribableSignalLike<Money>;\n\n  /**\n   * The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been calculated yet, such as when the buyer is still on the information step.\n   *\n   * `undefined` until the buyer selects a shipping method (typically after the\n   * information step).\n   */\n  totalShippingAmount: SubscribableSignalLike<Money | undefined>;\n\n  /**\n   * The total tax the buyer can expect to pay, or the total tax already included in product and shipping prices (for tax-inclusive regions). The value is `undefined` if taxes haven't been calculated yet.\n   *\n   * `undefined` when taxes haven't been calculated or aren't available for the\n   * buyer's region.\n   */\n  totalTaxAmount: SubscribableSignalLike<Money | undefined>;\n\n  /**\n   * The minimum total at the current step of checkout. Costs not yet calculated, such as shipping on the information step, aren't included. Gift cards and store credits are excluded from this total.\n   */\n  totalAmount: SubscribableSignalLike<Money>;\n}"
-    }
-  },
-  "CustomerPrivacy": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CustomerPrivacy",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "allowedProcessing",
-          "value": "AllowedProcessing",
-          "description": "Flags indicating whether each type of data processing is permitted, based on the visitor's consent, the merchant's privacy configuration, and the visitor's geographic location."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "metafields",
-          "value": "TrackingConsentMetafield[]",
-          "description": "The tracking consent metafields that have been stored for this visitor. These contain app-specific consent data beyond the standard categories.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "`[{key: 'analyticsType', value: 'granular'}, {key: 'marketingType', value: 'granular'}]`, or `[]`",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "region",
-          "value": "CustomerPrivacyRegion",
-          "description": "The visitor's geographic location, used to determine whether more granular consent controls should be displayed based on regional privacy regulations.",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "`{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "saleOfDataRegion",
-          "value": "boolean",
-          "description": "Whether the visitor is located in a region that requires an explicit opt-out option for the sale or sharing of personal data, such as California (CCPA) or other jurisdictions with similar regulations."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "shouldShowBanner",
-          "value": "boolean",
-          "description": "Whether a consent banner should be displayed by default when the page loads. Use this as the initial open/expanded state of the consent banner.\n\nThis is determined by the visitor's current privacy consent, the shop's [region visibility configuration](https://help.shopify.com/en/manual/privacy-and-security/privacy/customer-privacy-settings/privacy-settings#add-a-cookie-banner) settings, and the region in which the visitor is located."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "visitorConsent",
-          "value": "VisitorConsent",
-          "description": "The visitor's current privacy consent settings. Each property represents a consent category and is `true` (actively granted), `false` (actively denied), or `undefined` (no decision made yet)."
-        }
-      ],
-      "value": "export interface CustomerPrivacy {\n  /**\n   * Flags indicating whether each type of data processing is permitted, based on the visitor's consent, the merchant's privacy configuration, and the visitor's geographic location.\n   */\n  allowedProcessing: AllowedProcessing;\n  /**\n   * The tracking consent metafields that have been stored for this visitor. These contain app-specific consent data beyond the standard categories.\n   *\n   * @example `[{key: 'analyticsType', value: 'granular'}, {key: 'marketingType', value: 'granular'}]`, or `[]`\n   */\n  metafields: TrackingConsentMetafield[];\n  /**\n   * The visitor's current privacy consent settings. Each property represents a consent category and is `true` (actively granted), `false` (actively denied), or `undefined` (no decision made yet).\n   */\n  visitorConsent: VisitorConsent;\n  /**\n   * Whether a consent banner should be displayed by default when the page loads. Use this as the initial open/expanded state of the consent banner.\n   *\n   * This is determined by the visitor's current privacy consent, the shop's [region visibility configuration](https://help.shopify.com/en/manual/privacy-and-security/privacy/customer-privacy-settings/privacy-settings#add-a-cookie-banner) settings, and the region in which the visitor is located.\n   */\n  shouldShowBanner: boolean;\n  /**\n   * Whether the visitor is located in a region that requires an explicit opt-out option for the sale or sharing of personal data, such as California (CCPA) or other jurisdictions with similar regulations.\n   */\n  saleOfDataRegion: boolean;\n  /**\n   * The visitor's geographic location, used to determine whether more granular consent controls should be displayed based on regional privacy regulations.\n   *\n   * @example `{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  region?: CustomerPrivacyRegion;\n}"
-    }
-  },
-  "AllowedProcessing": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "AllowedProcessing",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "analytics",
-          "value": "boolean",
-          "description": "Whether analytics data can be collected based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. Analytics data includes how the shop was used and what interactions occurred.\n\nWhether analytics data can be collected right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.analytics`, before calling `shopify.analytics.publish()`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "marketing",
-          "value": "boolean",
-          "description": "Whether marketing data can be collected based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. Marketing data includes attribution and targeted advertising preferences.\n\nWhether marketing data can be collected right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.marketing`, before performing marketing-related data collection."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "preferences",
-          "value": "boolean",
-          "description": "Whether preference data can be collected based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. Preference data includes language, currency, and sizing choices.\n\nWhether preference data can be collected right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.preferences`, before storing or reading buyer preference data."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "saleOfData",
-          "value": "boolean",
-          "description": "Whether data can be shared with third parties based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. This typically applies to behavioral advertising data.\n\nWhether buyer data can be shared with or sold to third parties right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.saleOfData`, before sharing or selling buyer data with third parties."
-        }
-      ],
-      "value": "export interface AllowedProcessing {\n  /**\n   * Whether analytics data can be collected based on the visitor's consent,\n   * the merchant's privacy configuration, and the visitor's region. Analytics\n   * data includes how the shop was used and what interactions occurred.\n   *\n   * Whether analytics data can be collected right now. Combines the buyer's\n   * consent, the merchant's privacy configuration, and the buyer's region into\n   * a single boolean. Check this flag, not `visitorConsent.analytics`, before\n   * calling `shopify.analytics.publish()`.\n   */\n  analytics: boolean;\n  /**\n   * Whether marketing data can be collected based on the visitor's consent,\n   * the merchant's privacy configuration, and the visitor's region. Marketing\n   * data includes attribution and targeted advertising preferences.\n   *\n   * Whether marketing data can be collected right now. Combines the buyer's\n   * consent, the merchant's privacy configuration, and the buyer's region into\n   * a single boolean. Check this flag, not `visitorConsent.marketing`, before\n   * performing marketing-related data collection.\n   */\n  marketing: boolean;\n  /**\n   * Whether preference data can be collected based on the visitor's consent,\n   * the merchant's privacy configuration, and the visitor's region. Preference\n   * data includes language, currency, and sizing choices.\n   *\n   * Whether preference data can be collected right now. Combines the buyer's\n   * consent, the merchant's privacy configuration, and the buyer's region into\n   * a single boolean. Check this flag, not `visitorConsent.preferences`,\n   * before storing or reading buyer preference data.\n   */\n  preferences: boolean;\n  /**\n   * Whether data can be shared with third parties based on the visitor's\n   * consent, the merchant's privacy configuration, and the visitor's region.\n   * This typically applies to behavioral advertising data.\n   *\n   * Whether buyer data can be shared with or sold to third parties right now.\n   * Combines the buyer's consent, the merchant's privacy configuration, and\n   * the buyer's region into a single boolean. Check this flag, not\n   * `visitorConsent.saleOfData`, before sharing or selling buyer data with\n   * third parties.\n   */\n  saleOfData: boolean;\n}"
-    }
-  },
-  "TrackingConsentMetafield": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "TrackingConsentMetafield",
-      "description": "",
+      "name": "Metafield",
+      "description": "Metadata associated with the checkout. See the [metafields documentation](/docs/apps/build/custom-data/metafields) for more information on how metafields work.",
       "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "key",
           "value": "string",
-          "description": "The identifier for the tracking consent metafield, such as `'analyticsType'` or `'marketingType'`."
+          "description": "The name of the metafield.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'delivery_instructions'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "A container for a set of metafields. You need to define a custom namespace for your metafields to distinguish them from the metafields used by other apps.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'my_app'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "value",
-          "value": "string",
-          "description": "The value stored in the tracking consent metafield, such as `'granular'` or a stringified JSON object."
+          "value": "string | number",
+          "description": "The information to be stored as metadata."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "valueType",
+          "value": "'integer' | 'string' | 'json_string'",
+          "description": "The metafield's information type.\n\n- `'integer'`: A whole number value.\n- `'string'`: A plain text value.\n- `'json_string'`: A JSON-encoded string value."
         }
       ],
-      "value": "export interface TrackingConsentMetafield {\n  /**\n   * The identifier for the tracking consent metafield, such as `'analyticsType'` or `'marketingType'`.\n   */\n  key: string;\n  /**\n   * The value stored in the tracking consent metafield, such as `'granular'` or a stringified JSON object.\n   */\n  value: string;\n}"
+      "value": "export interface Metafield {\n  /**\n   * The name of the metafield.\n   *\n   * @example 'delivery_instructions'\n   */\n  key: string;\n\n  /**\n   * A container for a set of metafields. You need to define a custom\n   * namespace for your metafields to distinguish them from the metafields\n   * used by other apps.\n   *\n   * @example 'my_app'\n   */\n  namespace: string;\n\n  /**\n   * The information to be stored as metadata.\n   */\n  value: string | number;\n\n  /**\n   * The metafield's information type.\n   *\n   * - `'integer'`: A whole number value.\n   * - `'string'`: A plain text value.\n   * - `'json_string'`: A JSON-encoded string value.\n   */\n  valueType: 'integer' | 'string' | 'json_string';\n}"
     }
   },
-  "CustomerPrivacyRegion": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CustomerPrivacyRegion",
+  "ShippingOptionItemApi": {
+    "src/surfaces/checkout/api/shipping/shipping-option-item.ts": {
+      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
+      "name": "ShippingOptionItemApi",
       "description": "",
+      "isPublicDocs": true,
       "members": [
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
           "syntaxKind": "PropertySignature",
-          "name": "countryCode",
-          "value": "CountryCode",
-          "description": "The buyer's country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if geolocation failed.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'CA' for Canada, 'US' for United States, 'GB' for Great Britain",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
+          "name": "isTargetSelected",
+          "value": "SubscribableSignalLike<boolean>",
+          "description": "Whether the buyer has selected the target shipping option. When `true`, the target option is the buyer's active choice. When `false`, the buyer has chosen a different shipping option.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
           "syntaxKind": "PropertySignature",
-          "name": "provinceCode",
-          "value": "string",
-          "description": "The buyer's province, state, or region code in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format. The value is `undefined` if geolocation failed or only the country was detected.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'ON' for Ontario, 'ENG' for England, 'CA' for California",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
+          "name": "renderMode",
+          "value": "ShippingOptionItemRenderMode",
+          "description": "The render mode of this shipping option, indicating how the extension is displayed in the checkout UI."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "SubscribableSignalLike<ShippingOption>",
+          "description": "The shipping option that this extension is attached to. Use this to read the option's cost, carrier, delivery estimate, and other details.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
         }
       ],
-      "value": "export interface CustomerPrivacyRegion {\n  /**\n   * The buyer's country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if geolocation failed.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'CA' for Canada, 'US' for United States, 'GB' for Great Britain\n   */\n  countryCode?: CountryCode;\n  /**\n   * The buyer's province, state, or region code in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format. The value is `undefined` if geolocation failed or only the country was detected.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'ON' for Ontario, 'ENG' for England, 'CA' for California\n   */\n  provinceCode?: string;\n}"
+      "value": "export interface ShippingOptionItemApi {\n  /**\n   * The shipping option that this extension is attached to. Use this to read the option's cost, carrier, delivery estimate, and other details.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  target: SubscribableSignalLike<ShippingOption>;\n\n  /**\n   * Whether the buyer has selected the target shipping option. When `true`, the target option is the buyer's active choice. When `false`, the buyer has chosen a different shipping option.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  isTargetSelected: SubscribableSignalLike<boolean>;\n\n  /**\n   * The render mode of this shipping option, indicating how the extension is displayed in the checkout UI.\n   */\n  renderMode: ShippingOptionItemRenderMode;\n}"
     }
   },
-  "DeliveryGroup": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "DeliveryGroup",
-      "description": "A group of cart lines that share the same set of delivery options. For example, physical items might form one delivery group while digital items form another.",
+  "ShippingOptionItemRenderMode": {
+    "src/surfaces/checkout/api/shipping/shipping-option-item.ts": {
+      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
+      "name": "ShippingOptionItemRenderMode",
+      "description": "The render mode of a shipping option.",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
           "syntaxKind": "PropertySignature",
-          "name": "deliveryOptions",
-          "value": "DeliveryOption[]",
-          "description": "The delivery options available for this group, including shipping, pickup point, and pickup location options. The buyer selects one of these to determine how their items are delivered."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "groupType",
-          "value": "DeliveryGroupType",
-          "description": "Whether this group contains items for a one-time purchase or a subscription. Subscription delivery groups might have different shipping options. See `DeliveryGroupType` for possible values."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A unique identifier for the delivery group. The value is `undefined` if the underlying delivery line doesn't have an ID assigned.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "isDeliveryRequired",
+          "name": "overlay",
           "value": "boolean",
-          "description": "Whether physical delivery is required for the items in this group. Digital-only groups don't require delivery."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "selectedDeliveryOption",
-          "value": "DeliveryOptionReference",
-          "description": "The delivery option the buyer has selected for this group. The value is `undefined` if the buyer hasn't selected a delivery option yet. Contains a `handle` you can match against `deliveryOptions` entries.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "targetedCartLines",
-          "value": "CartLineReference[]",
-          "description": "The cart lines that belong to this delivery group. Each reference contains the cart line's `id`, which you can match against `lines` to get the full cart line details."
+          "description": "Whether the shipping option is rendered in an overlay. When `true`, the extension appears in a modal or sheet on top of the checkout page. When `false`, the extension renders inline within the shipping options list."
         }
       ],
-      "value": "export interface DeliveryGroup {\n  /**\n   * A unique identifier for the delivery group. The value is `undefined` if the underlying delivery line doesn't have an ID assigned.\n   */\n  id?: string;\n  /**\n   * The cart lines that belong to this delivery group. Each reference contains the cart line's `id`, which you can match against `lines` to get the full cart line details.\n   */\n  targetedCartLines: CartLineReference[];\n\n  /**\n   * The delivery options available for this group, including shipping, pickup point, and pickup location options. The buyer selects one of these to determine how their items are delivered.\n   */\n  deliveryOptions: DeliveryOption[];\n\n  /**\n   * The delivery option the buyer has selected for this group. The value is `undefined` if the buyer hasn't selected a delivery option yet. Contains a `handle` you can match against `deliveryOptions` entries.\n   */\n  selectedDeliveryOption?: DeliveryOptionReference;\n\n  /**\n   * Whether this group contains items for a one-time purchase or a subscription.\n   * Subscription delivery groups might have different shipping options. See `DeliveryGroupType` for possible values.\n   */\n  groupType: DeliveryGroupType;\n\n  /**\n   * Whether physical delivery is required for the items in this group.\n   * Digital-only groups don't require delivery.\n   */\n  isDeliveryRequired: boolean;\n}"
-    }
-  },
-  "DeliveryOption": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "DeliveryOption",
-      "value": "ShippingOption | PickupPointOption | PickupLocationOption",
-      "description": "A delivery option available to the buyer. Use the `type` property to determine which kind of option it is:\n\n- `ShippingOption` (`type: 'shipping' | 'local'`): Items shipped by a carrier or delivered locally by the merchant.\n- `PickupPointOption` (`type: 'pickupPoint'`): Items shipped to a third-party collection point for the buyer to pick up.\n- `PickupLocationOption` (`type: 'pickup'`): Items picked up directly from a merchant's store or warehouse."
+      "value": "export interface ShippingOptionItemRenderMode {\n  /**\n   * Whether the shipping option is rendered in an overlay. When `true`, the extension appears in a modal or sheet on top of the checkout page. When `false`, the extension renders inline within the shipping options list.\n   */\n  overlay: boolean;\n}"
     }
   },
   "ShippingOption": {
@@ -2277,66 +1349,185 @@
       "value": "export interface NumberRange {\n  /**\n   * The lower bound of the range. Undefined if only an upper bound is\n   * provided.\n   */\n  lower?: number;\n\n  /**\n   * The upper bound of the range. Undefined if only a lower bound is\n   * provided.\n   */\n  upper?: number;\n}"
     }
   },
-  "Metafield": {
+  "ShippingOptionListApi": {
+    "src/surfaces/checkout/api/shipping/shipping-option-list.ts": {
+      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+      "name": "ShippingOptionListApi",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliverySelectionGroups",
+          "value": "SubscribableSignalLike<\n    DeliverySelectionGroup[] | undefined\n  >",
+          "description": "The list of delivery selection groups available to the buyer, which let buyers choose between grouped delivery options. The value is `undefined` when no selection groups are available."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "SubscribableSignalLike<DeliveryGroupList | undefined>",
+          "description": "The delivery group list that this extension is attached to. Use this to access all delivery groups and their options. The value is `undefined` when there aren't any delivery groups for the given type."
+        }
+      ],
+      "value": "export interface ShippingOptionListApi {\n  /**\n   * The delivery group list that this extension is attached to. Use this to access all delivery groups and their options. The value is `undefined` when there aren't any delivery groups for the given type.\n   */\n  target: SubscribableSignalLike<DeliveryGroupList | undefined>;\n  /**\n   * The list of delivery selection groups available to the buyer, which let buyers choose between grouped delivery options. The value is `undefined` when no selection groups are available.\n   */\n  deliverySelectionGroups: SubscribableSignalLike<\n    DeliverySelectionGroup[] | undefined\n  >;\n}"
+    }
+  },
+  "DeliverySelectionGroup": {
+    "src/surfaces/checkout/api/shipping/shipping-option-list.ts": {
+      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+      "name": "DeliverySelectionGroup",
+      "description": "A named group of delivery options that the buyer can select as a unit.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "associatedDeliveryOptions",
+          "value": "DeliveryOptionReference[]",
+          "description": "The delivery options that belong to this selection group. Each reference's `handle` matches a delivery option handle in the associated delivery group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "Money",
+          "description": "The combined cost of all delivery options in this group before discounts."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "costAfterDiscounts",
+          "value": "Money",
+          "description": "The combined cost of all delivery options in this group after discounts have been applied. This is what the buyer actually pays."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "A unique identifier for this selection group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selected",
+          "value": "boolean",
+          "description": "Whether the buyer has selected this delivery selection group. When `true`, the associated delivery options are active. When `false`, the buyer has selected a different group."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The localized display title of this selection group, suitable for rendering in the checkout UI."
+        }
+      ],
+      "value": "export interface DeliverySelectionGroup {\n  /**\n   * A unique identifier for this selection group.\n   */\n  handle: string;\n  /**\n   * Whether the buyer has selected this delivery selection group. When `true`, the associated delivery options are active. When `false`, the buyer has selected a different group.\n   */\n  selected: boolean;\n  /**\n   * The localized display title of this selection group, suitable for rendering in the checkout UI.\n   */\n  title: string;\n  /**\n   * The delivery options that belong to this selection group. Each reference's `handle` matches a delivery option handle in the associated delivery group.\n   */\n  associatedDeliveryOptions: DeliveryOptionReference[];\n  /**\n   * The combined cost of all delivery options in this group before discounts.\n   */\n  cost: Money;\n  /**\n   * The combined cost of all delivery options in this group after discounts have been applied. This is what the buyer actually pays.\n   */\n  costAfterDiscounts: Money;\n}"
+    }
+  },
+  "DeliveryOptionReference": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "Metafield",
-      "description": "Metadata associated with the checkout. See the [metafields documentation](/docs/apps/build/custom-data/metafields) for more information on how metafields work.",
+      "name": "DeliveryOptionReference",
+      "description": "A reference to the delivery option selected by the buyer for a delivery group.",
       "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "key",
+          "name": "handle",
           "value": "string",
-          "description": "The name of the metafield.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'delivery_instructions'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "namespace",
-          "value": "string",
-          "description": "A container for a set of metafields. You need to define a custom namespace for your metafields to distinguish them from the metafields used by other apps.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'my_app'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string | number",
-          "description": "The information to be stored as metadata."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "valueType",
-          "value": "'integer' | 'string' | 'json_string'",
-          "description": "The metafield's information type.\n\n- `'integer'`: A whole number value.\n- `'string'`: A plain text value.\n- `'json_string'`: A JSON-encoded string value."
+          "description": "The unique identifier of the referenced delivery option. Match this against `DeliveryOption.handle` from the `deliveryOptions` array to get the full option details."
         }
       ],
-      "value": "export interface Metafield {\n  /**\n   * The name of the metafield.\n   *\n   * @example 'delivery_instructions'\n   */\n  key: string;\n\n  /**\n   * A container for a set of metafields. You need to define a custom\n   * namespace for your metafields to distinguish them from the metafields\n   * used by other apps.\n   *\n   * @example 'my_app'\n   */\n  namespace: string;\n\n  /**\n   * The information to be stored as metadata.\n   */\n  value: string | number;\n\n  /**\n   * The metafield's information type.\n   *\n   * - `'integer'`: A whole number value.\n   * - `'string'`: A plain text value.\n   * - `'json_string'`: A JSON-encoded string value.\n   */\n  valueType: 'integer' | 'string' | 'json_string';\n}"
+      "value": "export interface DeliveryOptionReference {\n  /**\n   * The unique identifier of the referenced delivery option. Match this against `DeliveryOption.handle` from the `deliveryOptions` array to get the full option details.\n   */\n  handle: string;\n}"
+    }
+  },
+  "DeliveryGroupList": {
+    "src/surfaces/checkout/api/shipping/shipping-option-list.ts": {
+      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+      "name": "DeliveryGroupList",
+      "description": "A collection of delivery groups that share the same group type.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryGroups",
+          "value": "DeliveryGroup[]",
+          "description": "The delivery groups in this list. Each group contains cart lines and available delivery options for those items."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "groupType",
+          "value": "DeliveryGroupType",
+          "description": "The type of delivery groups in this list. This is the same `DeliveryGroupType` used on `DeliveryGroup.groupType`.\n\n- `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.\n- `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries."
+        }
+      ],
+      "value": "export interface DeliveryGroupList {\n  /**\n   * The type of delivery groups in this list. This is the same `DeliveryGroupType` used on `DeliveryGroup.groupType`.\n   *\n   * - `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.\n   * - `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.\n   */\n  groupType: DeliveryGroupType;\n  /**\n   * The delivery groups in this list. Each group contains cart lines and available delivery options for those items.\n   */\n  deliveryGroups: DeliveryGroup[];\n}"
+    }
+  },
+  "DeliveryGroup": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryGroup",
+      "description": "A group of cart lines that share the same set of delivery options. For example, physical items might form one delivery group while digital items form another.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryOptions",
+          "value": "DeliveryOption[]",
+          "description": "The delivery options available for this group, including shipping, pickup point, and pickup location options. The buyer selects one of these to determine how their items are delivered."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "groupType",
+          "value": "DeliveryGroupType",
+          "description": "Whether this group contains items for a one-time purchase or a subscription. Subscription delivery groups might have different shipping options. See `DeliveryGroupType` for possible values."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A unique identifier for the delivery group. The value is `undefined` if the underlying delivery line doesn't have an ID assigned.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isDeliveryRequired",
+          "value": "boolean",
+          "description": "Whether physical delivery is required for the items in this group. Digital-only groups don't require delivery."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedDeliveryOption",
+          "value": "DeliveryOptionReference",
+          "description": "The delivery option the buyer has selected for this group. The value is `undefined` if the buyer hasn't selected a delivery option yet. Contains a `handle` you can match against `deliveryOptions` entries.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "targetedCartLines",
+          "value": "CartLineReference[]",
+          "description": "The cart lines that belong to this delivery group. Each reference contains the cart line's `id`, which you can match against `lines` to get the full cart line details."
+        }
+      ],
+      "value": "export interface DeliveryGroup {\n  /**\n   * A unique identifier for the delivery group. The value is `undefined` if the underlying delivery line doesn't have an ID assigned.\n   */\n  id?: string;\n  /**\n   * The cart lines that belong to this delivery group. Each reference contains the cart line's `id`, which you can match against `lines` to get the full cart line details.\n   */\n  targetedCartLines: CartLineReference[];\n\n  /**\n   * The delivery options available for this group, including shipping, pickup point, and pickup location options. The buyer selects one of these to determine how their items are delivered.\n   */\n  deliveryOptions: DeliveryOption[];\n\n  /**\n   * The delivery option the buyer has selected for this group. The value is `undefined` if the buyer hasn't selected a delivery option yet. Contains a `handle` you can match against `deliveryOptions` entries.\n   */\n  selectedDeliveryOption?: DeliveryOptionReference;\n\n  /**\n   * Whether this group contains items for a one-time purchase or a subscription.\n   * Subscription delivery groups might have different shipping options. See `DeliveryGroupType` for possible values.\n   */\n  groupType: DeliveryGroupType;\n\n  /**\n   * Whether physical delivery is required for the items in this group.\n   * Digital-only groups don't require delivery.\n   */\n  isDeliveryRequired: boolean;\n}"
+    }
+  },
+  "DeliveryOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "DeliveryOption",
+      "value": "ShippingOption | PickupPointOption | PickupLocationOption",
+      "description": "A delivery option available to the buyer. Use the `type` property to determine which kind of option it is:\n\n- `ShippingOption` (`type: 'shipping' | 'local'`): Items shipped by a carrier or delivered locally by the merchant.\n- `PickupPointOption` (`type: 'pickupPoint'`): Items shipped to a third-party collection point for the buyer to pick up.\n- `PickupLocationOption` (`type: 'pickup'`): Items picked up directly from a merchant's store or warehouse."
     }
   },
   "PickupPointOption": {
@@ -2479,92 +1670,6 @@
       "value": "interface PickupPointLocation {\n  /**\n   * The display name of the pickup point, such as the name of the locker\n   * or collection point.\n   */\n  name?: string;\n\n  /**\n   * The unique identifier of the pickup point.\n   */\n  handle: string;\n\n  /**\n   * The physical address of the pickup point.\n   */\n  address: MailingAddress;\n}"
     }
   },
-  "PickupLocationOption": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "PickupLocationOption",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "code",
-          "value": "string",
-          "description": "The carrier service code or rate identifier for this delivery option."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "description",
-          "value": "string",
-          "description": "Additional details about the delivery option provided by the carrier or merchant, such as estimated delivery windows or service level notes.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "handle",
-          "value": "string",
-          "description": "The unique identifier of the delivery option. Use this to match against `DeliveryOptionReference.handle` or `DeliverySelectionGroup` entries."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "location",
-          "value": "PickupLocation",
-          "description": "The merchant's store or warehouse where the buyer picks up their order, including the address and display name."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "metafields",
-          "value": "Metafield[]",
-          "description": "Custom [metafields](/docs/apps/build/custom-data/metafields) attached to this delivery option by the carrier or a [Shopify Function](/docs/apps/build/functions). Use these to display additional information about the option."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "title",
-          "value": "string",
-          "description": "The merchant-facing or carrier-provided display name for the delivery option, such as \"Standard Shipping\" or \"Express\".",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'pickup'",
-          "description": "Identifies this as a pickup location option, where the buyer picks up items directly from a merchant's store or warehouse."
-        }
-      ],
-      "value": "export interface PickupLocationOption extends DeliveryOptionBase {\n  /**\n   * Identifies this as a pickup location option, where the buyer picks up items directly from a merchant's store or warehouse.\n   */\n  type: 'pickup';\n\n  /**\n   * The merchant's store or warehouse where the buyer picks up their order, including the address and display name.\n   */\n  location: PickupLocation;\n}"
-    }
-  },
-  "PickupLocation": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "PickupLocation",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "address",
-          "value": "MailingAddress",
-          "description": "The physical address of the pickup location."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "name",
-          "value": "string",
-          "description": "The merchant-defined display name of the pickup location, such as a store name or warehouse label.",
-          "isOptional": true
-        }
-      ],
-      "value": "interface PickupLocation {\n  /**\n   * The merchant-defined display name of the pickup location, such as a\n   * store name or warehouse label.\n   */\n  name?: string;\n\n  /**\n   * The physical address of the pickup location.\n   */\n  address: MailingAddress;\n}"
-    }
-  },
   "DeliveryGroupType": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
@@ -2572,23 +1677,6 @@
       "name": "DeliveryGroupType",
       "value": "'oneTimePurchase' | 'subscription'",
       "description": "The possible types of a delivery group.\n\n- `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.\n- `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries."
-    }
-  },
-  "DeliveryOptionReference": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "DeliveryOptionReference",
-      "description": "A reference to the delivery option selected by the buyer for a delivery group.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "handle",
-          "value": "string",
-          "description": "The unique identifier of the referenced delivery option. Match this against `DeliveryOption.handle` from the `deliveryOptions` array to get the full option details."
-        }
-      ],
-      "value": "export interface DeliveryOptionReference {\n  /**\n   * The unique identifier of the referenced delivery option. Match this against `DeliveryOption.handle` from the `deliveryOptions` array to get the full option details.\n   */\n  handle: string;\n}"
     }
   },
   "CartLineReference": {
@@ -2608,133 +1696,691 @@
       "value": "export interface CartLineReference {\n  /**\n   * The unique identifier of the referenced cart line. Match this against `CartLine.id` from the `lines` property to get the full line item details.\n   */\n  id: string;\n}"
     }
   },
-  "CartDiscountAllocation": {
+  "AddressAutocompleteFormatSuggestionApi": {
+    "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
+      "name": "AddressAutocompleteFormatSuggestionApi",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "Target",
+          "description": "The autocomplete suggestion that the buyer selected during checkout.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface AddressAutocompleteFormatSuggestionApi {\n  /**\n   * The autocomplete suggestion that the buyer selected during checkout.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  target: Target;\n}"
+    }
+  },
+  "Target": {
+    "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
+      "name": "Target",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedSuggestion",
+          "value": "AddressAutocompleteSuggestion",
+          "description": ""
+        }
+      ],
+      "value": "interface Target {\n  selectedSuggestion: AddressAutocompleteSuggestion;\n}"
+    }
+  },
+  "AddressAutocompleteSuggestion": {
+    "src/surfaces/checkout/api/address-autocomplete/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+      "name": "AddressAutocompleteSuggestion",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "formattedAddress",
+          "value": "AutocompleteAddress",
+          "description": "The address object used to auto-populate the remaining address fields.\n\nIf this value is returned for every suggestion, then the `purchase.address-autocomplete.format-suggestion` extension target is not needed.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A textual identifier that uniquely identifies an autocomplete suggestion or address. This identifier may be used to search for a formatted address.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "\"35ef8d55-dceb-4ed8-847b-2f2fc7472f14\"",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "label",
+          "value": "string",
+          "description": "The address suggestion text presented to the buyer in the list of autocomplete suggestions.\n\nThis text is shown to the buyer as-is. No attempts will be made to parse it.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "\"123 Main St, Toronto, ON, CA\"",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "matchedSubstrings",
+          "value": "MatchedSubstring[]",
+          "description": "A list of substrings that matched the original search query.\n\nIf `matchedSubstrings` are provided, then they will be used to highlight the substrings of the suggestions that matched the original search query.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "[{offset: 0, length: 4}]",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface AddressAutocompleteSuggestion {\n  /**\n   * The address suggestion text presented to the buyer in the list of autocomplete suggestions.\n   *\n   * This text is shown to the buyer as-is. No attempts will be made to parse it.\n   *\n   * @example \"123 Main St, Toronto, ON, CA\"\n   */\n  label: string;\n\n  /**\n   * A textual identifier that uniquely identifies an autocomplete suggestion\n   * or address. This identifier may be used to search for a formatted address.\n   *\n   * @example \"35ef8d55-dceb-4ed8-847b-2f2fc7472f14\"\n   */\n  id?: string;\n\n  /**\n   * A list of substrings that matched the original search query.\n   *\n   * If `matchedSubstrings` are provided, then they will be used to highlight the substrings\n   * of the suggestions that matched the original search query.\n   *\n   * @example [{offset: 0, length: 4}]\n   */\n  matchedSubstrings?: MatchedSubstring[];\n\n  /**\n   * The address object used to auto-populate the remaining address fields.\n   *\n   * If this value is returned for every suggestion, then the\n   * `purchase.address-autocomplete.format-suggestion` extension target is not needed.\n   */\n  formattedAddress?: AutocompleteAddress;\n}"
+    }
+  },
+  "AutocompleteAddress": {
+    "src/surfaces/checkout/api/address-autocomplete/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+      "name": "AutocompleteAddress",
+      "description": "An address object used to auto-populate the address form fields.\n\nAll fields are optional",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address1",
+          "value": "string",
+          "description": "The first line of the street address, including the street number and name. The value is `undefined` if the buyer hasn't entered an address yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'151 O'Connor Street'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address2",
+          "value": "string",
+          "description": "The second line of the buyer's address, such as apartment number, suite, or unit. The value is `undefined` if the buyer didn't provide a second address line.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ground floor'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "city",
+          "value": "string",
+          "description": "The city, town, or village of the address. The value is `undefined` if the buyer hasn't entered a city yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ottawa'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "company",
+          "value": "string",
+          "description": "The buyer's company name. The value is `undefined` if the buyer didn't enter a company or the store doesn't collect company names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Shopify'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "countryCode",
+          "value": "CountryCode",
+          "description": "The two-letter country code in [ISO 3166 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if the buyer hasn't selected a country yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CA' for Canada.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "latitude",
+          "value": "number",
+          "description": "The latitude coordinates of the buyer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "43.6556377",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "longitude",
+          "value": "number",
+          "description": "The longitude coordinates of the buyer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "-79.38681079999999",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "provinceCode",
+          "value": "string",
+          "description": "The province, state, prefecture, or region code of the address. The format varies by country. The value is `undefined` if the buyer hasn't selected one yet or the country doesn't have provinces.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'ON' for Ontario.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "zip",
+          "value": "string",
+          "description": "The postal code or ZIP code of the address, used for mail sorting and delivery routing. The value is `undefined` if the buyer hasn't entered one yet or the country doesn't use postal codes.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'K2P 2L8'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface AutocompleteAddress\n  extends Pick<\n    MailingAddress,\n    | 'address1'\n    | 'address2'\n    | 'city'\n    | 'company'\n    | 'countryCode'\n    | 'provinceCode'\n    | 'zip'\n  > {\n  /**\n   * The latitude coordinates of the buyer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 43.6556377\n   */\n  latitude?: number;\n\n  /**\n   * The longitude coordinates of the buyer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example -79.38681079999999\n   */\n  longitude?: number;\n}"
+    }
+  },
+  "MatchedSubstring": {
+    "src/surfaces/checkout/api/address-autocomplete/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+      "name": "MatchedSubstring",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "length",
+          "value": "number",
+          "description": "The length of the matched substring in the suggestion label text."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "offset",
+          "value": "number",
+          "description": "The start location of the matched substring in the suggestion label text."
+        }
+      ],
+      "value": "export interface MatchedSubstring {\n  /**\n   * The start location of the matched substring in the suggestion label text.\n   */\n  offset: number;\n  /**\n   * The length of the matched substring in the suggestion label text.\n   */\n  length: number;\n}"
+    }
+  },
+  "AddressAutocompleteSuggestApi": {
+    "src/surfaces/checkout/api/address-autocomplete/suggest.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/suggest.ts",
+      "name": "AddressAutocompleteSuggestApi",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/suggest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "signal",
+          "value": "AbortSignal",
+          "description": "The signal that the extension should listen to for cancellation requests.\n\nIf the signal is aborted, the extension should cancel any ongoing requests. The signal will be aborted either when the buyer navigates away from the address field or when the debounced query value changes.\n\nPass this signal to any asynchronous operations that need to be cancelled, like `fetch`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/suggest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "Target",
+          "description": "The current state of the address form that the buyer is interacting with.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface AddressAutocompleteSuggestApi {\n  /**\n   * The signal that the extension should listen to for cancellation requests.\n   *\n   * If the signal is aborted, the extension should cancel any ongoing requests.\n   * The signal will be aborted either when the buyer navigates away from the\n   * address field or when the debounced query value changes.\n   *\n   * Pass this signal to any asynchronous operations that need to be cancelled,\n   * like `fetch`.\n   */\n  signal: AbortSignal;\n\n  /**\n   * The current state of the address form that the buyer is interacting with.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  target: Target;\n}"
+    }
+  },
+  "AddressAutocompleteStandardApi": {
+    "src/surfaces/checkout/api/address-autocomplete/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+      "name": "AddressAutocompleteStandardApi",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "analytics",
+          "value": "Analytics",
+          "description": "The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "appMetafields",
+          "value": "AppMetafieldEntry[]",
+          "description": "The metafields requested in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file. These metafields are updated when there's a change in the merchandise items being purchased by the customer.\n\nApp owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` is not supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n\n> Tip: > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.*"
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "Attribute[] | undefined",
+          "description": "The custom attributes left by the customer to the merchant, either in their cart or during checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billingAddress",
+          "value": "MailingAddress | undefined",
+          "description": "The proposed customer billing address. The address updates when the field is committed (on change) rather than every keystroke.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "checkoutToken",
+          "value": "CheckoutToken | undefined",
+          "description": "A stable ID that represents the current checkout.\n\nThis matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data) and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extension",
+          "value": "Extension<Target>",
+          "description": "The meta information about the extension."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "i18n",
+          "value": "I18n",
+          "description": "Utilities for translating content and formatting values according to the current [`localization`](/docs/api/checkout-ui-extensions/apis/localization) Type 'RunnableExtensionInstance<keyof RunnableExtensionTargets>' is not assignable to type 'ExtensionInstance<Target>'.\n\nRefer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples) for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "localization",
+          "value": "Localization",
+          "description": "The details about the location, language, and currency of the customer. For utilities to easily format and translate content based on these details, you can use the [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#properties-propertydetail-i18n) object instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "Metafield[]",
+          "description": "The metafields that apply to the current checkout.\n\nMetafields are stored locally on the client and are applied to the order object after the checkout completes. They are shared by all extensions running on checkout, and persist for as long as the customer is working on this checkout.\n\nOnce the order is created, you can query these metafields using the [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n\n> Caution: `metafields` is deprecated. Use `appMetafields` with cart metafields instead.",
+          "deprecationMessage": "Use `appMetafields` with cart metafields instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "<Data = unknown, Variables = Record<string, unknown>>(query: string, options?: { variables?: Variables; version?: StorefrontApiVersion; }) => Promise<{ data?: Data; errors?: GraphQLError[]; }>",
+          "description": "The method used to query the Storefront GraphQL API with a prefetched token.\n\nRefer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionToken",
+          "value": "SessionToken",
+          "description": "The session token providing a set of claims as a signed JSON Web Token (JWT).\n\nThe token has a TTL of 5 minutes.\n\nIf the previous token expires, this value will reflect a new session token with a new signature and expiry.\n\nLearn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "settings",
+          "value": "ExtensionSettings",
+          "description": "The settings matching the settings definition written in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.\n\n Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.\n\n> Note: The settings are empty when an extension is being installed in the [checkout editor](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-editor)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shippingAddress",
+          "value": "MailingAddress | undefined",
+          "description": "The proposed customer shipping address. During the information step, the address updates when the field is committed (on change) rather than every keystroke.\n\n> Note: An address value is only present if delivery is required. Otherwise, the subscribable value is undefined.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "Shop",
+          "description": "The shop where the checkout is taking place."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storage",
+          "value": "Storage",
+          "description": "The key-value storage for the extension.\n\nIt uses `localStorage` and should persist across the customer's current checkout session.\n\n> Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.\n\nData is shared across all activated extension targets of this extension. In versions 2023-07 and earlier, each activated extension target had its own storage."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "version",
+          "value": "Version",
+          "description": "The runner version being used for the extension.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'unstable'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface AddressAutocompleteStandardApi<\n  Target extends\n    | 'purchase.address-autocomplete.suggest'\n    | 'purchase.address-autocomplete.format-suggestion',\n> {\n  /**\n   * The metafields requested in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration)\n   * file. These metafields are updated when there's a change in the merchandise items\n   * being purchased by the customer.\n   *\n   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` is not supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * > Tip:\n   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.*\n   */\n  appMetafields: AppMetafieldEntry[];\n\n  /**\n   * The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event.\n   */\n  analytics: Analytics;\n\n  /**\n   * The custom attributes left by the customer to the merchant, either in their cart or during checkout.\n   */\n  attributes: Attribute[] | undefined;\n\n  /**\n   * The proposed customer billing address. The address updates when the field is\n   * committed (on change) rather than every keystroke.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  billingAddress?: MailingAddress | undefined;\n\n  /**\n   * A stable ID that represents the current checkout.\n   *\n   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)\n   * and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).\n   */\n  checkoutToken: CheckoutToken | undefined;\n\n  /**\n   * The meta information about the extension.\n   */\n  extension: Extension<Target>;\n\n  /**\n   * Utilities for translating content and formatting values according to the current\n   * [`localization`](/docs/api/checkout-ui-extensions/apis/localization)\n   * Type 'RunnableExtensionInstance<keyof RunnableExtensionTargets>' is not assignable to type 'ExtensionInstance<Target>'.\n   *\n   * Refer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples)\n   * for more information.\n   */\n  i18n: I18n;\n\n  /**\n   * The details about the location, language, and currency of the customer. For utilities to easily\n   * format and translate content based on these details, you can use the\n   * [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#properties-propertydetail-i18n)\n   * object instead.\n   */\n  localization: Localization;\n\n  /**\n   * The metafields that apply to the current checkout.\n   *\n   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.\n   * They are shared by all extensions running on checkout, and\n   * persist for as long as the customer is working on this checkout.\n   *\n   * Once the order is created, you can query these metafields using the\n   * [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n   *\n   * > Caution:\n   * `metafields` is deprecated. Use `appMetafields` with cart metafields instead.\n   *\n   * @deprecated Use `appMetafields` with cart metafields instead.\n   */\n  metafields: Metafield[];\n\n  /**\n   * The method used to query the Storefront GraphQL API with a prefetched token.\n   *\n   * Refer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.\n   */\n  query: <Data = unknown, Variables = Record<string, unknown>>(\n    query: string,\n    options?: {variables?: Variables; version?: StorefrontApiVersion},\n  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;\n\n  /**\n   * The session token providing a set of claims as a signed JSON Web Token (JWT).\n   *\n   * The token has a TTL of 5 minutes.\n   *\n   * If the previous token expires, this value will reflect a new session token with a new signature and expiry.\n   *\n   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).\n   */\n  sessionToken: SessionToken;\n\n  /**\n   * The settings matching the settings definition written in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.\n   *\n   *  Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.\n   *\n   * > Note: The settings are empty when an extension is being installed in the [checkout editor](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-editor).\n\n   */\n  settings: ExtensionSettings;\n\n  /**\n   * The proposed customer shipping address. During the information step,\n   * the address updates when the field is committed (on change) rather than every keystroke.\n   *\n   * > Note: An address value is only present if delivery is required. Otherwise, the subscribable value is undefined.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  shippingAddress?: MailingAddress | undefined;\n\n  /** The shop where the checkout is taking place. */\n  shop: Shop;\n\n  /**\n   * The key-value storage for the extension.\n   *\n   * It uses `localStorage` and should persist across the customer's current checkout session.\n   *\n   * > Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.\n   *\n   * Data is shared across all activated extension targets of this extension. In versions 2023-07 and earlier,\n   * each activated extension target had its own storage.\n   */\n  storage: Storage;\n\n  /**\n   * The runner version being used for the extension.\n   *\n   * @example 'unstable'\n   */\n  version: Version;\n}"
+    }
+  },
+  "Analytics": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Analytics",
+      "description": "Tracks custom events and sends visitor information to [Web Pixels](/docs/apps/marketing). Use `publish()` to emit events and `visitor()` to submit buyer contact details.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "publish",
+          "value": "(name: string, data: Record<string, unknown>) => Promise<boolean>",
+          "description": "Publishes a custom event to [Web Pixels](/docs/apps/marketing). Returns `true` when the event is successfully dispatched.\n\nThe Promise resolves to `true` when the event was dispatched. The boolean indicates dispatch confirmation only. It doesn't indicate whether any specific web pixel processed the event."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "visitor",
+          "value": "(data: { email?: string; phone?: string; }) => Promise<VisitorResult>",
+          "description": "Submits buyer contact details for attribution and analytics purposes."
+        }
+      ],
+      "value": "export interface Analytics {\n  /**\n   * Publishes a custom event to [Web Pixels](/docs/apps/marketing).\n   * Returns `true` when the event is successfully dispatched.\n   *\n   * The Promise resolves to `true` when the event was dispatched. The boolean\n   * indicates dispatch confirmation only. It doesn't indicate whether any\n   * specific web pixel processed the event.\n   */\n  publish(name: string, data: Record<string, unknown>): Promise<boolean>;\n\n  /**\n   * Submits buyer contact details for attribution and analytics purposes.\n   */\n  visitor(data: {email?: string; phone?: string}): Promise<VisitorResult>;\n}"
+    }
+  },
+  "VisitorResult": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
       "syntaxKind": "TypeAliasDeclaration",
-      "name": "CartDiscountAllocation",
-      "value": "CartCodeDiscountAllocation | CartAutomaticDiscountAllocation | CartCustomDiscountAllocation",
-      "description": "A discount allocation applied to the cart. Use the `type` property to determine how the discount was triggered:\n\n- `CartCodeDiscountAllocation` (`type: 'code'`): Triggered by a discount code the buyer entered.\n- `CartAutomaticDiscountAllocation` (`type: 'automatic'`): Applied automatically based on merchant-configured rules.\n- `CartCustomDiscountAllocation` (`type: 'custom'`): Applied by a [Shopify Function](/docs/api/functions/latest/discount)."
+      "name": "VisitorResult",
+      "value": "VisitorSuccess | VisitorError",
+      "description": "Represents a visitor result."
     }
   },
-  "CartCodeDiscountAllocation": {
+  "VisitorSuccess": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartCodeDiscountAllocation",
-      "description": "",
+      "name": "VisitorSuccess",
+      "description": "Represents a successful visitor result.",
       "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "code",
-          "value": "string",
-          "description": "The discount code string that the buyer entered during checkout, such as `\"SAVE10\"` or `\"FREESHIP\"`."
-        },
+          "name": "type",
+          "value": "'success'",
+          "description": "Indicates that the visitor information was validated and submitted."
+        }
+      ],
+      "value": "export interface VisitorSuccess {\n  /**\n   * Indicates that the visitor information was validated and submitted.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "VisitorError": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "VisitorError",
+      "description": "Represents an unsuccessful visitor result.",
+      "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "discountedAmount",
-          "value": "Money",
-          "description": "The monetary value that was deducted from the line item or order total by this discount allocation."
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It isn't localized and shouldn't be displayed to the buyer."
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "type",
-          "value": "'code'",
-          "description": "Identifies this as a code-based discount, triggered by a discount code the buyer entered at checkout."
+          "value": "'error'",
+          "description": "Indicates that the visitor information is invalid and wasn't submitted. Common causes include using the wrong data type or omitting a required property."
         }
       ],
-      "value": "export interface CartCodeDiscountAllocation extends CartDiscountAllocationBase {\n  /**\n   * The discount code string that the buyer entered during checkout, such as `\"SAVE10\"` or `\"FREESHIP\"`.\n   */\n  code: string;\n\n  /**\n   * Identifies this as a code-based discount, triggered by a discount code the buyer entered at checkout.\n   */\n  type: 'code';\n}"
+      "value": "export interface VisitorError {\n  /**\n   * Indicates that the visitor information is invalid and wasn't submitted.\n   * Common causes include using the wrong data type or omitting a required property.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It isn't localized and shouldn't be displayed to the buyer.\n   */\n  message: string;\n}"
     }
   },
-  "CartAutomaticDiscountAllocation": {
+  "AppMetafieldEntry": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartAutomaticDiscountAllocation",
-      "description": "",
+      "name": "AppMetafieldEntry",
+      "description": "An entry that pairs a Shopify resource with one of its [metafields](/docs/apps/build/custom-data/metafields). Each entry contains a `target` identifying which resource the metafield belongs to and a `metafield` object with the actual data.",
       "members": [
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "discountedAmount",
-          "value": "Money",
-          "description": "The monetary value that was deducted from the line item or order total by this discount allocation."
+          "name": "metafield",
+          "value": "AppMetafield",
+          "description": "The metafield data, including the namespace, key, value, and content type. Use the `namespace` and `key` together to uniquely identify the metafield within its resource."
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "title",
+          "name": "target",
+          "value": "AppMetafieldEntryTarget",
+          "description": "The Shopify resource that this metafield is attached to, including the resource type (such as `'product'` or `'customer'`) and its globally-unique ID.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`."
+        }
+      ],
+      "value": "export interface AppMetafieldEntry {\n  /**\n   * The Shopify resource that this metafield is attached to, including the resource type (such as `'product'` or `'customer'`) and its globally-unique ID.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.\n   */\n  target: AppMetafieldEntryTarget;\n\n  /**\n   * The metafield data, including the namespace, key, value, and content type. Use the `namespace` and `key` together to uniquely identify the metafield within its resource.\n   */\n  metafield: AppMetafield;\n}"
+    }
+  },
+  "AppMetafield": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AppMetafield",
+      "description": "Represents a custom [metafield](/docs/apps/build/custom-data/metafields) attached to a resource such as a product, variant, customer, or shop.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
           "value": "string",
-          "description": "The merchant-defined title of the automatic discount as displayed to the buyer, such as \"Summer Sale 10% Off\"."
+          "description": "The identifier for the metafield within its namespace, such as `'ingredients'` or `'shipping_weight'`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "namespace",
+          "value": "string",
+          "description": "The namespace that the metafield belongs to. Namespaces group related metafields and prevent naming collisions between different apps.\n\nApp owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information."
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "type",
-          "value": "'automatic'",
-          "description": "Identifies this as an automatic discount, applied based on merchant-configured rules without a code."
-        }
-      ],
-      "value": "export interface CartAutomaticDiscountAllocation\n  extends CartDiscountAllocationBase {\n  /**\n   * The merchant-defined title of the automatic discount as displayed to the buyer, such as \"Summer Sale 10% Off\".\n   */\n  title: string;\n\n  /**\n   * Identifies this as an automatic discount, applied based on merchant-configured rules without a code.\n   */\n  type: 'automatic';\n}"
-    }
-  },
-  "CartCustomDiscountAllocation": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartCustomDiscountAllocation",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "discountedAmount",
-          "value": "Money",
-          "description": "The monetary value that was deducted from the line item or order total by this discount allocation."
+          "value": "string",
+          "description": "The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`. This is the full type identifier, whereas `valueType` is a simplified category."
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "title",
+          "name": "value",
           "value": "string",
-          "description": "The title of the custom discount, typically applied by a [Shopify Function](/docs/api/functions/latest/discount)."
+          "description": "The value of a metafield, stored as a string regardless of the underlying type. For JSON metafields, parse the string to access structured data."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "valueType",
+          "value": "'boolean' | 'float' | 'integer' | 'json_string' | 'string'",
+          "description": "The metafield's information type.\n\n- `'boolean'`: A true or false value.\n- `'float'`: A decimal number value.\n- `'integer'`: A whole number value.\n- `'json_string'`: A JSON-encoded string value.\n- `'string'`: A plain text value."
+        }
+      ],
+      "value": "export interface AppMetafield {\n  /**\n   * The identifier for the metafield within its namespace, such as `'ingredients'` or `'shipping_weight'`.\n   */\n  key: string;\n\n  /**\n   * The namespace that the metafield belongs to. Namespaces group related metafields and prevent naming collisions between different apps.\n   *\n   * App owned metafield namespaces are returned using the `$app` format. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   */\n  namespace: string;\n\n  /**\n   * The value of a metafield, stored as a string regardless of the underlying type. For JSON metafields, parse the string to access structured data.\n   */\n  value: string;\n\n  /**\n   * The metafield's information type.\n   *\n   * - `'boolean'`: A true or false value.\n   * - `'float'`: A decimal number value.\n   * - `'integer'`: A whole number value.\n   * - `'json_string'`: A JSON-encoded string value.\n   * - `'string'`: A plain text value.\n   */\n  valueType: 'boolean' | 'float' | 'integer' | 'json_string' | 'string';\n\n  /**\n   * The metafield's [type name](/docs/apps/build/custom-data/metafields/list-of-data-types), such as `'single_line_text_field'` or `'json'`. This is the full type identifier, whereas `valueType` is a simplified category.\n   */\n  type: string;\n}"
+    }
+  },
+  "AppMetafieldEntryTarget": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AppMetafieldEntryTarget",
+      "description": "The Shopify resource that a metafield is attached to. Each entry identifies a specific resource by its type and globally-unique ID, so you can trace where the data comes from.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "The globally-unique identifier of the Shopify resource, in [GID](/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the [Storefront API](/docs/api/storefront).",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/Product/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
         },
         {
           "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "type",
-          "value": "'custom'",
-          "description": "Identifies this as a custom discount applied by a [Shopify Function](/docs/api/functions/latest/discount)."
+          "value": "| 'customer'\n    | 'product'\n    | 'shop'\n    | 'shopUser'\n    | 'variant'\n    | 'company'\n    | 'companyLocation'\n    | 'cart'",
+          "description": "The kind of Shopify resource this metafield belongs to:\n\n- `'customer'`: The customer who placed the order.\n- `'product'`: A product in the merchant's catalog.\n- `'shop'`: The merchant's shop.\n- `'shopUser'`: A staff member or collaborator account on the shop.\n- `'variant'`: A specific variant of a product.\n- `'company'`: A [B2B](/docs/apps/build/b2b) company associated with the order.\n- `'companyLocation'`: A location belonging to a [B2B](/docs/apps/build/b2b) company.\n- `'cart'`: The cart associated with the checkout.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`."
         }
       ],
-      "value": "export interface CartCustomDiscountAllocation\n  extends CartDiscountAllocationBase {\n  /**\n   * The title of the custom discount, typically applied by a [Shopify Function](/docs/api/functions/latest/discount).\n   */\n  title: string;\n\n  /**\n   * Identifies this as a custom discount applied by a [Shopify Function](/docs/api/functions/latest/discount).\n   */\n  type: 'custom';\n}"
+      "value": "export interface AppMetafieldEntryTarget {\n  /**\n   * The kind of Shopify resource this metafield belongs to:\n   *\n   * - `'customer'`: The customer who placed the order.\n   * - `'product'`: A product in the merchant's catalog.\n   * - `'shop'`: The merchant's shop.\n   * - `'shopUser'`: A staff member or collaborator account on the shop.\n   * - `'variant'`: A specific variant of a product.\n   * - `'company'`: A [B2B](/docs/apps/build/b2b) company associated with the order.\n   * - `'companyLocation'`: A location belonging to a [B2B](/docs/apps/build/b2b) company.\n   * - `'cart'`: The cart associated with the checkout.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data) when the type is `customer`, `company` or `companyLocation`.\n   */\n  type:\n    | 'customer'\n    | 'product'\n    | 'shop'\n    | 'shopUser'\n    | 'variant'\n    | 'company'\n    | 'companyLocation'\n    | 'cart';\n\n  /**\n   * The globally-unique identifier of the Shopify resource, in [GID](/docs/api/usage/gids) format. Use this value to match the metafield to a specific resource in your extension or when querying the [Storefront API](/docs/api/storefront).\n   *\n   * @example 'gid://shopify/Product/123'\n   */\n  id: string;\n}"
     }
   },
-  "CartDiscountCode": {
+  "CheckoutToken": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartDiscountCode",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "code",
-          "value": "string",
-          "description": "The discount code string entered by the buyer during checkout or applied programmatically, such as `\"SAVE10\"` or `\"FREESHIP\"`. Use this to display which discount codes were applied."
-        }
-      ],
-      "value": "export interface CartDiscountCode {\n  /**\n   * The discount code string entered by the buyer during checkout or applied programmatically, such as `\"SAVE10\"` or `\"FREESHIP\"`. Use this to display which discount codes were applied.\n   */\n  code: string;\n}"
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CheckoutToken",
+      "value": "string",
+      "description": ""
     }
   },
   "Extension": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+    "src/surfaces/checkout/api/address-autocomplete/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
       "name": "Extension",
-      "description": "Metadata about the running extension, including its API version, target, capabilities, and editor context. Use this to read configuration details or conditionally render content based on where the extension is running.",
+      "description": "",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "apiVersion",
           "value": "ApiVersion",
@@ -2745,7 +2391,7 @@
               "description": "",
               "tabs": [
                 {
-                  "code": "'2024-10', '2025-01', '2025-04', '2025-07', '2025-10'",
+                  "code": "'2023-10', '2024-01', '2024-04', '2025-07', '2025-10'",
                   "title": "Example"
                 }
               ]
@@ -2753,40 +2399,40 @@
           ]
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "capabilities",
-          "value": "SubscribableSignalLike<Capability[]>",
-          "description": "The allowed capabilities of the extension, defined in your [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file."
+          "value": "Capability[]",
+          "description": "The allowed capabilities of the extension, defined in your [shopify.extension.toml](/docs/api/checkout-ui-extensions/configuration) file.\n\n* [`api_access`](/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.\n\n* [`network_access`](/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.\n\n* [`block_progress`](/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.\n\n* [`collect_buyer_consent.sms_marketing`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.\n\n* [`collect_buyer_consent.customer_privacy`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that will be honored on Shopify-managed services.\n\n* [`iframe.sources`](/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "editor",
           "value": "Editor",
-          "description": "Information about the editor where the extension is being rendered.\n\nIf the value is undefined, then the extension isn't running in an editor.",
+          "description": "The information about the editor where the extension is being rendered.\n\nIf the value is undefined, then the extension is not running in an editor.",
           "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "rendered",
-          "value": "SubscribableSignalLike<boolean>",
-          "description": "A Boolean to show whether your extension is currently rendered to the screen.\n\nShopify might render your extension before it's visible in the UI, typically to pre-render extensions that appear on a later step of the checkout.\n\nYour extension might also continue to run after the customer has navigated away from where it was rendered. The extension continues running so that your extension is immediately available to render if the customer navigates back."
+          "value": "boolean",
+          "description": "A Boolean to show whether your extension is currently rendered to the screen.\n\nShopify might render your extension before it's visible in the UI, typically to pre-render extensions that will appear on a later step of the checkout.\n\nYour extension might also continue to run after the customer has navigated away from where it was rendered. The extension continues running so that your extension is immediately available to render if the customer navigates back.\n\nIf the extension is not capable of rendering UI components, then the value will always be false."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "scriptUrl",
           "value": "string",
           "description": "The URL to the script that started the extension target."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "target",
           "value": "Target",
-          "description": "The identifier that specifies where in Shopify's UI your code is being injected. This is one of the targets you've included in your extension's configuration file.",
+          "description": "The identifier that specifies where in Shopify’s UI your code is being injected. This will be one of the targets you have included in your extension’s configuration file.",
           "examples": [
             {
               "title": "Example",
@@ -2801,11 +2447,11 @@
           ]
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "version",
           "value": "string",
-          "description": "The published version of the running extension target.\n\nFor unpublished extensions, the value is `undefined`.\n\nDon't use this property as a stable identifier in development environments. It becomes available only after the extension is published.",
+          "description": "The published version of the running extension target.\n\nFor unpublished extensions, the value is `undefined`.",
           "isOptional": true,
           "examples": [
             {
@@ -2821,7 +2467,7 @@
           ]
         }
       ],
-      "value": "export interface Extension<Target extends ExtensionTarget = ExtensionTarget> {\n  /**\n   * The API version that was set in the extension config file.\n   *\n   * @example '2024-10', '2025-01', '2025-04', '2025-07', '2025-10'\n   */\n  apiVersion: ApiVersion;\n\n  /**\n   * The allowed capabilities of the extension, defined in your\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file.\n   */\n  capabilities: SubscribableSignalLike<Capability[]>;\n\n  /**\n   * Information about the editor where the extension is being rendered.\n   *\n   * If the value is undefined, then the extension isn't running in an editor.\n   */\n  editor?: Editor;\n\n  /**\n   * A Boolean to show whether your extension is currently rendered to the screen.\n   *\n   * Shopify might render your extension before it's visible in the UI,\n   * typically to pre-render extensions that appear on a later step of the\n   * checkout.\n   *\n   * Your extension might also continue to run after the customer has navigated away\n   * from where it was rendered. The extension continues running so that\n   * your extension is immediately available to render if the customer navigates back.\n   */\n  rendered: SubscribableSignalLike<boolean>;\n\n  /**\n   * The URL to the script that started the extension target.\n   */\n  scriptUrl: string;\n\n  /**\n   * The identifier that specifies where in Shopify's UI your code is being\n   * injected. This is one of the targets you've included in your\n   * extension's configuration file.\n   *\n   * @example 'purchase.checkout.block.render'\n   * @see /docs/api/checkout-ui-extensions/{API_VERSION}/extension-targets-overview\n   * @see /docs/apps/app-extensions/configuration#targets\n   */\n  target: Target;\n\n  /**\n   * The published version of the running extension target.\n   *\n   * For unpublished extensions, the value is `undefined`.\n   *\n   * Don't use this property as a stable identifier in development environments.\n   * It becomes available only after the extension is published.\n   *\n   * @example 3.0.10\n   */\n  version?: string;\n}"
+      "value": "interface Extension<\n  Target extends\n    | 'purchase.address-autocomplete.suggest'\n    | 'purchase.address-autocomplete.format-suggestion',\n> {\n  /**\n   * The API version that was set in the extension config file.\n   *\n   * @example '2023-10', '2024-01', '2024-04', '2025-07', '2025-10'\n   */\n  apiVersion: ApiVersion;\n\n  /**\n   * The allowed capabilities of the extension, defined\n   * in your [shopify.extension.toml](/docs/api/checkout-ui-extensions/configuration) file.\n   *\n   * * [`api_access`](/docs/api/checkout-ui-extensions/configuration#api-access): the extension can access the Storefront API.\n   *\n   * * [`network_access`](/docs/api/checkout-ui-extensions/configuration#network-access): the extension can make external network calls.\n   *\n   * * [`block_progress`](/docs/api/checkout-ui-extensions/configuration#block-progress): the extension can block a customer's progress and the merchant has allowed this blocking behavior.\n   *\n   * * [`collect_buyer_consent.sms_marketing`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can collect customer consent for SMS marketing.\n   *\n   * * [`collect_buyer_consent.customer_privacy`](/docs/api/checkout-ui-extensions/configuration#collect-buyer-consent): the extension can register customer consent decisions that will be honored on Shopify-managed services.\n   *\n   * * [`iframe.sources`](/docs/api/checkout-ui-extensions/configuration#iframe): the extension can embed an external URL in an iframe.\n   */\n  capabilities: Capability[];\n\n  /**\n   * The information about the editor where the extension is being rendered.\n   *\n   * If the value is undefined, then the extension is not running in an editor.\n   */\n  editor?: Editor;\n\n  /**\n   * A Boolean to show whether your extension is currently rendered to the screen.\n   *\n   * Shopify might render your extension before it's visible in the UI,\n   * typically to pre-render extensions that will appear on a later step of the\n   * checkout.\n   *\n   * Your extension might also continue to run after the customer has navigated away\n   * from where it was rendered. The extension continues running so that\n   * your extension is immediately available to render if the customer navigates back.\n   *\n   * If the extension is not capable of rendering UI components, then the value will always be false.\n   */\n  rendered: boolean;\n\n  /**\n   * The URL to the script that started the extension target.\n   */\n  scriptUrl: string;\n  /**\n   * The identifier that specifies where in Shopify’s UI your code is being\n   * injected. This will be one of the targets you have included in your\n   * extension’s configuration file.\n   *\n   * @example 'purchase.checkout.block.render'\n   * @see /docs/api/checkout-ui-extensions/latest/extension-targets-overview\n   * @see /docs/apps/app-extensions/configuration#targets\n   */\n  target: Target;\n\n  /**\n   * The published version of the running extension target.\n   *\n   * For unpublished extensions, the value is `undefined`.\n   *\n   * @example 3.0.10\n   */\n  version?: string;\n}"
     }
   },
   "ApiVersion": {
@@ -2906,644 +2552,56 @@
       "value": "export interface I18nTranslate {\n  <ReplacementType = string>(\n    key: string,\n    options?: Record<string, ReplacementType | string | number>,\n  ): ReplacementType extends string | number\n    ? string\n    : (string | ReplacementType)[];\n}"
     }
   },
-  "CartInstructions": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartInstructions",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "attributes",
-          "value": "AttributesCartInstructions",
-          "description": "Whether the extension can update custom attributes using `applyAttributeChange()`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "delivery",
-          "value": "DeliveryCartInstructions",
-          "description": "Whether the extension can modify the shipping address using `applyShippingAddressChange()`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "discounts",
-          "value": "DiscountsCartInstructions",
-          "description": "Whether the extension can add or remove discount codes using `applyDiscountCodeChange()`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "lines",
-          "value": "CartLinesCartInstructions",
-          "description": "Whether the extension can add, remove, or update cart lines using `applyCartLinesChange()`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "metafields",
-          "value": "MetafieldsCartInstructions",
-          "description": "Whether the extension can add, update, or delete cart metafields using `applyMetafieldChange()`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "notes",
-          "value": "NotesCartInstructions",
-          "description": "Whether the extension can update the order note using `applyNoteChange()`."
-        }
-      ],
-      "value": "export interface CartInstructions {\n  /**\n   * Whether the extension can update custom attributes using `applyAttributeChange()`.\n   */\n  attributes: AttributesCartInstructions;\n\n  /**\n   * Whether the extension can modify the shipping address using `applyShippingAddressChange()`.\n   */\n  delivery: DeliveryCartInstructions;\n\n  /**\n   * Whether the extension can add or remove discount codes using `applyDiscountCodeChange()`.\n   */\n  discounts: DiscountsCartInstructions;\n\n  /**\n   * Whether the extension can add, remove, or update cart lines using `applyCartLinesChange()`.\n   */\n  lines: CartLinesCartInstructions;\n\n  /**\n   * Whether the extension can add, update, or delete cart metafields using `applyMetafieldChange()`.\n   */\n  metafields: MetafieldsCartInstructions;\n\n  /**\n   * Whether the extension can update the order note using `applyNoteChange()`.\n   */\n  notes: NotesCartInstructions;\n}"
-    }
-  },
-  "AttributesCartInstructions": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "AttributesCartInstructions",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canUpdateAttributes",
-          "value": "boolean",
-          "description": "Whether attributes can be updated using `applyAttributeChange()`. When `false`, the checkout configuration doesn't allow attribute changes. Even when `true`, calls to `applyAttributeChange()` can still fail during accelerated checkout (Apple Pay, Google Pay)."
-        }
-      ],
-      "value": "export interface AttributesCartInstructions {\n  /**\n   * Whether attributes can be updated using `applyAttributeChange()`. When\n   * `false`, the checkout configuration doesn't allow attribute changes.\n   * Even when `true`, calls to `applyAttributeChange()` can still fail\n   * during accelerated checkout (Apple Pay, Google Pay).\n   */\n  canUpdateAttributes: boolean;\n}"
-    }
-  },
-  "DeliveryCartInstructions": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "DeliveryCartInstructions",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canSelectCustomAddress",
-          "value": "boolean",
-          "description": "Whether the shipping address can be modified using `applyShippingAddressChange()`. When `false`, the buyer is using an accelerated checkout flow (Apple Pay, Google Pay) where the address can't be changed."
-        }
-      ],
-      "value": "export interface DeliveryCartInstructions {\n  /**\n   * Whether the shipping address can be modified using\n   * `applyShippingAddressChange()`. When `false`, the buyer is using an\n   * accelerated checkout flow (Apple Pay, Google Pay) where the address\n   * can't be changed.\n   */\n  canSelectCustomAddress: boolean;\n}"
-    }
-  },
-  "DiscountsCartInstructions": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "DiscountsCartInstructions",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canUpdateDiscountCodes",
-          "value": "boolean",
-          "description": "Whether discount codes can be updated using `applyDiscountCodeChange()`. When `false`, the checkout configuration doesn't allow discount code changes. Even when `true`, calls to `applyDiscountCodeChange()` can still fail during accelerated checkout (Apple Pay, Google Pay)."
-        }
-      ],
-      "value": "export interface DiscountsCartInstructions {\n  /**\n   * Whether discount codes can be updated using `applyDiscountCodeChange()`.\n   * When `false`, the checkout configuration doesn't allow discount code\n   * changes. Even when `true`, calls to `applyDiscountCodeChange()` can\n   * still fail during accelerated checkout (Apple Pay, Google Pay).\n   */\n  canUpdateDiscountCodes: boolean;\n}"
-    }
-  },
-  "CartLinesCartInstructions": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartLinesCartInstructions",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canAddCartLine",
-          "value": "boolean",
-          "description": "Whether new cart lines can be added using `applyCartLinesChange()`. When `false`, the checkout configuration doesn't allow adding lines (for example, draft orders). Even when `true`, calls can still fail during accelerated checkout (Apple Pay, Google Pay)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canRemoveCartLine",
-          "value": "boolean",
-          "description": "Whether cart lines can be removed using `applyCartLinesChange()`. When `false`, the checkout configuration doesn't allow removing lines. Even when `true`, calls can still fail during accelerated checkout."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canUpdateCartLine",
-          "value": "boolean",
-          "description": "Whether cart lines can be updated using `applyCartLinesChange()`. When `false`, the checkout configuration doesn't allow updating lines. Even when `true`, calls can still fail during accelerated checkout."
-        }
-      ],
-      "value": "export interface CartLinesCartInstructions {\n  /**\n   * Whether new cart lines can be added using `applyCartLinesChange()`. When\n   * `false`, the checkout configuration doesn't allow adding lines (for\n   * example, draft orders). Even when `true`, calls can still fail during\n   * accelerated checkout (Apple Pay, Google Pay).\n   */\n  canAddCartLine: boolean;\n\n  /**\n   * Whether cart lines can be removed using `applyCartLinesChange()`. When\n   * `false`, the checkout configuration doesn't allow removing lines.\n   * Even when `true`, calls can still fail during accelerated checkout.\n   */\n  canRemoveCartLine: boolean;\n\n  /**\n   * Whether cart lines can be updated using `applyCartLinesChange()`. When\n   * `false`, the checkout configuration doesn't allow updating lines.\n   * Even when `true`, calls can still fail during accelerated checkout.\n   */\n  canUpdateCartLine: boolean;\n}"
-    }
-  },
-  "MetafieldsCartInstructions": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "MetafieldsCartInstructions",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canDeleteCartMetafield",
-          "value": "boolean",
-          "description": "Whether the extension can delete cart metafields using `applyMetafieldChange()`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canSetCartMetafields",
-          "value": "boolean",
-          "description": "Whether the extension can add or update cart metafields using `applyMetafieldChange()`."
-        }
-      ],
-      "value": "export interface MetafieldsCartInstructions {\n  /**\n   * Whether the extension can add or update cart metafields using\n   * `applyMetafieldChange()`.\n   */\n  canSetCartMetafields: boolean;\n\n  /**\n   * Whether the extension can delete cart metafields using\n   * `applyMetafieldChange()`.\n   */\n  canDeleteCartMetafield: boolean;\n}"
-    }
-  },
-  "NotesCartInstructions": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "NotesCartInstructions",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "canUpdateNote",
-          "value": "boolean",
-          "description": "Whether the order note can be updated using `applyNoteChange()`. When `false`, the checkout configuration doesn't allow note changes. Even when `true`, calls to `applyNoteChange()` can still fail during accelerated checkout (Apple Pay, Google Pay)."
-        }
-      ],
-      "value": "export interface NotesCartInstructions {\n  /**\n   * Whether the order note can be updated using `applyNoteChange()`. When\n   * `false`, the checkout configuration doesn't allow note changes. Even\n   * when `true`, calls to `applyNoteChange()` can still fail during\n   * accelerated checkout (Apple Pay, Google Pay).\n   */\n  canUpdateNote: boolean;\n}"
-    }
-  },
-  "CartLine": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartLine",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "attributes",
-          "value": "Attribute[]",
-          "description": "Custom key-value attributes attached to this cart line, such as gift messages or engraving text. Use `applyCartLinesChange()` to update these values."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "cost",
-          "value": "CartLineCost",
-          "description": "The cost breakdown for this line item, including the total price after any line-level discounts have been applied."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "discountAllocations",
-          "value": "CartDiscountAllocation[]",
-          "description": "Discounts applied to this cart line, including code-based, automatic, and custom discounts. Each allocation shows the discounted amount and how the discount was triggered."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A unique identifier for the cart line in the format `gid://shopify/CartLine/<id>`. This ID isn't stable and can change after any cart operation, so avoid persisting it. Always look up the current ID before calling `applyCartLinesChange()`, because you'll need it to create a `CartLineChange` object.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/CartLine/123'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "lineComponents",
-          "value": "CartBundleLineComponent[]",
-          "description": "The individual components of a [bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component represents a separate product within the bundle. Returns an empty array if the line item isn't a bundle."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "merchandise",
-          "value": "Merchandise",
-          "description": "The product variant or other merchandise associated with this line item. Use this to access product details such as the title, image, SKU, and selected options."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "parentRelationship",
-          "value": "CartLineParentRelationship | null",
-          "description": "The parent line item that this line belongs to, or `null` if this is a top-level line item. Used to identify lines added as children of a bundle or other grouped product."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "quantity",
-          "value": "number",
-          "description": "The number of units of this merchandise that the buyer purchased."
-        }
-      ],
-      "value": "export interface CartLine {\n  /**\n   * A unique identifier for the cart line in the format `gid://shopify/CartLine/<id>`. This ID isn't stable and can change after any cart operation, so avoid persisting it. Always look up the current ID before calling `applyCartLinesChange()`, because you'll need it to create a `CartLineChange` object.\n   *\n   * @example 'gid://shopify/CartLine/123'\n   */\n  id: string;\n\n  /**\n   * The product variant or other merchandise associated with this line item. Use this to access product details such as the title, image, SKU, and selected options.\n   */\n  merchandise: Merchandise;\n\n  /**\n   * The number of units of this merchandise that the buyer purchased.\n   */\n  quantity: number;\n\n  /**\n   * The cost breakdown for this line item, including the total price after any line-level discounts have been applied.\n   */\n  cost: CartLineCost;\n\n  /**\n   * Custom key-value attributes attached to this cart line, such as gift messages or engraving text. Use `applyCartLinesChange()` to update these values.\n   */\n  attributes: Attribute[];\n\n  /**\n   * Discounts applied to this cart line, including code-based, automatic, and custom discounts. Each allocation shows the discounted amount and how the discount was triggered.\n   */\n  discountAllocations: CartDiscountAllocation[];\n\n  /**\n   * The individual components of a [bundle](/docs/apps/build/product-merchandising/bundles) line item. Each component represents a separate product within the bundle. Returns an empty array if the line item isn't a bundle.\n   */\n  lineComponents: CartLineComponentType[];\n\n  /**\n   * The parent line item that this line belongs to, or `null` if this is a\n   * top-level line item. Used to identify lines added as children of a bundle\n   * or other grouped product.\n   */\n  parentRelationship: CartLineParentRelationship | null;\n}"
-    }
-  },
-  "CartLineCost": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartLineCost",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "totalAmount",
-          "value": "Money",
-          "description": "The total price the buyer pays for this line item after all line-level discounts have been applied, but before order-level discounts, taxes, and shipping."
-        }
-      ],
-      "value": "export interface CartLineCost {\n  /**\n   * The total price the buyer pays for this line item after all line-level discounts have been applied, but before order-level discounts, taxes, and shipping.\n   */\n  totalAmount: Money;\n}"
-    }
-  },
-  "CartBundleLineComponent": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartBundleLineComponent",
-      "description": "An individual component within a bundled cart line. Each `CartLine` that represents a bundle has a `lineComponents` array containing these components.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "attributes",
-          "value": "Attribute[]",
-          "description": "Custom key-value pairs attached to this bundle component, such as personalization options specific to this item within the bundle.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "[{key: 'engraving', value: 'hello world'}]",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "cost",
-          "value": "CartLineCost",
-          "description": "The cost breakdown for this bundle component, including the total amount after any per-item discounts."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A unique identifier for this component within the bundle, in the format `gid://shopify/CartLineComponent/<id>`. This ID isn't stable and might change after any operation that updates the line items.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/CartLineComponent/123'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "merchandise",
-          "value": "Merchandise",
-          "description": "The product variant included in this bundle component. Use this to display product details for individual items within a bundle."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "quantity",
-          "value": "number",
-          "description": "The number of units of this component included in the bundle."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'bundle'",
-          "description": "Identifies this as a bundle line component. This is currently the only component type."
-        }
-      ],
-      "value": "export interface CartBundleLineComponent {\n  /**\n   * Identifies this as a bundle line component. This is currently the only component type.\n   */\n  type: 'bundle';\n\n  /**\n   * A unique identifier for this component within the bundle, in the format `gid://shopify/CartLineComponent/<id>`. This ID isn't stable and might change after any operation that updates the line items.\n   *\n   * @example 'gid://shopify/CartLineComponent/123'\n   */\n  id: string;\n\n  /**\n   * The product variant included in this bundle component. Use this to display product details for individual items within a bundle.\n   */\n  merchandise: Merchandise;\n\n  /**\n   * The number of units of this component included in the bundle.\n   */\n  quantity: number;\n\n  /**\n   * The cost breakdown for this bundle component, including the total amount after any per-item discounts.\n   */\n  cost: CartLineCost;\n\n  /**\n   * Custom key-value pairs attached to this bundle component, such as personalization options specific to this item within the bundle.\n   *\n   * @example [{key: 'engraving', value: 'hello world'}]\n   */\n  attributes: Attribute[];\n}"
-    }
-  },
-  "Merchandise": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "Merchandise",
-      "value": "ProductVariant",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A globally-unique identifier for the product variant in the format `gid://shopify/ProductVariant/<id>`.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/ProductVariant/123'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "image",
-          "value": "ImageDetails",
-          "description": "The image associated with the product variant. Falls back to the product image if the variant doesn't have its own. The value is `undefined` if neither the variant nor the product has an image.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "product",
-          "value": "Product",
-          "description": "The parent product that this variant belongs to. Use this to access the product's ID, vendor, and type."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "requiresShipping",
-          "value": "boolean",
-          "description": "Whether this product variant requires physical shipping. When `true`, the buyer must provide a shipping address. Returns `false` for digital products, gift cards, and services."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "selectedOptions",
-          "value": "SelectedOption[]",
-          "description": "The product options applied to this variant, such as size, color, or material. Each entry contains the option name and the selected value."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "sellingPlan",
-          "value": "SellingPlan",
-          "description": "The [selling plan](/docs/apps/build/purchase-options/subscriptions) associated with this variant, such as a subscription or pre-order plan. The value is `undefined` if the item isn't being purchased through a selling plan.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "sku",
-          "value": "string",
-          "description": "The stock keeping unit (SKU) assigned to this variant by the merchant, used for inventory tracking. The value is `undefined` if no SKU has been set.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "subtitle",
-          "value": "string",
-          "description": "A secondary description for the variant that provides additional context, such as a color or size combination. The value is `undefined` if no subtitle is available.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "title",
-          "value": "string",
-          "description": "The display title of the product variant, such as \"Small\" or \"Red / Large\". This is the variant-specific label, not the parent product title."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'variant'",
-          "description": "Identifies the merchandise as a product variant. This is currently the only merchandise type in checkout."
-        }
-      ]
-    }
-  },
-  "Product": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "Product",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A globally-unique identifier for the product in the format `gid://shopify/Product/<id>`.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/Product/123'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "productType",
-          "value": "string",
-          "description": "A merchant-defined categorization for the product, such as \"Accessories\" or \"Clothing\". Commonly used for filtering and organizing products in a storefront."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "vendor",
-          "value": "string",
-          "description": "The name of the product's vendor or manufacturer, as set by the merchant in Shopify admin."
-        }
-      ],
-      "value": "export interface Product {\n  /**\n   * A globally-unique identifier for the product in the format `gid://shopify/Product/<id>`.\n   *\n   * @example 'gid://shopify/Product/123'\n   */\n  id: string;\n\n  /**\n   * The name of the product's vendor or manufacturer, as set by the merchant in Shopify admin.\n   */\n  vendor: string;\n\n  /**\n   * A merchant-defined categorization for the product, such as \"Accessories\" or \"Clothing\". Commonly used for filtering and organizing products in a storefront.\n   */\n  productType: string;\n}"
-    }
-  },
-  "SelectedOption": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "SelectedOption",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "name",
-          "value": "string",
-          "description": "The name of the product option, such as \"Color\" or \"Size\".",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Size'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string",
-          "description": "The selected value for the product option, such as \"Red\" or \"Large\".",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Large'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface SelectedOption {\n  /**\n   * The name of the product option, such as \"Color\" or \"Size\".\n   *\n   * @example 'Size'\n   */\n  name: string;\n\n  /**\n   * The selected value for the product option, such as \"Red\" or \"Large\".\n   *\n   * @example 'Large'\n   */\n  value: string;\n}"
-    }
-  },
-  "SellingPlan": {
-    "src/surfaces/checkout/api/shared.ts": {
-      "filePath": "src/surfaces/checkout/api/shared.ts",
-      "name": "SellingPlan",
-      "description": "A [selling plan](/docs/apps/build/purchase-options/subscriptions) represents a recurring or deferred purchasing option for a product, such as a subscription, pre-order, or try-before-you-buy plan. The merchant configures selling plans to define how and when the buyer is charged.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A globally-unique identifier for the selling plan in the format `gid://shopify/SellingPlan/<id>`. Use this to reference the specific selling plan associated with a line item.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'gid://shopify/SellingPlan/1'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "recurringDeliveries",
-          "value": "boolean",
-          "description": "Whether purchasing through this selling plan results in multiple deliveries. `true` for subscription plans with recurring fulfillment, `false` for one-time pre-orders or try-before-you-buy plans."
-        }
-      ],
-      "value": "export interface SellingPlan {\n  /**\n   * A globally-unique identifier for the selling plan in the format\n   * `gid://shopify/SellingPlan/<id>`. Use this to reference the specific\n   * selling plan associated with a line item.\n   *\n   * @example 'gid://shopify/SellingPlan/1'\n   */\n  id: string;\n\n  /**\n   * Whether purchasing through this selling plan results in multiple\n   * deliveries. `true` for subscription plans with recurring fulfillment,\n   * `false` for one-time pre-orders or try-before-you-buy plans.\n   */\n  recurringDeliveries: boolean;\n}"
-    }
-  },
-  "CartLineParentRelationship": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "CartLineParentRelationship",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "parent",
-          "value": "{ id: string; }",
-          "description": "The parent cart line that a cart line is associated with."
-        }
-      ],
-      "value": "export interface CartLineParentRelationship {\n  /**\n   * The parent cart line that a cart line is associated with.\n   */\n  parent: {\n    /**\n     * These line item IDs aren't stable at the moment, and they might change after\n     * any operations on the line items. Always look up an updated\n     * ID before any call to `applyCartLinesChange` because you'll need the ID to\n     * create a `CartLineChange` object.\n     * @example 'gid://shopify/CartLine/123'\n     */\n    id: string;\n  };\n}"
-    }
-  },
   "Localization": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+    "src/surfaces/checkout/api/address-autocomplete/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
       "name": "Localization",
-      "description": "The buyer's language, country, currency, and timezone context. Use this to adapt your extension to the buyer's region and display localized content.",
+      "description": "",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "country",
-          "value": "SubscribableSignalLike<Country | undefined>",
-          "description": "The country context of the checkout, carried over from the cart. It updates when the buyer changes their shipping address country. Use this value to display region-specific content such as local support information or regional policies. The value is `undefined` if the buyer's country is unknown.\n\nDerived from the buyer's shipping address. Returns `undefined` until the buyer enters a shipping address."
+          "value": "Country | undefined",
+          "description": "The country context of the checkout. This value carries over from the context of the cart, where it was used to contextualize the storefront experience. If the country is unknown, then the value is undefined."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "currency",
-          "value": "SubscribableSignalLike<Currency>",
-          "description": "The currency that the buyer sees for money amounts in the checkout. Use this value to format prices and totals in the buyer's expected currency."
+          "value": "Currency",
+          "description": "The currency that the customer sees for money amounts in the checkout."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "extensionLanguage",
-          "value": "SubscribableSignalLike<Language>",
-          "description": "The best available language match for your extension based on the buyer's language. If the buyer's language is `'fr-CA'` but your extension supports only `'fr'`, this returns `'fr'`. If your extension doesn't support any variant of the buyer's language, this falls back to your extension's default locale (the `.default.json` translation file). Use this value to load the correct translation file for your extension."
+          "value": "Language",
+          "description": "This is the customer's language, as supported by the extension. If the customer's actual language is not supported by the extension, then this is the language that is used for translations.\n\nFor example, if the customer's language is 'fr-CA' but your extension only supports translations for 'fr', then the `isoCode` for this language is 'fr'. If your extension does not provide french translations at all, then this value is the default locale for your extension (that is, the one matching your .default.json file)."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "language",
-          "value": "SubscribableSignalLike<Language>",
-          "description": "The language the buyer sees in the checkout. This reflects the language selected by the buyer or determined by their browser settings, and might differ from the languages your extension supports."
+          "value": "Language",
+          "description": "The language the customer sees in the checkout."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "market",
-          "value": "SubscribableSignalLike<Market | undefined>",
-          "description": "The [market](/docs/apps/build/markets) context of the checkout, carried over from the cart context. Markets group countries and regions with shared pricing, languages, and domains. The market context updates when the buyer changes the country of their shipping address. The value is `undefined` if the market is unknown.",
-          "deprecationMessage": "Merchants now manage which extensions load for each\nmarket, so extensions no longer need to check this value."
+          "value": "Market | undefined",
+          "description": "The [market](/docs/apps/markets) context of the checkout. This value carries over from the context of the cart, where it was used to contextualize the storefront experience. If the market is unknown, then the value is undefined."
         },
         {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "timezone",
-          "value": "SubscribableSignalLike<Timezone>",
-          "description": "The buyer's time zone, based on their browser or account settings. Use this value to format dates and times relative to the buyer's local time."
+          "value": "Timezone",
+          "description": "The buyer’s time zone."
         }
       ],
-      "value": "export interface Localization {\n  /**\n   * The currency that the buyer sees for money amounts in the checkout. Use this value to format prices and totals in the buyer's expected currency.\n   */\n  currency: SubscribableSignalLike<Currency>;\n\n  /**\n   * The buyer's time zone, based on their browser or account settings. Use this value to format dates and times relative to the buyer's local time.\n   */\n  timezone: SubscribableSignalLike<Timezone>;\n\n  /**\n   * The language the buyer sees in the checkout. This reflects the language selected by the buyer or determined by their browser settings, and might differ from the languages your extension supports.\n   */\n  language: SubscribableSignalLike<Language>;\n\n  /**\n   * The best available language match for your extension based on the buyer's language. If the buyer's language is `'fr-CA'` but your extension supports only `'fr'`, this returns `'fr'`. If your extension doesn't support any variant of the buyer's language, this falls back to your extension's default locale (the `.default.json` translation file). Use this value to load the correct translation file for your extension.\n   */\n  extensionLanguage: SubscribableSignalLike<Language>;\n\n  /**\n   * The country context of the checkout, carried over from the cart. It updates when the buyer changes their shipping address country. Use this value to display region-specific content such as local support information or regional policies. The value is `undefined` if the buyer's country is unknown.\n   *\n   * Derived from the buyer's shipping address. Returns `undefined` until the\n   * buyer enters a shipping address.\n   */\n  country: SubscribableSignalLike<Country | undefined>;\n\n  /**\n   * The [market](/docs/apps/build/markets) context of the checkout,\n   * carried over from the cart context. Markets group countries and\n   * regions with shared pricing, languages, and domains. The market\n   * context updates when the buyer changes the country of their\n   * shipping address. The value is `undefined` if the market is unknown.\n   *\n   * @deprecated Merchants now manage which extensions load for each\n   * market, so extensions no longer need to check this value.\n   */\n  market: SubscribableSignalLike<Market | undefined>;\n}"
+      "value": "interface Localization {\n  /**\n   * The currency that the customer sees for money amounts in the checkout.\n   */\n  currency: Currency;\n\n  /**\n   * The buyer’s time zone.\n   */\n  timezone: Timezone;\n\n  /**\n   * The language the customer sees in the checkout.\n   */\n  language: Language;\n\n  /**\n   * This is the customer's language, as supported by the extension.\n   * If the customer's actual language is not supported by the extension,\n   * then this is the language that is used for translations.\n   *\n   * For example, if the customer's language is 'fr-CA' but your extension\n   * only supports translations for 'fr', then the `isoCode` for this\n   * language is 'fr'. If your extension does not provide french\n   * translations at all, then this value is the default locale for your\n   * extension (that is, the one matching your .default.json file).\n   */\n  extensionLanguage: Language;\n\n  /**\n   * The country context of the checkout. This value carries over from the\n   * context of the cart, where it was used to contextualize the storefront\n   * experience. If the country is unknown, then the value is undefined.\n   */\n  country: Country | undefined;\n\n  /**\n   * The [market](/docs/apps/markets) context of the\n   * checkout. This value carries over from the context of the cart, where it\n   * was used to contextualize the storefront experience. If the market is unknown,\n   * then the value is undefined.\n   */\n  market: Market | undefined;\n}"
     }
   },
   "Country": {
@@ -3652,58 +2710,6 @@
       "description": ""
     }
   },
-  "LocalizedField": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "name": "LocalizedField",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "key",
-          "value": "LocalizedFieldKey",
-          "description": "The identifier for the localized field, indicating the type of information collected (for example, a tax credential or shipping credential for a specific country)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "title",
-          "value": "string",
-          "description": "The localized display label for the field, suitable for rendering in the UI.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'CPF/CNPJ' for a Brazilian tax credential",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "value",
-          "value": "string",
-          "description": "The current value entered by the buyer for this field."
-        }
-      ],
-      "value": "export interface LocalizedField {\n  /**\n   * The identifier for the localized field, indicating the type of information\n   * collected (for example, a tax credential or shipping credential for a\n   * specific country).\n   */\n  key: LocalizedFieldKey;\n\n  /**\n   * The localized display label for the field, suitable for rendering in the UI.\n   *\n   * @example 'CPF/CNPJ' for a Brazilian tax credential\n   */\n  title: string;\n\n  /**\n   * The current value entered by the buyer for this field.\n   */\n  value: string;\n}"
-    }
-  },
-  "LocalizedFieldKey": {
-    "src/shared.ts": {
-      "filePath": "src/shared.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "LocalizedFieldKey",
-      "value": "'SHIPPING_CREDENTIAL_BR' | 'SHIPPING_CREDENTIAL_CL' | 'SHIPPING_CREDENTIAL_CN' | 'SHIPPING_CREDENTIAL_CO' | 'SHIPPING_CREDENTIAL_CR' | 'SHIPPING_CREDENTIAL_EC' | 'SHIPPING_CREDENTIAL_ES' | 'SHIPPING_CREDENTIAL_GT' | 'SHIPPING_CREDENTIAL_ID' | 'SHIPPING_CREDENTIAL_KR' | 'SHIPPING_CREDENTIAL_MY' | 'SHIPPING_CREDENTIAL_MX' | 'SHIPPING_CREDENTIAL_PE' | 'SHIPPING_CREDENTIAL_PT' | 'SHIPPING_CREDENTIAL_PY' | 'SHIPPING_CREDENTIAL_TR' | 'SHIPPING_CREDENTIAL_TW' | 'SHIPPING_CREDENTIAL_TYPE_CO' | 'TAX_CREDENTIAL_BR' | 'TAX_CREDENTIAL_CL' | 'TAX_CREDENTIAL_CO' | 'TAX_CREDENTIAL_CR' | 'TAX_CREDENTIAL_EC' | 'TAX_CREDENTIAL_ES' | 'TAX_CREDENTIAL_GT' | 'TAX_CREDENTIAL_ID' | 'TAX_CREDENTIAL_IT' | 'TAX_CREDENTIAL_MX' | 'TAX_CREDENTIAL_MY' | 'TAX_CREDENTIAL_PE' | 'TAX_CREDENTIAL_PT' | 'TAX_CREDENTIAL_PY' | 'TAX_CREDENTIAL_TR' | 'TAX_CREDENTIAL_TYPE_CO' | 'TAX_CREDENTIAL_TYPE_MX' | 'TAX_CREDENTIAL_USE_MX' | 'TAX_EMAIL_IT'",
-      "description": "A union of keys for the localized fields that are required by certain countries."
-    }
-  },
   "StorefrontApiVersion": {
     "src/shared.ts": {
       "filePath": "src/shared.ts",
@@ -3737,31 +2743,6 @@
       "value": "export interface GraphQLError {\n  /**\n   * A human-readable description of the error.\n   */\n  message: string;\n  /**\n   * Additional error metadata including the request ID and error code.\n   */\n  extensions: {\n    /**\n     * The unique identifier for the API request, useful for debugging with Shopify support.\n     */\n    requestId: string;\n    /**\n     * A machine-readable error code identifying the type of error.\n     */\n    code: string;\n  };\n}"
     }
   },
-  "SelectedPaymentOption": {
-    "src/surfaces/checkout/api/standard/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "SelectedPaymentOption",
-      "value": "PaymentOption",
-      "description": "A payment option that the buyer has actively selected. This is the same shape as `PaymentOption` and appears in `selectedPaymentOptions`.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "handle",
-          "value": "string",
-          "description": "A session-scoped identifier for this payment option. This handle isn't globally unique; it's specific to the current checkout session or the shop."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "| 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite'",
-          "description": "The type of the payment option.\n\nShops can be configured to support many different payment options. Some options are available only to buyers in specific regions.\n\n| Type  | Description  |\n|---|---|\n| `creditCard`  |  A vaulted or manually entered credit card.  |\n| `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n| `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n| `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n| `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n| `other`  |  Another type of payment not defined here.  |\n| `paymentOnDelivery`  |  A payment collected on delivery.  |\n| `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n| `wallet`  |  An integrated wallet such as PayPal, Google Pay, or Apple Pay.  |\n| `customOnsite` | A custom payment option that's processed through a checkout extension with a payments app. |"
-        }
-      ]
-    }
-  },
   "SessionToken": {
     "src/surfaces/checkout/api/standard/standard.ts": {
       "filePath": "src/surfaces/checkout/api/standard/standard.ts",
@@ -3787,244 +2768,6 @@
       "value": "Record<\n  string,\n  string | number | boolean | undefined\n>",
       "description": "The merchant-defined setting values for the extension.",
       "members": []
-    }
-  },
-  "ShippingAddress": {
-    "src/surfaces/checkout/api/shared.ts": {
-      "filePath": "src/surfaces/checkout/api/shared.ts",
-      "name": "ShippingAddress",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "address1",
-          "value": "string",
-          "description": "The first line of the street address, including the street number and name. The value is `undefined` if the buyer hasn't entered an address yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'151 O'Connor Street'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "address2",
-          "value": "string",
-          "description": "The second line of the buyer's address, such as apartment number, suite, or unit. The value is `undefined` if the buyer didn't provide a second address line.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Ground floor'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "city",
-          "value": "string",
-          "description": "The city, town, or village of the address. The value is `undefined` if the buyer hasn't entered a city yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Ottawa'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "company",
-          "value": "string",
-          "description": "The buyer's company name. The value is `undefined` if the buyer didn't enter a company or the store doesn't collect company names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Shopify'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "countryCode",
-          "value": "CountryCode",
-          "description": "The two-letter country code in [ISO 3166 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if the buyer hasn't selected a country yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'CA' for Canada.",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "firstName",
-          "value": "string",
-          "description": "The buyer's first name. Use this alongside `lastName` when you need to display or process name parts separately. The value is `undefined` if the buyer didn't provide a first name or the store doesn't collect split names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'John'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "lastName",
-          "value": "string",
-          "description": "The buyer's last name. Use this alongside `firstName` when you need to display or process name parts separately. The value is `undefined` if the buyer didn't provide a last name or the store doesn't collect split names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Doe'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "name",
-          "value": "string",
-          "description": "The buyer's full name, typically a combination of first and last name. The value is `undefined` if the buyer didn't provide a name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'John Doe'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "oneTimeUse",
-          "value": "boolean",
-          "description": "Controls whether the address is saved to the buyer's account. When `true`, the address won't be saved and is only used for this checkout. When `false` or `undefined`, the address might be saved to the buyer's account for future use.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "phone",
-          "value": "string",
-          "description": "The phone number associated with the address, typically in international format. The value is `undefined` if the buyer didn't provide a phone number or the store doesn't collect phone numbers.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'+1 613 111 2222'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "provinceCode",
-          "value": "string",
-          "description": "The province, state, prefecture, or region code of the address. The format varies by country. The value is `undefined` if the buyer hasn't selected one yet or the country doesn't have provinces.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'ON' for Ontario.",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "zip",
-          "value": "string",
-          "description": "The postal code or ZIP code of the address, used for mail sorting and delivery routing. The value is `undefined` if the buyer hasn't entered one yet or the country doesn't use postal codes.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'K2P 2L8'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface ShippingAddress extends MailingAddress {\n  /**\n   * Controls whether the address is saved to the buyer's account. When\n   * `true`, the address won't be saved and is only used for this checkout.\n   * When `false` or `undefined`, the address might be saved to the buyer's\n   * account for future use.\n   */\n  oneTimeUse?: boolean;\n}"
     }
   },
   "Shop": {
@@ -4116,6 +2859,747 @@
       "name": "Version",
       "value": "string",
       "description": ""
+    }
+  },
+  "DocsStyle": {
+    "src/surfaces/checkout/style/style.ts": {
+      "filePath": "src/surfaces/checkout/style/style.ts",
+      "name": "DocsStyle",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/style/style.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "default",
+          "value": "<T>(defaultValue: T) => StylesConditionalStyle<T, StylesBaseConditions>",
+          "description": "Sets an optional default value to use when no other condition is met."
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/style.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "when",
+          "value": "<T>(conditions: StylesConditions, value: T) => StylesConditionalStyle<T, StylesBaseConditions>",
+          "description": "Adjusts the style based on different conditions. All conditions, expressed as a literal object, must be met for the associated value to be applied.\n\nThe `when` method can be chained together to build more complex styles."
+        }
+      ],
+      "value": "export interface DocsStyle {\n  /**\n   * Sets an optional default value to use when no other condition is met.\n   *\n   * @param defaultValue The default value\n   * @returns The chainable condition style\n   */\n  default: <T>(defaultValue: T) => StylesConditionalStyle<T>;\n  /**\n   * Adjusts the style based on different conditions. All conditions, expressed\n   * as a literal object, must be met for the associated value to be applied.\n   *\n   * The `when` method can be chained together to build more complex styles.\n   *\n   * @param conditions The condition(s)\n   * @param value The conditional value that can be applied if the conditions are met\n   * @returns The chainable condition style\n   */\n  when: <T>(\n    conditions: StylesConditions,\n    value: T,\n  ) => StylesConditionalStyle<T>;\n}"
+    }
+  },
+  "StylesConditionalStyle": {
+    "src/surfaces/checkout/style/types.ts": {
+      "filePath": "src/surfaces/checkout/style/types.ts",
+      "name": "StylesConditionalStyle",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "conditionals",
+          "value": "StylesConditionalValue<T, AcceptedConditions>[]",
+          "description": "An array of conditional values."
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "default",
+          "value": "T",
+          "description": "The default value applied when none of the conditional values specified in `conditionals` are met.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface StylesConditionalStyle<\n  T,\n  AcceptedConditions extends StylesBaseConditions = StylesBaseConditions,\n> {\n  /**\n   * The default value applied when none of the conditional values\n   * specified in `conditionals` are met.\n   */\n  default?: T;\n  /**\n   * An array of conditional values.\n   */\n  conditionals: StylesConditionalValue<T, AcceptedConditions>[];\n}"
+    }
+  },
+  "StylesConditionalValue": {
+    "src/surfaces/checkout/style/types.ts": {
+      "filePath": "src/surfaces/checkout/style/types.ts",
+      "name": "StylesConditionalValue",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "conditions",
+          "value": "AcceptedConditions",
+          "description": "The conditions that must be met for the value to be applied. At least one condition must be specified."
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "T",
+          "description": "The value that will be applied if the conditions are met."
+        }
+      ],
+      "value": "export interface StylesConditionalValue<\n  T,\n  AcceptedConditions extends StylesBaseConditions = StylesBaseConditions,\n> {\n  /**\n   * The conditions that must be met for the value to be applied. At least one\n   * condition must be specified.\n   */\n  conditions: AcceptedConditions;\n  /**\n   * The value that will be applied if the conditions are met.\n   */\n  value: T;\n}"
+    }
+  },
+  "StylesBaseConditions": {
+    "src/surfaces/checkout/style/types.ts": {
+      "filePath": "src/surfaces/checkout/style/types.ts",
+      "name": "StylesBaseConditions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "focus",
+          "value": "true",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hover",
+          "value": "true",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "resolution",
+          "value": "1 | 1.3 | 1.5 | 2 | 2.6 | 3 | 3.5 | 4",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "viewportInlineSize",
+          "value": "{ min: ViewportInlineSize; }",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface StylesBaseConditions {\n  viewportInlineSize?: {min: ViewportInlineSize};\n  hover?: true;\n  focus?: true;\n  resolution?: 1 | 1.3 | 1.5 | 2 | 2.6 | 3 | 3.5 | 4;\n}"
+    }
+  },
+  "ViewportInlineSize": {
+    "src/surfaces/checkout/style/types.ts": {
+      "filePath": "src/surfaces/checkout/style/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ViewportInlineSize",
+      "value": "'extraSmall' | 'small' | 'medium' | 'large'",
+      "description": ""
+    }
+  },
+  "StylesConditions": {
+    "src/surfaces/checkout/style/types.ts": {
+      "filePath": "src/surfaces/checkout/style/types.ts",
+      "name": "StylesConditions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "focus",
+          "value": "true",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hover",
+          "value": "true",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/style/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "viewportInlineSize",
+          "value": "{ min: ViewportInlineSize; }",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface StylesConditions {\n  viewportInlineSize?: {min: ViewportInlineSize};\n  hover?: true;\n  focus?: true;\n}"
+    }
+  },
+  "ShopifyGlobal": {
+    "src/surfaces/checkout/globals.ts": {
+      "filePath": "src/surfaces/checkout/globals.ts",
+      "name": "ShopifyGlobal",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/globals.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "extend",
+          "value": "<ExtensionTarget extends keyof ExtensionTargets>(target: ExtensionTarget, extend: () => ExtensionTargets[ExtensionTarget][\"output\"]) => void",
+          "description": ""
+        },
+        {
+          "filePath": "src/surfaces/checkout/globals.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "reload",
+          "value": "() => void",
+          "description": ""
+        }
+      ],
+      "value": "export interface ShopifyGlobal {\n  extend<ExtensionTarget extends keyof ExtensionTargets>(\n    target: ExtensionTarget,\n    extend: () => ExtensionTargets[ExtensionTarget]['output'],\n  ): void;\n  reload(): void;\n}"
+    }
+  },
+  "ExtensionTarget": {
+    "src/surfaces/checkout/extension-targets.ts": {
+      "filePath": "src/surfaces/checkout/extension-targets.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ExtensionTarget",
+      "value": "keyof ExtensionTargets",
+      "description": "",
+      "isPublicDocs": true
+    }
+  },
+  "ExtensionTargets": {
+    "src/surfaces/checkout/extension-targets.ts": {
+      "filePath": "src/surfaces/checkout/extension-targets.ts",
+      "name": "ExtensionTargets",
+      "description": "",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::Actions::RenderBefore",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Actions::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately before any actions within each step.",
+          "deprecationMessage": "Use `purchase.checkout.actions.render-before` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::CartLineDetails::RenderAfter",
+          "value": "RenderExtension<\n    CheckoutApi &\n      CartLineItemApi &\n      StandardApi<'Checkout::CartLineDetails::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders on every line item, inside the details under the line item properties element.",
+          "deprecationMessage": "Use `purchase.checkout.cart-line-item.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::CartLineDetails::RenderLineComponents",
+          "value": "RenderExtension<\n    CartLineItemApi &\n      StandardApi<'Checkout::CartLineDetails::RenderLineComponents'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders on every bundle line item, inside the details under the line item properties element. It replaces the default bundle products rendering.",
+          "deprecationMessage": "Use `purchase.cart-line-item.line-components.render` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::CartLines::RenderAfter",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::CartLines::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after all line items.",
+          "deprecationMessage": "Use `purchase.checkout.cart-line-list.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::Contact::RenderAfter",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Contact::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately after the contact form element.",
+          "deprecationMessage": "Use `purchase.checkout.contact.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::CustomerInformation::RenderAfter",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::CustomerInformation::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after a purchase below the customer information.",
+          "deprecationMessage": "Use `purchase.thank-you.customer-information.render-after` or\n`customer-account.order-status.customer-information.render-after` from `@shopify/ui-extension/customer-account` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::DeliveryAddress::RenderBefore",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::DeliveryAddress::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered between the shipping address header and shipping address form elements.",
+          "deprecationMessage": "Use `purchase.checkout.delivery-address.render-before` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::Dynamic::Render",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Dynamic::Render'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that isn't tied to a specific checkout section or feature. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets).",
+          "deprecationMessage": "Use `purchase.checkout.block.render` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::GiftCard::Render",
+          "value": "RenderExtension<\n    RedeemableApi & CheckoutApi & StandardApi<'Checkout::GiftCard::Render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
+          "description": "A static extension target that renders the gift card entry form fields after the buyer ticks a box to use a gift card. This does not replace the native gift card entry form which is rendered in a separate part of checkout.",
+          "deprecationMessage": "Use `purchase.checkout.gift-card.render` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::PaymentMethod::HostedFields::RenderAfter",
+          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PaymentMethod::HostedFields::RenderAfter'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
+          "description": "A static extension target that renders after the hosted fields of a credit card payment method. for a credit card payment method when selected by the buyer.",
+          "deprecationMessage": "Use `purchase.checkout.payment-option-item.hosted-fields.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::PaymentMethod::Render",
+          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PaymentMethod::Render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
+          "description": "A static extension target that renders the form fields for a payment method when selected by the buyer.",
+          "deprecationMessage": "Use `purchase.checkout.payment-option-item.details.render` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::PaymentMethod::RenderRequiredAction",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::PaymentMethod::RenderRequiredAction'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders a form modal when a buyer selects the custom onsite payment method.",
+          "deprecationMessage": "Use `purchase.checkout.payment-option-item.action-required.render` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::PickupLocations::RenderAfter",
+          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupLocations::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after pickup location options.",
+          "deprecationMessage": "Use `purchase.checkout.pickup-location-list.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::PickupLocations::RenderBefore",
+          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupLocations::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered before pickup location options.",
+          "deprecationMessage": "Use `purchase.checkout.pickup-location-list.render-before` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::PickupPoints::RenderAfter",
+          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupPoints::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately after the pickup points.",
+          "deprecationMessage": "Use `purchase.checkout.pickup-point-list.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::PickupPoints::RenderBefore",
+          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupPoints::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately before the pickup points.",
+          "deprecationMessage": "Use `purchase.checkout.pickup-point-list.render-before` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::Reductions::RenderAfter",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Reductions::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered in the order summary, after the discount form and discount tag elements.",
+          "deprecationMessage": "Use `purchase.checkout.reductions.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::Reductions::RenderBefore",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Reductions::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered in the order summary, before the discount form element.",
+          "deprecationMessage": "Use `purchase.checkout.reductions.render-before` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ShippingMethodDetails::RenderAfter",
+          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethodDetails::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after the shipping method details within the shipping method option list, for each option.",
+          "deprecationMessage": "Use `purchase.checkout.shipping-option-item.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ShippingMethodDetails::RenderExpanded",
+          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethodDetails::RenderExpanded'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered under the shipping method within the shipping method option list, for each option.",
+          "deprecationMessage": "Use `purchase.checkout.shipping-option-item.details.render` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ShippingMethods::RenderAfter",
+          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethods::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after the shipping method options.",
+          "deprecationMessage": "Use `purchase.checkout.shipping-option-list.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ShippingMethods::RenderBefore",
+          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethods::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered between the shipping method header and shipping method options.",
+          "deprecationMessage": "Use `purchase.checkout.shipping-option-list.render-before` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ThankYou::CartLineDetails::RenderAfter",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      CartLineItemApi &\n      StandardApi<'Checkout::ThankYou::CartLineDetails::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders on every line item, inside the details under the line item properties element on the **Thank you** page.",
+          "deprecationMessage": "Use `purchase.thank-you.cart-line-item.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ThankYou::CartLines::RenderAfter",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'Checkout::ThankYou::CartLines::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after all line items on the **Thank you** page.",
+          "deprecationMessage": "Use `purchase.thank-you.cart-line-list.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ThankYou::CustomerInformation::RenderAfter",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'Checkout::ThankYou::CustomerInformation::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after a purchase below the customer information on the **Thank you** page.",
+          "deprecationMessage": "Use `purchase.thank-you.customer-information.render-after` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Checkout::ThankYou::Dynamic::Render",
+          "value": "RenderExtension<\n    OrderConfirmationApi & StandardApi<'Checkout::ThankYou::Dynamic::Render'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Thank you** page. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets).",
+          "deprecationMessage": "Use `purchase.thank-you.block.render` instead.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.address-autocomplete.format-suggestion",
+          "value": "RunnableExtension<\n    AddressAutocompleteStandardApi<'purchase.address-autocomplete.format-suggestion'> &\n      AddressAutocompleteFormatSuggestionApi,\n    AddressAutocompleteFormatSuggestionOutput\n  >",
+          "description": "An extension target that formats the selected address suggestion provided by a `purchase.address-autocomplete.suggest` target. This address is used to auto-populate the fields in the address form.\n\nIt must return a formatted address.\n\nThis target does not support rendering UI components."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.address-autocomplete.suggest",
+          "value": "RunnableExtension<\n    AddressAutocompleteStandardApi<'purchase.address-autocomplete.suggest'> &\n      AddressAutocompleteSuggestApi,\n    AddressAutocompleteSuggestOutput\n  >",
+          "description": "An extension target that provides address autocomplete suggestions. These suggestions are shown to buyers as they interact with address forms during checkout.\n\nIt must return a list of address suggestions. If a formatted address is provided with each suggestion, it will be used to auto-populate the fields in the address form when the buyer selects a suggestion.\n\nThis target does not support rendering UI components."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.cart-line-item.line-components.render",
+          "value": "RenderExtension<\n    CartLineItemApi &\n      StandardApi<'purchase.cart-line-item.line-components.render'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders on every bundle line item, inside the details under the line item properties element. It replaces the default bundle products rendering.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.actions.render-before",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.actions.render-before'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately before any actions within each step."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.block.render",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.block.render'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that isn't tied to a specific checkout section or feature. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.cart-line-item.render-after",
+          "value": "RenderExtension<\n    CheckoutApi &\n      CartLineItemApi &\n      StandardApi<'purchase.checkout.cart-line-item.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders on every line item, inside the details under the line item properties element."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.cart-line-list.render-after",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.cart-line-list.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after all line items."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.chat.render",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.chat.render'>,\n    AllowedComponents<'Chat'>\n  >",
+          "description": "A static extension target that is rendered on top of the checkout page as an overlay. It is positioned in the bottom right corner of the screen."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.contact.render-after",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.contact.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately after the contact form element."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.delivery-address.render-after",
+          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.delivery-address.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after the shipping address form elements."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.delivery-address.render-before",
+          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.delivery-address.render-before'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered between the shipping address header and shipping address form elements."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.footer.render-after",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.footer.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered below the footer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.gift-card.render",
+          "value": "RenderExtension<\n    RedeemableApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.gift-card.render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
+          "description": "A static extension target that renders the gift card entry form fields after the buyer ticks a box to use a gift card. This does not replace the native gift card entry form which is rendered in a separate part of checkout.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.header.render-after",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.header.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered below the header."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.payment-method-list.render-after",
+          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.payment-method-list.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders below the list of payment methods."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.payment-method-list.render-before",
+          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.payment-method-list.render-before'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders between the payment heading and payment method list."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.payment-option-item.action-required.render",
+          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.payment-option-item.action-required.render'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders a form modal when a buyer selects the custom onsite payment method.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.payment-option-item.details.render",
+          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.payment-option-item.details.render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
+          "description": "A static extension target that renders the form fields for a payment method when selected by the buyer.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.payment-option-item.hosted-fields.render-after",
+          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.payment-option-item.hosted-fields.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders after the hosted fields of a credit card payment method.",
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.pickup-location-list.render-after",
+          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-location-list.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after pickup location options."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.pickup-location-list.render-before",
+          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-location-list.render-before'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered before pickup location options."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.pickup-location-option-item.render-after",
+          "value": "RenderExtension<\n    PickupLocationItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-location-option-item.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after the pickup location details within the local pickup option list, for each option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.pickup-point-list.render-after",
+          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-point-list.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately after the pickup points."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.pickup-point-list.render-before",
+          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-point-list.render-before'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered immediately before the pickup points."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.reductions.render-after",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.reductions.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered in the order summary, after the discount form and discount tag elements."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.reductions.render-before",
+          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.reductions.render-before'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered in the order summary, before the discount form element."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.shipping-option-item.details.render",
+          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-item.details.render'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered under the shipping method within the shipping method option list, for each option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.shipping-option-item.render-after",
+          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-item.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after the shipping method details within the shipping method option list, for each option."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.shipping-option-list.render-after",
+          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-list.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after the shipping method options."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.checkout.shipping-option-list.render-before",
+          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-list.render-before'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered between the shipping method header and shipping method options."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.announcement.render",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.announcement.render'>,\n    AnyThankYouComponent\n  >",
+          "description": "A static extension target that is rendered on top of the **Thank you page** as a dismissable announcement."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.block.render",
+          "value": "RenderExtension<\n    OrderConfirmationApi & StandardApi<'purchase.thank-you.block.render'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Thank you** page. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.cart-line-item.render-after",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      CartLineItemApi &\n      StandardApi<'purchase.thank-you.cart-line-item.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that renders on every line item, inside the details under the line item properties element on the **Thank you** page."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.cart-line-list.render-after",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.cart-line-list.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after all line items on the **Thank you** page."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.chat.render",
+          "value": "RenderExtension<\n    OrderConfirmationApi & StandardApi<'purchase.thank-you.chat.render'>,\n    AllowedComponents<'Chat'>\n  >",
+          "description": "A static extension target that is rendered on top of the **Thank you page** as an overlay. It is positioned in the bottom right corner of the screen."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.customer-information.render-after",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.customer-information.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered after a purchase below the customer information on the **Thank you** page."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.footer.render-after",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.footer.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered below the footer on the **Thank you** page."
+        },
+        {
+          "filePath": "src/surfaces/checkout/extension-targets.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchase.thank-you.header.render-after",
+          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.header.render-after'>,\n    AnyCheckoutComponent\n  >",
+          "description": "A static extension target that is rendered below the header on the **Thank you** page."
+        }
+      ],
+      "value": "export interface ExtensionTargets\n  extends RenderExtensionTargets,\n    RunnableExtensionTargets {}"
+    }
+  },
+  "RenderExtension": {
+    "src/extension.ts": {
+      "filePath": "src/extension.ts",
+      "name": "RenderExtension",
+      "description": "Defines the structure of a render extension, which displays UI in the Shopify admin.",
+      "members": [
+        {
+          "filePath": "src/extension.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "api",
+          "value": "Api",
+          "description": "The API object providing access to extension capabilities, data, and methods. The specific API type depends on the extension target and determines what functionality is available to your extension, such as authentication, storage, data access, and GraphQL querying."
+        },
+        {
+          "filePath": "src/extension.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "components",
+          "value": "ComponentsSet",
+          "description": "The set of UI components available for rendering your extension. This defines which Polaris components and custom components can be used to build your extension's interface. The available components vary by extension target."
+        },
+        {
+          "filePath": "src/extension.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "output",
+          "value": "void | Promise<void>",
+          "description": "The render function output. Your extension's render function should return void or a Promise that resolves to void. Use this to perform any necessary setup, rendering, or async operations when your extension loads."
+        }
+      ],
+      "value": "export interface RenderExtension<Api, ComponentsSet extends string> {\n  /**\n   * The API object providing access to extension capabilities, data, and methods. The specific API type depends on the extension target and determines what functionality is available to your extension, such as authentication, storage, data access, and GraphQL querying.\n   */\n  api: Api;\n  /**\n   * The set of UI components available for rendering your extension. This defines which Polaris components and custom components can be used to build your extension's interface. The available components vary by extension target.\n   */\n  components: ComponentsSet;\n  /**\n   * The render function output. Your extension's render function should return void or a Promise that resolves to void. Use this to perform any necessary setup, rendering, or async operations when your extension loads.\n   */\n  output: void | Promise<void>;\n}"
     }
   },
   "CheckoutApi": {
@@ -5126,6 +4610,244 @@
       "value": "export interface ShippingAddressUpdateChange {\n  /**\n   * Identifies this as a shipping address update. This is the only supported change type for `applyShippingAddressChange()`.\n   */\n  type: 'updateShippingAddress';\n\n  /**\n   * Fields to update in the shipping address. You only need to provide\n   * values for the fields you want to update. Any fields you don't list\n   * keep their current values.\n   */\n  address: Partial<ShippingAddress>;\n}"
     }
   },
+  "ShippingAddress": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "ShippingAddress",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address1",
+          "value": "string",
+          "description": "The first line of the street address, including the street number and name. The value is `undefined` if the buyer hasn't entered an address yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'151 O'Connor Street'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address2",
+          "value": "string",
+          "description": "The second line of the buyer's address, such as apartment number, suite, or unit. The value is `undefined` if the buyer didn't provide a second address line.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ground floor'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "city",
+          "value": "string",
+          "description": "The city, town, or village of the address. The value is `undefined` if the buyer hasn't entered a city yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Ottawa'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "company",
+          "value": "string",
+          "description": "The buyer's company name. The value is `undefined` if the buyer didn't enter a company or the store doesn't collect company names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Shopify'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "countryCode",
+          "value": "CountryCode",
+          "description": "The two-letter country code in [ISO 3166 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if the buyer hasn't selected a country yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CA' for Canada.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "firstName",
+          "value": "string",
+          "description": "The buyer's first name. Use this alongside `lastName` when you need to display or process name parts separately. The value is `undefined` if the buyer didn't provide a first name or the store doesn't collect split names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'John'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lastName",
+          "value": "string",
+          "description": "The buyer's last name. Use this alongside `firstName` when you need to display or process name parts separately. The value is `undefined` if the buyer didn't provide a last name or the store doesn't collect split names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'Doe'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The buyer's full name, typically a combination of first and last name. The value is `undefined` if the buyer didn't provide a name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'John Doe'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "oneTimeUse",
+          "value": "boolean",
+          "description": "Controls whether the address is saved to the buyer's account. When `true`, the address won't be saved and is only used for this checkout. When `false` or `undefined`, the address might be saved to the buyer's account for future use.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "phone",
+          "value": "string",
+          "description": "The phone number associated with the address, typically in international format. The value is `undefined` if the buyer didn't provide a phone number or the store doesn't collect phone numbers.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'+1 613 111 2222'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "provinceCode",
+          "value": "string",
+          "description": "The province, state, prefecture, or region code of the address. The format varies by country. The value is `undefined` if the buyer hasn't selected one yet or the country doesn't have provinces.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'ON' for Ontario.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "zip",
+          "value": "string",
+          "description": "The postal code or ZIP code of the address, used for mail sorting and delivery routing. The value is `undefined` if the buyer hasn't entered one yet or the country doesn't use postal codes.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'K2P 2L8'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface ShippingAddress extends MailingAddress {\n  /**\n   * Controls whether the address is saved to the buyer's account. When\n   * `true`, the address won't be saved and is only used for this checkout.\n   * When `false` or `undefined`, the address might be saved to the buyer's\n   * account for future use.\n   */\n  oneTimeUse?: boolean;\n}"
+    }
+  },
   "ShippingAddressChangeResult": {
     "src/surfaces/checkout/api/checkout/checkout.ts": {
       "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
@@ -5208,806 +4930,267 @@
       "value": "export interface ShippingAddressChangeFieldError {\n  /**\n   * The `MailingAddress` field that caused the error, such as `'countryCode'` or `'zip'`. The value is `undefined` if the error isn't specific to a single field.\n   */\n  field?: keyof MailingAddress;\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It isn't localized and shouldn't be displayed to the buyer.\n   */\n  message: string;\n}"
     }
   },
-  "UseBillingAddressGeneratedType": {
-    "src/surfaces/checkout/preact/billing-address.ts": {
-      "filePath": "src/surfaces/checkout/preact/billing-address.ts",
-      "name": "UseBillingAddressGeneratedType",
-      "description": "Returns the proposed `billingAddress` applied to the checkout.",
-      "isPublicDocs": true,
-      "params": [],
-      "returns": {
-        "filePath": "src/surfaces/checkout/preact/billing-address.ts",
-        "description": "",
-        "name": "MailingAddress | undefined",
-        "value": "MailingAddress | undefined"
-      },
-      "value": "export function useBillingAddress<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>(): MailingAddress | undefined {\n  const billingAddress = useApi<Target>().billingAddress;\n\n  if (!billingAddress) {\n    throw new ScopeNotGrantedError(\n      'Using billing address requires having billing address permissions granted to your app.',\n    );\n  }\n\n  return useSubscription(billingAddress);\n}"
-    }
-  },
-  "UseShippingAddressGeneratedType": {
-    "src/surfaces/checkout/preact/shipping-address.ts": {
-      "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
-      "name": "UseShippingAddressGeneratedType",
-      "description": "Returns the proposed `shippingAddress` applied to the checkout.",
-      "isPublicDocs": true,
-      "params": [],
-      "returns": {
-        "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
-        "description": "",
-        "name": "ShippingAddress | undefined",
-        "value": "ShippingAddress | undefined"
-      },
-      "value": "export function useShippingAddress<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>(): ShippingAddress | undefined {\n  const shippingAddress = useApi<Target>().shippingAddress;\n\n  if (!shippingAddress) {\n    throw new ScopeNotGrantedError(\n      'Using shipping address requires having shipping address permissions granted to your app.',\n    );\n  }\n\n  return useSubscription(shippingAddress);\n}"
-    }
-  },
-  "UseApplyShippingAddressChangeGeneratedType": {
-    "src/surfaces/checkout/preact/shipping-address.ts": {
-      "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
-      "name": "UseApplyShippingAddressChangeGeneratedType",
-      "description": "Returns a function to mutate the `shippingAddress` property of checkout.",
-      "isPublicDocs": true,
-      "params": [],
-      "returns": {
-        "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
-        "description": "",
-        "name": "(change: ShippingAddressChange) => Promise<ShippingAddressChangeResult> | undefined",
-        "value": "(change: ShippingAddressChange) => Promise<ShippingAddressChangeResult> | undefined"
-      },
-      "value": "export function useApplyShippingAddressChange<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>():\n  | ((change: ShippingAddressChange) => Promise<ShippingAddressChangeResult>)\n  | undefined {\n  const api = useApi<Target>();\n\n  if ('applyShippingAddressChange' in api) {\n    return api.applyShippingAddressChange;\n  }\n\n  throw new ExtensionHasNoMethodError(\n    'applyShippingAddressChange',\n    api.extension.target,\n  );\n}"
-    }
-  },
-  "ShippingAddressChange": {
-    "src/surfaces/checkout/api/checkout/checkout.ts": {
-      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "ShippingAddressChange",
-      "value": "ShippingAddressUpdateChange",
-      "description": "The input for `applyShippingAddressChange()`. Currently only supports `ShippingAddressUpdateChange` (with `type: 'updateShippingAddress'`).",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "address",
-          "value": "Partial<ShippingAddress>",
-          "description": "Fields to update in the shipping address. You only need to provide values for the fields you want to update. Any fields you don't list keep their current values."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "type",
-          "value": "'updateShippingAddress'",
-          "description": "Identifies this as a shipping address update. This is the only supported change type for `applyShippingAddressChange()`."
-        }
-      ]
-    }
-  },
-  "AnyComponent": {
-    "src/surfaces/checkout/shared.ts": {
-      "filePath": "src/surfaces/checkout/shared.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "AnyComponent",
-      "value": "(typeof SUPPORTED_COMPONENTS)[number] | PrivateComponent",
-      "description": "",
-      "isPublicDocs": true
-    }
-  },
-  "PrivateComponent": {
-    "src/surfaces/checkout/shared.ts": {
-      "filePath": "src/surfaces/checkout/shared.ts",
-      "syntaxKind": "TypeAliasDeclaration",
-      "name": "PrivateComponent",
-      "value": "'Chat'",
-      "description": "Note: Chat is not supported in the 2025-10 release candidate, but it is tied to a target, and we don't want to remove the target documentation. Once Chat is supported, you can remove this note."
-    }
-  },
-  "CartLineItemApi": {
-    "src/surfaces/checkout/api/cart-line/cart-line-item.ts": {
-      "filePath": "src/surfaces/checkout/api/cart-line/cart-line-item.ts",
-      "name": "CartLineItemApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/cart-line/cart-line-item.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "SubscribableSignalLike<CartLine>",
-          "description": "The cart line that this extension is attached to. Use this to read the line item's merchandise, quantity, cost, and attributes.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties.\n\n> Note: Until version `2023-04`, this property was a `ReadonlySignalLike<PresentmentCartLine>`."
-        }
-      ],
-      "value": "export interface CartLineItemApi {\n  /**\n   * The cart line that this extension is attached to. Use this to read the\n   * line item's merchandise, quantity, cost, and attributes.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   *\n   * > Note: Until version `2023-04`, this property was a `ReadonlySignalLike<PresentmentCartLine>`.\n   */\n  target: SubscribableSignalLike<CartLine>;\n}"
-    }
-  },
-  "PickupLocationListApi": {
-    "src/surfaces/checkout/api/pickup/pickup-location-list.ts": {
-      "filePath": "src/surfaces/checkout/api/pickup/pickup-location-list.ts",
-      "name": "PickupLocationListApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/pickup/pickup-location-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "isLocationFormVisible",
-          "value": "SubscribableSignalLike<boolean>",
-          "description": "Whether the location search form is currently visible to the buyer. Use this to conditionally render UI that depends on the buyer actively searching for pickup locations."
-        }
-      ],
-      "value": "export interface PickupLocationListApi {\n  /**\n   * Whether the location search form is currently visible to the buyer.\n   * Use this to conditionally render UI that depends on the buyer actively\n   * searching for pickup locations.\n   */\n  isLocationFormVisible: SubscribableSignalLike<boolean>;\n}"
-    }
-  },
-  "PickupPointListApi": {
-    "src/surfaces/checkout/api/pickup/pickup-point-list.ts": {
-      "filePath": "src/surfaces/checkout/api/pickup/pickup-point-list.ts",
-      "name": "PickupPointListApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/pickup/pickup-point-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "isLocationFormVisible",
-          "value": "SubscribableSignalLike<boolean>",
-          "description": "Reflects which view was active when the extension loaded. When the buyer moves to the next view, the extension restarts with the current value rather than updating in place."
-        }
-      ],
-      "value": "export interface PickupPointListApi {\n  /**\n   * Reflects which view was active when the extension loaded. When the\n   * buyer moves to the next view, the extension restarts with the\n   * current value rather than updating in place.\n   */\n  isLocationFormVisible: SubscribableSignalLike<boolean>;\n}"
-    }
-  },
-  "PickupLocationItemApi": {
-    "src/surfaces/checkout/api/pickup/pickup-location-item.ts": {
-      "filePath": "src/surfaces/checkout/api/pickup/pickup-location-item.ts",
-      "name": "PickupLocationItemApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/pickup/pickup-location-item.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "isTargetSelected",
-          "value": "SubscribableSignalLike<boolean>",
-          "description": "Whether the buyer has selected the target pickup location. When `true`, the target location is the buyer's active choice. When `false`, the buyer has chosen a different pickup location.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/pickup/pickup-location-item.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "SubscribableSignalLike<PickupLocationOption>",
-          "description": "The pickup location that this extension is attached to. Use this to read the location's name, address, and other details.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
-        }
-      ],
-      "value": "export interface PickupLocationItemApi {\n  /**\n   * The pickup location that this extension is attached to. Use this to read the location's name, address, and other details.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  target: SubscribableSignalLike<PickupLocationOption>;\n\n  /**\n   * Whether the buyer has selected the target pickup location. When `true`, the target location is the buyer's active choice. When `false`, the buyer has chosen a different pickup location.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  isTargetSelected: SubscribableSignalLike<boolean>;\n}"
-    }
-  },
-  "ShippingOptionItemApi": {
-    "src/surfaces/checkout/api/shipping/shipping-option-item.ts": {
-      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
-      "name": "ShippingOptionItemApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "isTargetSelected",
-          "value": "SubscribableSignalLike<boolean>",
-          "description": "Whether the buyer has selected the target shipping option. When `true`, the target option is the buyer's active choice. When `false`, the buyer has chosen a different shipping option.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "renderMode",
-          "value": "ShippingOptionItemRenderMode",
-          "description": "The render mode of this shipping option, indicating how the extension is displayed in the checkout UI."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "SubscribableSignalLike<ShippingOption>",
-          "description": "The shipping option that this extension is attached to. Use this to read the option's cost, carrier, delivery estimate, and other details.\n\nAvailable only on the corresponding item target. Shipping option item targets expose shipping option properties; pickup location item targets expose pickup location properties."
-        }
-      ],
-      "value": "export interface ShippingOptionItemApi {\n  /**\n   * The shipping option that this extension is attached to. Use this to read the option's cost, carrier, delivery estimate, and other details.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  target: SubscribableSignalLike<ShippingOption>;\n\n  /**\n   * Whether the buyer has selected the target shipping option. When `true`, the target option is the buyer's active choice. When `false`, the buyer has chosen a different shipping option.\n   *\n   * Available only on the corresponding item target. Shipping option item\n   * targets expose shipping option properties; pickup location item targets\n   * expose pickup location properties.\n   */\n  isTargetSelected: SubscribableSignalLike<boolean>;\n\n  /**\n   * The render mode of this shipping option, indicating how the extension is displayed in the checkout UI.\n   */\n  renderMode: ShippingOptionItemRenderMode;\n}"
-    }
-  },
-  "ShippingOptionItemRenderMode": {
-    "src/surfaces/checkout/api/shipping/shipping-option-item.ts": {
-      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
-      "name": "ShippingOptionItemRenderMode",
-      "description": "The render mode of a shipping option.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-item.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "overlay",
-          "value": "boolean",
-          "description": "Whether the shipping option is rendered in an overlay. When `true`, the extension appears in a modal or sheet on top of the checkout page. When `false`, the extension renders inline within the shipping options list."
-        }
-      ],
-      "value": "export interface ShippingOptionItemRenderMode {\n  /**\n   * Whether the shipping option is rendered in an overlay. When `true`, the extension appears in a modal or sheet on top of the checkout page. When `false`, the extension renders inline within the shipping options list.\n   */\n  overlay: boolean;\n}"
-    }
-  },
-  "ShippingOptionListApi": {
-    "src/surfaces/checkout/api/shipping/shipping-option-list.ts": {
-      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-      "name": "ShippingOptionListApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "deliverySelectionGroups",
-          "value": "SubscribableSignalLike<\n    DeliverySelectionGroup[] | undefined\n  >",
-          "description": "The list of delivery selection groups available to the buyer, which let buyers choose between grouped delivery options. The value is `undefined` when no selection groups are available."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "SubscribableSignalLike<DeliveryGroupList | undefined>",
-          "description": "The delivery group list that this extension is attached to. Use this to access all delivery groups and their options. The value is `undefined` when there aren't any delivery groups for the given type."
-        }
-      ],
-      "value": "export interface ShippingOptionListApi {\n  /**\n   * The delivery group list that this extension is attached to. Use this to access all delivery groups and their options. The value is `undefined` when there aren't any delivery groups for the given type.\n   */\n  target: SubscribableSignalLike<DeliveryGroupList | undefined>;\n  /**\n   * The list of delivery selection groups available to the buyer, which let buyers choose between grouped delivery options. The value is `undefined` when no selection groups are available.\n   */\n  deliverySelectionGroups: SubscribableSignalLike<\n    DeliverySelectionGroup[] | undefined\n  >;\n}"
-    }
-  },
-  "DeliverySelectionGroup": {
-    "src/surfaces/checkout/api/shipping/shipping-option-list.ts": {
-      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-      "name": "DeliverySelectionGroup",
-      "description": "A named group of delivery options that the buyer can select as a unit.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "associatedDeliveryOptions",
-          "value": "DeliveryOptionReference[]",
-          "description": "The delivery options that belong to this selection group. Each reference's `handle` matches a delivery option handle in the associated delivery group."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "cost",
-          "value": "Money",
-          "description": "The combined cost of all delivery options in this group before discounts."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "costAfterDiscounts",
-          "value": "Money",
-          "description": "The combined cost of all delivery options in this group after discounts have been applied. This is what the buyer actually pays."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "handle",
-          "value": "string",
-          "description": "A unique identifier for this selection group."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "selected",
-          "value": "boolean",
-          "description": "Whether the buyer has selected this delivery selection group. When `true`, the associated delivery options are active. When `false`, the buyer has selected a different group."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "title",
-          "value": "string",
-          "description": "The localized display title of this selection group, suitable for rendering in the checkout UI."
-        }
-      ],
-      "value": "export interface DeliverySelectionGroup {\n  /**\n   * A unique identifier for this selection group.\n   */\n  handle: string;\n  /**\n   * Whether the buyer has selected this delivery selection group. When `true`, the associated delivery options are active. When `false`, the buyer has selected a different group.\n   */\n  selected: boolean;\n  /**\n   * The localized display title of this selection group, suitable for rendering in the checkout UI.\n   */\n  title: string;\n  /**\n   * The delivery options that belong to this selection group. Each reference's `handle` matches a delivery option handle in the associated delivery group.\n   */\n  associatedDeliveryOptions: DeliveryOptionReference[];\n  /**\n   * The combined cost of all delivery options in this group before discounts.\n   */\n  cost: Money;\n  /**\n   * The combined cost of all delivery options in this group after discounts have been applied. This is what the buyer actually pays.\n   */\n  costAfterDiscounts: Money;\n}"
-    }
-  },
-  "DeliveryGroupList": {
-    "src/surfaces/checkout/api/shipping/shipping-option-list.ts": {
-      "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-      "name": "DeliveryGroupList",
-      "description": "A collection of delivery groups that share the same group type.",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "deliveryGroups",
-          "value": "DeliveryGroup[]",
-          "description": "The delivery groups in this list. Each group contains cart lines and available delivery options for those items."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/shipping/shipping-option-list.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "groupType",
-          "value": "DeliveryGroupType",
-          "description": "The type of delivery groups in this list. This is the same `DeliveryGroupType` used on `DeliveryGroup.groupType`.\n\n- `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.\n- `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries."
-        }
-      ],
-      "value": "export interface DeliveryGroupList {\n  /**\n   * The type of delivery groups in this list. This is the same `DeliveryGroupType` used on `DeliveryGroup.groupType`.\n   *\n   * - `'oneTimePurchase'`: Items bought as a single, non-recurring purchase.\n   * - `'subscription'`: Items bought through a [selling plan](/docs/apps/build/purchase-options/subscriptions) that results in recurring deliveries.\n   */\n  groupType: DeliveryGroupType;\n  /**\n   * The delivery groups in this list. Each group contains cart lines and available delivery options for those items.\n   */\n  deliveryGroups: DeliveryGroup[];\n}"
-    }
-  },
-  "AddressAutocompleteFormatSuggestionApi": {
-    "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts": {
-      "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
-      "name": "AddressAutocompleteFormatSuggestionApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "Target",
-          "description": "The autocomplete suggestion that the buyer selected during checkout.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        }
-      ],
-      "value": "export interface AddressAutocompleteFormatSuggestionApi {\n  /**\n   * The autocomplete suggestion that the buyer selected during checkout.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  target: Target;\n}"
-    }
-  },
-  "Target": {
-    "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts": {
-      "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
-      "name": "Target",
+  "StandardApi": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "StandardApi",
       "description": "",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/format-suggestion.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "selectedSuggestion",
-          "value": "AddressAutocompleteSuggestion",
-          "description": ""
-        }
-      ],
-      "value": "interface Target {\n  selectedSuggestion: AddressAutocompleteSuggestion;\n}"
-    }
-  },
-  "AddressAutocompleteSuggestion": {
-    "src/surfaces/checkout/api/address-autocomplete/shared.ts": {
-      "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-      "name": "AddressAutocompleteSuggestion",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "formattedAddress",
-          "value": "AutocompleteAddress",
-          "description": "The address object used to auto-populate the remaining address fields.\n\nIf this value is returned for every suggestion, then the `purchase.address-autocomplete.format-suggestion` extension target is not needed.",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "id",
-          "value": "string",
-          "description": "A textual identifier that uniquely identifies an autocomplete suggestion or address. This identifier may be used to search for a formatted address.",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "\"35ef8d55-dceb-4ed8-847b-2f2fc7472f14\"",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "label",
-          "value": "string",
-          "description": "The address suggestion text presented to the buyer in the list of autocomplete suggestions.\n\nThis text is shown to the buyer as-is. No attempts will be made to parse it.",
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "\"123 Main St, Toronto, ON, CA\"",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "matchedSubstrings",
-          "value": "MatchedSubstring[]",
-          "description": "A list of substrings that matched the original search query.\n\nIf `matchedSubstrings` are provided, then they will be used to highlight the substrings of the suggestions that matched the original search query.",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "[{offset: 0, length: 4}]",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface AddressAutocompleteSuggestion {\n  /**\n   * The address suggestion text presented to the buyer in the list of autocomplete suggestions.\n   *\n   * This text is shown to the buyer as-is. No attempts will be made to parse it.\n   *\n   * @example \"123 Main St, Toronto, ON, CA\"\n   */\n  label: string;\n\n  /**\n   * A textual identifier that uniquely identifies an autocomplete suggestion\n   * or address. This identifier may be used to search for a formatted address.\n   *\n   * @example \"35ef8d55-dceb-4ed8-847b-2f2fc7472f14\"\n   */\n  id?: string;\n\n  /**\n   * A list of substrings that matched the original search query.\n   *\n   * If `matchedSubstrings` are provided, then they will be used to highlight the substrings\n   * of the suggestions that matched the original search query.\n   *\n   * @example [{offset: 0, length: 4}]\n   */\n  matchedSubstrings?: MatchedSubstring[];\n\n  /**\n   * The address object used to auto-populate the remaining address fields.\n   *\n   * If this value is returned for every suggestion, then the\n   * `purchase.address-autocomplete.format-suggestion` extension target is not needed.\n   */\n  formattedAddress?: AutocompleteAddress;\n}"
-    }
-  },
-  "AutocompleteAddress": {
-    "src/surfaces/checkout/api/address-autocomplete/shared.ts": {
-      "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-      "name": "AutocompleteAddress",
-      "description": "An address object used to auto-populate the address form fields.\n\nAll fields are optional",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "address1",
-          "value": "string",
-          "description": "The first line of the street address, including the street number and name. The value is `undefined` if the buyer hasn't entered an address yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'151 O'Connor Street'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "address2",
-          "value": "string",
-          "description": "The second line of the buyer's address, such as apartment number, suite, or unit. The value is `undefined` if the buyer didn't provide a second address line.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Ground floor'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "city",
-          "value": "string",
-          "description": "The city, town, or village of the address. The value is `undefined` if the buyer hasn't entered a city yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Ottawa'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "company",
-          "value": "string",
-          "description": "The buyer's company name. The value is `undefined` if the buyer didn't enter a company or the store doesn't collect company names.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'Shopify'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "countryCode",
-          "value": "CountryCode",
-          "description": "The two-letter country code in [ISO 3166 Alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if the buyer hasn't selected a country yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'CA' for Canada.",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "latitude",
-          "value": "number",
-          "description": "The latitude coordinates of the buyer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "43.6556377",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "longitude",
-          "value": "number",
-          "description": "The longitude coordinates of the buyer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "-79.38681079999999",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "provinceCode",
-          "value": "string",
-          "description": "The province, state, prefecture, or region code of the address. The format varies by country. The value is `undefined` if the buyer hasn't selected one yet or the country doesn't have provinces.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'ON' for Ontario.",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "zip",
-          "value": "string",
-          "description": "The postal code or ZIP code of the address, used for mail sorting and delivery routing. The value is `undefined` if the buyer hasn't entered one yet or the country doesn't use postal codes.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true,
-          "examples": [
-            {
-              "title": "Example",
-              "description": "",
-              "tabs": [
-                {
-                  "code": "'K2P 2L8'",
-                  "title": "Example"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "value": "export interface AutocompleteAddress\n  extends Pick<\n    MailingAddress,\n    | 'address1'\n    | 'address2'\n    | 'city'\n    | 'company'\n    | 'countryCode'\n    | 'provinceCode'\n    | 'zip'\n  > {\n  /**\n   * The latitude coordinates of the buyer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 43.6556377\n   */\n  latitude?: number;\n\n  /**\n   * The longitude coordinates of the buyer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example -79.38681079999999\n   */\n  longitude?: number;\n}"
-    }
-  },
-  "MatchedSubstring": {
-    "src/surfaces/checkout/api/address-autocomplete/shared.ts": {
-      "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-      "name": "MatchedSubstring",
-      "description": "",
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "length",
-          "value": "number",
-          "description": "The length of the matched substring in the suggestion label text."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/shared.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "offset",
-          "value": "number",
-          "description": "The start location of the matched substring in the suggestion label text."
-        }
-      ],
-      "value": "export interface MatchedSubstring {\n  /**\n   * The start location of the matched substring in the suggestion label text.\n   */\n  offset: number;\n  /**\n   * The length of the matched substring in the suggestion label text.\n   */\n  length: number;\n}"
-    }
-  },
-  "AddressAutocompleteSuggestApi": {
-    "src/surfaces/checkout/api/address-autocomplete/suggest.ts": {
-      "filePath": "src/surfaces/checkout/api/address-autocomplete/suggest.ts",
-      "name": "AddressAutocompleteSuggestApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/suggest.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "signal",
-          "value": "AbortSignal",
-          "description": "The signal that the extension should listen to for cancellation requests.\n\nIf the signal is aborted, the extension should cancel any ongoing requests. The signal will be aborted either when the buyer navigates away from the address field or when the debounced query value changes.\n\nPass this signal to any asynchronous operations that need to be cancelled, like `fetch`."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/suggest.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "target",
-          "value": "Target",
-          "description": "The current state of the address form that the buyer is interacting with.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
-        }
-      ],
-      "value": "export interface AddressAutocompleteSuggestApi {\n  /**\n   * The signal that the extension should listen to for cancellation requests.\n   *\n   * If the signal is aborted, the extension should cancel any ongoing requests.\n   * The signal will be aborted either when the buyer navigates away from the\n   * address field or when the debounced query value changes.\n   *\n   * Pass this signal to any asynchronous operations that need to be cancelled,\n   * like `fetch`.\n   */\n  signal: AbortSignal;\n\n  /**\n   * The current state of the address form that the buyer is interacting with.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  target: Target;\n}"
-    }
-  },
-  "AddressAutocompleteStandardApi": {
-    "src/surfaces/checkout/api/address-autocomplete/standard.ts": {
-      "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-      "name": "AddressAutocompleteStandardApi",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "analytics",
           "value": "Analytics",
-          "description": "The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event."
+          "description": "Tracks custom events and sends visitor information to [Web Pixels](/docs/apps/marketing). Use `publish()` to emit events and `visitor()` to submit buyer contact details."
         },
         {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "appliedGiftCards",
+          "value": "SubscribableSignalLike<AppliedGiftCard[]>",
+          "description": "The gift cards that have been applied to the checkout. Each entry includes the last four characters of the gift card code, the amount used at checkout, and the card's remaining balance."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "applyTrackingConsentChange",
+          "value": "ApplyTrackingConsentChangeType",
+          "description": "Enables setting and updating customer privacy consent settings and tracking consent metafields.\n\n> Note: Requires the [`collect_buyer_consent` capability](/docs/apps/build/customer-accounts/capabilities#collect-buyer-consent) to be set to `true`.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "appMetafields",
-          "value": "AppMetafieldEntry[]",
-          "description": "The metafields requested in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file. These metafields are updated when there's a change in the merchandise items being purchased by the customer.\n\nApp owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` is not supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n\n> Tip: > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.*"
+          "value": "SubscribableSignalLike<AppMetafieldEntry[]>",
+          "description": "The metafields requested in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file. These metafields are updated when there's a change in the merchandise items being purchased by the customer.\n\nApp owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` isn't supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
         },
         {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "attributes",
-          "value": "Attribute[] | undefined",
-          "description": "The custom attributes left by the customer to the merchant, either in their cart or during checkout."
+          "value": "SubscribableSignalLike<Attribute[]>",
+          "description": "The custom key-value attributes attached to the cart or checkout. These are set by the buyer or by an extension using `applyAttributeChange()`. The list is empty if no attributes have been added."
         },
         {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "availablePaymentOptions",
+          "value": "SubscribableSignalLike<PaymentOption[]>",
+          "description": "All payment options available to the buyer for this checkout, such as credit cards, wallets, and local payment methods. The list depends on the shop's payment configuration and the buyer's region.\n\nThe set of payment options can change when the buyer updates their address or cart, so subscribe to changes rather than reading once during initialization. Each option exposes `handle` and `type` only. Provider names, logos, fees, and installment terms aren't available."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "billingAddress",
-          "value": "MailingAddress | undefined",
-          "description": "The proposed customer billing address. The address updates when the field is committed (on change) rather than every keystroke.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "value": "SubscribableSignalLike<MailingAddress | undefined>",
+          "description": "The proposed customer billing address. The address updates when the field is committed (on change) rather than every keystroke. The property is available only if the extension has access to protected customer data. The subscribable value is `undefined` if the billing address hasn't been provided yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
           "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "checkoutToken",
-          "value": "CheckoutToken | undefined",
-          "description": "A stable ID that represents the current checkout.\n\nThis matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data) and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object)."
+          "name": "buyerIdentity",
+          "value": "BuyerIdentity",
+          "description": "Information about the buyer that's interacting with the checkout. The property is available only if the extension has access to protected customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "buyerJourney",
+          "value": "BuyerJourney",
+          "description": "Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "checkoutSettings",
+          "value": "SubscribableSignalLike<CheckoutSettings>",
+          "description": "Settings applied to the buyer's checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "checkoutToken",
+          "value": "SubscribableSignalLike<CheckoutToken | undefined>",
+          "description": "A stable ID that represents the current checkout.\n\nThe value is `undefined` when the checkout hasn't been created on the server yet.\n\nUse this to correlate checkout sessions across your extension, web pixels, and backend systems.\n\nThis matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data) and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).\n\nCan be `undefined`. Handle the `undefined` state before using the value."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cost",
+          "value": "CartCost",
+          "description": "The cost breakdown for the current checkout, including subtotal, shipping, tax, and total amounts. These values update as the buyer progresses through checkout and costs like shipping and tax are calculated."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "customerPrivacy",
+          "value": "SubscribableSignalLike<CustomerPrivacy>",
+          "description": "Customer privacy consent settings and a flag denoting if consent has previously been collected."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryGroups",
+          "value": "SubscribableSignalLike<DeliveryGroup[]>",
+          "description": "The delivery groups for this checkout. Each group contains one or more cart lines and the available delivery options (shipping, pickup point, or pickup location) for those items.\n\nEmpty until the buyer enters enough address information for Shopify to calculate shipping rates."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountAllocations",
+          "value": "SubscribableSignalLike<CartDiscountAllocation[]>",
+          "description": "The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from [Shopify Functions](/docs/apps/build/functions). Each allocation indicates how much was discounted and how the discount was triggered."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discountCodes",
+          "value": "SubscribableSignalLike<CartDiscountCode[]>",
+          "description": "The discount codes currently applied to the checkout. The list is empty if no discount codes have been applied. Use `applyDiscountCodeChange()` to add or remove codes."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "extension",
           "value": "Extension<Target>",
-          "description": "The meta information about the extension."
+          "description": "Metadata about the running extension, including the current target, API version, capabilities, and editor context. Use this to conditionally render content based on where the extension is running."
         },
         {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "i18n",
-          "value": "I18n",
-          "description": "Utilities for translating content and formatting values according to the current [`localization`](/docs/api/checkout-ui-extensions/apis/localization) Type 'RunnableExtensionInstance<keyof RunnableExtensionTargets>' is not assignable to type 'ExtensionInstance<Target>'.\n\nRefer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples) for more information."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "localization",
-          "value": "Localization",
-          "description": "The details about the location, language, and currency of the customer. For utilities to easily format and translate content based on these details, you can use the [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#properties-propertydetail-i18n) object instead."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "metafields",
-          "value": "Metafield[]",
-          "description": "The metafields that apply to the current checkout.\n\nMetafields are stored locally on the client and are applied to the order object after the checkout completes. They are shared by all extensions running on checkout, and persist for as long as the customer is working on this checkout.\n\nOnce the order is created, you can query these metafields using the [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n\n> Caution: `metafields` is deprecated. Use `appMetafields` with cart metafields instead.",
-          "deprecationMessage": "Use `appMetafields` with cart metafields instead."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "query",
-          "value": "<Data = unknown, Variables = Record<string, unknown>>(query: string, options?: { variables?: Variables; version?: StorefrontApiVersion; }) => Promise<{ data?: Data; errors?: GraphQLError[]; }>",
-          "description": "The method used to query the Storefront GraphQL API with a prefetched token.\n\nRefer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "sessionToken",
-          "value": "SessionToken",
-          "description": "The session token providing a set of claims as a signed JSON Web Token (JWT).\n\nThe token has a TTL of 5 minutes.\n\nIf the previous token expires, this value will reflect a new session token with a new signature and expiry.\n\nLearn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "settings",
-          "value": "ExtensionSettings",
-          "description": "The settings matching the settings definition written in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.\n\n Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.\n\n> Note: The settings are empty when an extension is being installed in the [checkout editor](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-editor)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "shippingAddress",
-          "value": "MailingAddress | undefined",
-          "description": "The proposed customer shipping address. During the information step, the address updates when the field is committed (on change) rather than every keystroke.\n\n> Note: An address value is only present if delivery is required. Otherwise, the subscribable value is undefined.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
-          "isOptional": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "shop",
-          "value": "Shop",
-          "description": "The shop where the checkout is taking place."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "storage",
-          "value": "Storage",
-          "description": "The key-value storage for the extension.\n\nIt uses `localStorage` and should persist across the customer's current checkout session.\n\n> Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.\n\nData is shared across all activated extension targets of this extension. In versions 2023-07 and earlier, each activated extension target had its own storage."
-        },
-        {
-          "filePath": "src/surfaces/checkout/api/address-autocomplete/standard.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "version",
-          "value": "Version",
-          "description": "The runner version being used for the extension.",
+          "name": "extensionPoint",
+          "value": "Target",
+          "description": "The identifier that specifies where in Shopify's UI your code is being injected. This is one of the targets you've included in your extension's configuration file.",
+          "deprecationMessage": "Use `extension.target` instead.",
           "examples": [
             {
               "title": "Example",
               "description": "",
               "tabs": [
                 {
-                  "code": "'unstable'",
+                  "code": "'purchase.checkout.block.render'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "i18n",
+          "value": "I18n",
+          "description": "Utilities for translating strings, formatting currencies, numbers, and dates according to the buyer's locale. Use alongside [`localization`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization) to build fully localized extensions."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "instructions",
+          "value": "SubscribableSignalLike<CartInstructions>",
+          "description": "The cart instructions used to create the checkout and possibly limit extension capabilities.\n\nThese instructions should be checked before performing any actions that might be affected by them.\n\nFor example, if you intend to add a discount code via the `applyDiscountCodeChange` method, check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.\n\n> Caution: Check cart instructions before calling select APIs, as > some may not be available. See the > [Cart Instructions API](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples) > for more information."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lines",
+          "value": "SubscribableSignalLike<CartLine[]>",
+          "description": "The list of line items the buyer intends to purchase. Each entry includes the merchandise, quantity, cost, and any custom attributes. Use `applyCartLinesChange()` to add, remove, or update line items."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "localization",
+          "value": "Localization",
+          "description": "The buyer's language, country, currency, and timezone context. For formatting and translation helpers, use the [`i18n`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization#properties-propertydetail-i18n) object instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "localizedFields",
+          "value": "SubscribableSignalLike<LocalizedField[]>",
+          "description": "Additional region-specific fields required during checkout, such as tax identification numbers (Brazil's CPF/CNPJ) or customs credentials. The property is available only if the extension has access to protected customer data. The array is empty if the current checkout doesn't require any localized fields.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "SubscribableSignalLike<Metafield[]>",
+          "description": "The metafields that apply to the current checkout.\n\nMetafields are stored locally on the client and are applied to the order object after the checkout completes.\n\nThese metafields are shared by all extensions running on checkout, and persist for as long as the customer is working on this checkout.\n\nOnce the order is created, you can query these metafields using the [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n\n> Caution: `metafields` is deprecated. Use `appMetafields` with cart metafields instead.",
+          "deprecationMessage": "Use `appMetafields` with cart metafields instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "note",
+          "value": "SubscribableSignalLike<string | undefined>",
+          "description": "A note left by the customer to the merchant, either in their cart or during checkout.\n\nThe value is `undefined` if the buyer hasn't entered a note. Use this to display or react to order-level instructions such as delivery preferences or gift messages."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "<Data = unknown, Variables = Record<string, unknown>>(query: string, options?: { variables?: Variables; version?: StorefrontApiVersion; }) => Promise<{ data?: Data; errors?: GraphQLError[]; }>",
+          "description": "The method used to query the Storefront GraphQL API with a prefetched token."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "selectedPaymentOptions",
+          "value": "SubscribableSignalLike<SelectedPaymentOption[]>",
+          "description": "The payment options the buyer has currently selected. This updates as the buyer changes their payment method. The array can contain multiple entries when the buyer splits payment across methods (for example, a gift card and a credit card).\n\nEach option exposes `handle` and `type` only. Provider names, logos, fees, and installment terms aren't available."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionToken",
+          "value": "SessionToken",
+          "description": "The session token providing a set of claims as a signed JSON Web Token (JWT).\n\nThe token has a TTL of five minutes.\n\nIf the previous token expires, this value reflects a new session token with a new signature and expiry.\n\nLearn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "settings",
+          "value": "SubscribableSignalLike<ExtensionSettings>",
+          "description": "The settings matching the settings definition written in the [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file.\n\n Refer to [settings examples](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/settings#examples) for more information.\n\n> Note: When an extension is being installed in the editor, the settings are empty until a merchant sets a value. In that case, this object updates in real time as a merchant fills in the settings."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shippingAddress",
+          "value": "SubscribableSignalLike<ShippingAddress | undefined>",
+          "description": "The proposed customer shipping address. During the information step, the address updates when the field is committed (on change) rather than every keystroke. The property is available only if the extension has access to protected customer data. When available, the subscribable value is `undefined` if delivery isn't required.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "Shop",
+          "description": "The store where the checkout is taking place, including the shop name, storefront URL, `.myshopify.com` subdomain, and a globally-unique ID."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storage",
+          "value": "Storage",
+          "description": "Key-value storage that persists across page loads within the current checkout session. Data is shared across all activated targets associated with this extension.\n\n> Caution: Data persistence isn't guaranteed and storage is cleared when the buyer starts a new checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "version",
+          "value": "Version",
+          "description": "The renderer version being used for the extension.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'2025-10'",
                   "title": "Example"
                 }
               ]
@@ -6015,748 +5198,1482 @@
           ]
         }
       ],
-      "value": "export interface AddressAutocompleteStandardApi<\n  Target extends\n    | 'purchase.address-autocomplete.suggest'\n    | 'purchase.address-autocomplete.format-suggestion',\n> {\n  /**\n   * The metafields requested in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration)\n   * file. These metafields are updated when there's a change in the merchandise items\n   * being purchased by the customer.\n   *\n   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` is not supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * > Tip:\n   * > Cart metafields are only available on carts created via the Storefront API version `2023-04` or later.*\n   */\n  appMetafields: AppMetafieldEntry[];\n\n  /**\n   * The methods for interacting with [Web Pixels](/docs/apps/marketing), such as emitting an event.\n   */\n  analytics: Analytics;\n\n  /**\n   * The custom attributes left by the customer to the merchant, either in their cart or during checkout.\n   */\n  attributes: Attribute[] | undefined;\n\n  /**\n   * The proposed customer billing address. The address updates when the field is\n   * committed (on change) rather than every keystroke.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  billingAddress?: MailingAddress | undefined;\n\n  /**\n   * A stable ID that represents the current checkout.\n   *\n   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)\n   * and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).\n   */\n  checkoutToken: CheckoutToken | undefined;\n\n  /**\n   * The meta information about the extension.\n   */\n  extension: Extension<Target>;\n\n  /**\n   * Utilities for translating content and formatting values according to the current\n   * [`localization`](/docs/api/checkout-ui-extensions/apis/localization)\n   * Type 'RunnableExtensionInstance<keyof RunnableExtensionTargets>' is not assignable to type 'ExtensionInstance<Target>'.\n   *\n   * Refer to [`localization` examples](/docs/api/checkout-ui-extensions/apis/localization#examples)\n   * for more information.\n   */\n  i18n: I18n;\n\n  /**\n   * The details about the location, language, and currency of the customer. For utilities to easily\n   * format and translate content based on these details, you can use the\n   * [`i18n`](/docs/api/checkout-ui-extensions/apis/localization#properties-propertydetail-i18n)\n   * object instead.\n   */\n  localization: Localization;\n\n  /**\n   * The metafields that apply to the current checkout.\n   *\n   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.\n   * They are shared by all extensions running on checkout, and\n   * persist for as long as the customer is working on this checkout.\n   *\n   * Once the order is created, you can query these metafields using the\n   * [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n   *\n   * > Caution:\n   * `metafields` is deprecated. Use `appMetafields` with cart metafields instead.\n   *\n   * @deprecated Use `appMetafields` with cart metafields instead.\n   */\n  metafields: Metafield[];\n\n  /**\n   * The method used to query the Storefront GraphQL API with a prefetched token.\n   *\n   * Refer to [Storefront API access examples](/docs/api/checkout-ui-extensions/apis/storefront-api) for more information.\n   */\n  query: <Data = unknown, Variables = Record<string, unknown>>(\n    query: string,\n    options?: {variables?: Variables; version?: StorefrontApiVersion},\n  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;\n\n  /**\n   * The session token providing a set of claims as a signed JSON Web Token (JWT).\n   *\n   * The token has a TTL of 5 minutes.\n   *\n   * If the previous token expires, this value will reflect a new session token with a new signature and expiry.\n   *\n   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).\n   */\n  sessionToken: SessionToken;\n\n  /**\n   * The settings matching the settings definition written in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/configuration) file.\n   *\n   *  Refer to [settings examples](/docs/api/checkout-ui-extensions/apis/settings#examples) for more information.\n   *\n   * > Note: The settings are empty when an extension is being installed in the [checkout editor](https://help.shopify.com/en/manual/checkout-settings/checkout-extensibility/checkout-editor).\n\n   */\n  settings: ExtensionSettings;\n\n  /**\n   * The proposed customer shipping address. During the information step,\n   * the address updates when the field is committed (on change) rather than every keystroke.\n   *\n   * > Note: An address value is only present if delivery is required. Otherwise, the subscribable value is undefined.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  shippingAddress?: MailingAddress | undefined;\n\n  /** The shop where the checkout is taking place. */\n  shop: Shop;\n\n  /**\n   * The key-value storage for the extension.\n   *\n   * It uses `localStorage` and should persist across the customer's current checkout session.\n   *\n   * > Caution: Data persistence isn't guaranteed and storage is reset when the customer starts a new checkout.\n   *\n   * Data is shared across all activated extension targets of this extension. In versions 2023-07 and earlier,\n   * each activated extension target had its own storage.\n   */\n  storage: Storage;\n\n  /**\n   * The runner version being used for the extension.\n   *\n   * @example 'unstable'\n   */\n  version: Version;\n}"
+      "value": "export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {\n  /**\n   * Tracks custom events and sends visitor information to\n   * [Web Pixels](/docs/apps/marketing). Use `publish()` to emit events\n   * and `visitor()` to submit buyer contact details.\n   */\n  analytics: Analytics;\n\n  /**\n   * The gift cards that have been applied to the checkout. Each entry includes\n   * the last four characters of the gift card code, the amount used at\n   * checkout, and the card's remaining balance.\n   */\n  appliedGiftCards: SubscribableSignalLike<AppliedGiftCard[]>;\n\n  /**\n   * The cart instructions used to create the checkout and possibly limit extension capabilities.\n   *\n   * These instructions should be checked before performing any actions that might be affected by them.\n   *\n   * For example, if you intend to add a discount code via the `applyDiscountCodeChange` method,\n   * check `discounts.canUpdateDiscountCodes` to ensure it's supported in this checkout.\n   *\n   * > Caution: Check cart instructions before calling select APIs, as\n   * > some may not be available. See the\n   * > [Cart Instructions API](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/cart-instructions#examples)\n   * > for more information.\n   *\n   */\n  instructions: SubscribableSignalLike<CartInstructions>;\n\n  /**\n   * The metafields requested in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration)\n   * file. These metafields are updated when there's a change in the merchandise items\n   * being purchased by the customer.\n   *\n   * App owned metafields are supported and are returned using the `$app` format. The fully qualified reserved namespace format such as `app--{your-app-id}[--{optional-namespace}]` isn't supported. See [app owned metafields](/docs/apps/build/custom-data/ownership#reserved-prefixes) for more information.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  appMetafields: SubscribableSignalLike<AppMetafieldEntry[]>;\n\n  /**\n   * The custom key-value attributes attached to the cart or checkout. These are set by the buyer or by an extension using `applyAttributeChange()`. The list is empty if no attributes have been added.\n   */\n  attributes: SubscribableSignalLike<Attribute[]>;\n\n  /**\n   * All payment options available to the buyer for this checkout, such as\n   * credit cards, wallets, and local payment methods. The list depends on\n   * the shop's payment configuration and the buyer's region.\n   *\n   * The set of payment options can change when the buyer updates their\n   * address or cart, so subscribe to changes rather than reading once\n   * during initialization. Each option exposes `handle` and `type` only.\n   * Provider names, logos, fees, and installment terms aren't available.\n   */\n  availablePaymentOptions: SubscribableSignalLike<PaymentOption[]>;\n\n  /**\n   * Information about the buyer that's interacting with the checkout. The property is available only if the extension has access to protected customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  buyerIdentity?: BuyerIdentity;\n\n  /**\n   * Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.\n   */\n  buyerJourney: BuyerJourney;\n\n  /**\n   * Settings applied to the buyer's checkout.\n   */\n  checkoutSettings: SubscribableSignalLike<CheckoutSettings>;\n\n  /**\n   * A stable ID that represents the current checkout.\n   *\n   * The value is `undefined` when the checkout hasn't been created on the server yet.\n   *\n   * Use this to correlate checkout sessions across your extension, web pixels, and backend systems.\n   *\n   * This matches the `data.checkout.token` field in a [checkout-related WebPixel event](/docs/api/web-pixels-api/standard-events/checkout_started#properties-propertydetail-data)\n   * and the `checkout_token` field in the [REST Admin API `Order` resource](/docs/api/admin-rest/unstable/resources/order#resource-object).\n   *\n   * Can be `undefined`. Handle the `undefined` state before using the value.\n   */\n  checkoutToken: SubscribableSignalLike<CheckoutToken | undefined>;\n\n  /**\n   * The cost breakdown for the current checkout, including subtotal, shipping, tax, and total amounts. These values update as the buyer progresses through checkout and costs like shipping and tax are calculated.\n   */\n  cost: CartCost;\n\n  /**\n   * The delivery groups for this checkout. Each group contains one or more cart lines and the available delivery options (shipping, pickup point, or pickup location) for those items.\n   *\n   * Empty until the buyer enters enough address information for Shopify to\n   * calculate shipping rates.\n   */\n  deliveryGroups: SubscribableSignalLike<DeliveryGroup[]>;\n\n  /**\n   * The discount codes currently applied to the checkout. The list is empty if no discount codes have been applied. Use `applyDiscountCodeChange()` to add or remove codes.\n   */\n  discountCodes: SubscribableSignalLike<CartDiscountCode[]>;\n\n  /**\n   * The discount allocations applied to the entire cart, including automatic discounts, code-based discounts, and custom discounts from [Shopify Functions](/docs/apps/build/functions). Each allocation indicates how much was discounted and how the discount was triggered.\n   */\n  discountAllocations: SubscribableSignalLike<CartDiscountAllocation[]>;\n\n  /**\n   * Metadata about the running extension, including the current target, API version,\n   * capabilities, and editor context. Use this to conditionally render content\n   * based on where the extension is running.\n   */\n  extension: Extension<Target>;\n\n  /**\n   * The identifier that specifies where in Shopify's UI your code is being\n   * injected. This is one of the targets you've included in your\n   * extension's configuration file.\n   *\n   * @example 'purchase.checkout.block.render'\n   * @see /docs/api/checkout-ui-extensions/{API_VERSION}/extension-targets-overview\n   * @see /docs/apps/app-extensions/configuration#targets\n   *\n   * @deprecated Use `extension.target` instead.\n   */\n  extensionPoint: Target;\n\n  /**\n   * Utilities for translating strings, formatting currencies, numbers, and dates\n   * according to the buyer's locale. Use alongside\n   * [`localization`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization)\n   * to build fully localized extensions.\n   */\n  i18n: I18n;\n\n  /**\n   * The list of line items the buyer intends to purchase. Each entry includes the merchandise, quantity, cost, and any custom attributes. Use `applyCartLinesChange()` to add, remove, or update line items.\n   */\n  lines: SubscribableSignalLike<CartLine[]>;\n\n  /**\n   * The buyer's language, country, currency, and timezone context. For\n   * formatting and translation helpers, use the\n   * [`i18n`](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/localization#properties-propertydetail-i18n)\n   * object instead.\n   */\n  localization: Localization;\n\n  /**\n   * The metafields that apply to the current checkout.\n   *\n   * Metafields are stored locally on the client and are applied to the order object after the checkout completes.\n   *\n   * These metafields are shared by all extensions running on checkout, and\n   * persist for as long as the customer is working on this checkout.\n   *\n   * Once the order is created, you can query these metafields using the\n   * [GraphQL Admin API](/docs/admin-api/graphql/reference/orders/order#metafield-2021-01)\n   *\n   * > Caution:\n   * `metafields` is deprecated. Use `appMetafields` with cart metafields instead.\n   *\n   * @deprecated Use `appMetafields` with cart metafields instead.\n   */\n  metafields: SubscribableSignalLike<Metafield[]>;\n\n  /**\n   * A note left by the customer to the merchant, either in their cart or during checkout.\n   *\n   * The value is `undefined` if the buyer hasn't entered a note. Use this to display or react to order-level instructions such as delivery preferences or gift messages.\n   */\n  note: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The method used to query the Storefront GraphQL API with a prefetched token.\n   *\n   */\n  query: <Data = unknown, Variables = Record<string, unknown>>(\n    query: string,\n    options?: {variables?: Variables; version?: StorefrontApiVersion},\n  ) => Promise<{data?: Data; errors?: GraphQLError[]}>;\n\n  /**\n   * The payment options the buyer has currently selected. This updates as\n   * the buyer changes their payment method. The array can contain multiple\n   * entries when the buyer splits payment across methods (for example, a\n   * gift card and a credit card).\n   *\n   * Each option exposes `handle` and `type` only. Provider names, logos,\n   * fees, and installment terms aren't available.\n   */\n  selectedPaymentOptions: SubscribableSignalLike<SelectedPaymentOption[]>;\n\n  /**\n   * The session token providing a set of claims as a signed JSON Web Token (JWT).\n   *\n   * The token has a TTL of five minutes.\n   *\n   * If the previous token expires, this value reflects a new session token with a new signature and expiry.\n   *\n   * Learn more about [session tokens](/docs/apps/build/authentication-authorization/session-tokens).\n   */\n  sessionToken: SessionToken;\n\n  /**\n   * The settings matching the settings definition written in the\n   * [`shopify.extension.toml`](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration) file.\n   *\n   *  Refer to [settings examples](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/settings#examples) for more information.\n   *\n   * > Note: When an extension is being installed in the editor, the settings are empty until\n   * a merchant sets a value. In that case, this object updates in real time as a merchant fills in the settings.\n   */\n  settings: SubscribableSignalLike<ExtensionSettings>;\n\n  /**\n   * The proposed customer shipping address. During the information step, the address\n   * updates when the field is committed (on change) rather than every keystroke.\n   * The property is available only if the extension has access to protected customer\n   * data. When available, the subscribable value is `undefined` if delivery isn't required.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  shippingAddress?: SubscribableSignalLike<ShippingAddress | undefined>;\n\n  /**\n   * The proposed customer billing address. The address updates when the field is\n   * committed (on change) rather than every keystroke. The property is available only\n   * if the extension has access to protected customer data. The subscribable value is\n   * `undefined` if the billing address hasn't been provided yet.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  billingAddress?: SubscribableSignalLike<MailingAddress | undefined>;\n\n  /**\n   * The store where the checkout is taking place, including the shop name,\n   * storefront URL, `.myshopify.com` subdomain, and a globally-unique ID.\n   */\n  shop: Shop;\n\n  /**\n   * Key-value storage that persists across page loads within the current checkout\n   * session. Data is shared across all activated targets associated with\n   * this extension.\n   *\n   * > Caution: Data persistence isn't guaranteed and storage is cleared when the\n   * buyer starts a new checkout.\n   */\n  storage: Storage;\n\n  /**\n   * The renderer version being used for the extension.\n   *\n   * @example '2025-10'\n   */\n  version: Version;\n\n  /**\n   * Customer privacy consent settings and a flag denoting if consent has previously been collected.\n   */\n  customerPrivacy: SubscribableSignalLike<CustomerPrivacy>;\n\n  /**\n   * Enables setting and updating customer privacy consent settings and tracking consent metafields.\n   *\n   * > Note: Requires the [`collect_buyer_consent` capability](/docs/apps/build/customer-accounts/capabilities#collect-buyer-consent) to be set to `true`.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  applyTrackingConsentChange: ApplyTrackingConsentChangeType;\n\n  /**\n   * Additional region-specific fields required during checkout, such as tax identification numbers (Brazil's CPF/CNPJ) or customs credentials. The property is available only if the extension has access to protected customer data. The array is empty if the current checkout doesn't require any localized fields.\n   */\n  localizedFields?: SubscribableSignalLike<LocalizedField[]>;\n}"
     }
   },
-  "DocsStyle": {
-    "src/surfaces/checkout/style/style.ts": {
-      "filePath": "src/surfaces/checkout/style/style.ts",
-      "name": "DocsStyle",
+  "AppliedGiftCard": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AppliedGiftCard",
       "description": "",
-      "isPublicDocs": true,
       "members": [
         {
-          "filePath": "src/surfaces/checkout/style/style.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "default",
-          "value": "<T>(defaultValue: T) => StylesConditionalStyle<T, StylesBaseConditions>",
-          "description": "Sets an optional default value to use when no other condition is met."
+          "name": "amountUsed",
+          "value": "Money",
+          "description": "The amount of the applied gift card that's used when the checkout is completed. This might be less than `balance` if the order total is lower than the card's remaining balance."
         },
         {
-          "filePath": "src/surfaces/checkout/style/style.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "when",
-          "value": "<T>(conditions: StylesConditions, value: T) => StylesConditionalStyle<T, StylesBaseConditions>",
-          "description": "Adjusts the style based on different conditions. All conditions, expressed as a literal object, must be met for the associated value to be applied.\n\nThe `when` method can be chained together to build more complex styles."
+          "name": "balance",
+          "value": "Money",
+          "description": "The current balance of the applied gift card before checkout completion. This reflects the full remaining value on the card, not just the amount being applied to this order."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lastCharacters",
+          "value": "string",
+          "description": "The last four characters of the applied gift card's code. The full code isn't exposed for security reasons. Use this value to display which card is applied."
         }
       ],
-      "value": "export interface DocsStyle {\n  /**\n   * Sets an optional default value to use when no other condition is met.\n   *\n   * @param defaultValue The default value\n   * @returns The chainable condition style\n   */\n  default: <T>(defaultValue: T) => StylesConditionalStyle<T>;\n  /**\n   * Adjusts the style based on different conditions. All conditions, expressed\n   * as a literal object, must be met for the associated value to be applied.\n   *\n   * The `when` method can be chained together to build more complex styles.\n   *\n   * @param conditions The condition(s)\n   * @param value The conditional value that can be applied if the conditions are met\n   * @returns The chainable condition style\n   */\n  when: <T>(\n    conditions: StylesConditions,\n    value: T,\n  ) => StylesConditionalStyle<T>;\n}"
+      "value": "export interface AppliedGiftCard {\n  /**\n   * The last four characters of the applied gift card's code. The full code isn't exposed for security reasons. Use this value to display which card is applied.\n   */\n  lastCharacters: string;\n\n  /**\n   * The amount of the applied gift card that's used when the checkout is completed. This might be less than `balance` if the order total is lower than the card's remaining balance.\n   */\n  amountUsed: Money;\n\n  /**\n   * The current balance of the applied gift card before checkout completion. This reflects the full remaining value on the card, not just the amount being applied to this order.\n   */\n  balance: Money;\n}"
     }
   },
-  "StylesConditionalStyle": {
-    "src/surfaces/checkout/style/types.ts": {
-      "filePath": "src/surfaces/checkout/style/types.ts",
-      "name": "StylesConditionalStyle",
+  "ApplyTrackingConsentChangeType": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ApplyTrackingConsentChangeType",
+      "description": "",
+      "params": [
+        {
+          "name": "visitorConsent",
+          "description": "",
+          "value": "VisitorConsentChange",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+        "description": "",
+        "name": "Promise<TrackingConsentChangeResult>",
+        "value": "Promise<TrackingConsentChangeResult>"
+      },
+      "value": "(\n  visitorConsent: VisitorConsentChange,\n) => Promise<TrackingConsentChangeResult>"
+    }
+  },
+  "VisitorConsentChange": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "VisitorConsentChange",
       "description": "",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "conditionals",
-          "value": "StylesConditionalValue<T, AcceptedConditions>[]",
-          "description": "An array of conditional values."
-        },
-        {
-          "filePath": "src/surfaces/checkout/style/types.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "default",
-          "value": "T",
-          "description": "The default value applied when none of the conditional values specified in `conditionals` are met.",
+          "name": "analytics",
+          "value": "boolean",
+          "description": "The visitor's consent for analytics tracking. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
           "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "marketing",
+          "value": "boolean",
+          "description": "The visitor's consent for marketing and targeted advertising. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "TrackingConsentMetafieldChange[]",
+          "description": "Tracking consent metafield data to be saved.\n\nIf the value is `null`, the metafield is deleted.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "`[{key: 'granularAnalytics', value: 'true'}, {key: 'granularMarketing', value: 'false'}]`",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "preferences",
+          "value": "boolean",
+          "description": "The visitor's consent for storing preferences such as language and currency. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "saleOfData",
+          "value": "boolean",
+          "description": "The visitor's consent for the sale or sharing of their personal data with third parties. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'changeVisitorConsent'",
+          "description": "Identifies this as a visitor consent change. This is the only supported change type for `applyTrackingConsentChange()`."
         }
       ],
-      "value": "export interface StylesConditionalStyle<\n  T,\n  AcceptedConditions extends StylesBaseConditions = StylesBaseConditions,\n> {\n  /**\n   * The default value applied when none of the conditional values\n   * specified in `conditionals` are met.\n   */\n  default?: T;\n  /**\n   * An array of conditional values.\n   */\n  conditionals: StylesConditionalValue<T, AcceptedConditions>[];\n}"
+      "value": "export interface VisitorConsentChange extends VisitorConsent {\n  /**\n   * Tracking consent metafield data to be saved.\n   *\n   * If the value is `null`, the metafield is deleted.\n   *\n   * @example `[{key: 'granularAnalytics', value: 'true'}, {key: 'granularMarketing', value: 'false'}]`\n   */\n  metafields?: TrackingConsentMetafieldChange[];\n  /**\n   * Identifies this as a visitor consent change. This is the only supported change type for `applyTrackingConsentChange()`.\n   */\n  type: 'changeVisitorConsent';\n}"
     }
   },
-  "StylesConditionalValue": {
-    "src/surfaces/checkout/style/types.ts": {
-      "filePath": "src/surfaces/checkout/style/types.ts",
-      "name": "StylesConditionalValue",
+  "TrackingConsentMetafieldChange": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentMetafieldChange",
       "description": "",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "conditions",
-          "value": "AcceptedConditions",
-          "description": "The conditions that must be met for the value to be applied. At least one condition must be specified."
+          "name": "key",
+          "value": "string",
+          "description": "The identifier for the tracking consent metafield to update."
         },
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
           "name": "value",
-          "value": "T",
-          "description": "The value that will be applied if the conditions are met."
+          "value": "string | null",
+          "description": "The new value to store in the metafield. Set to `null` to delete the metafield.\n\nConsent metafield values are strings, not booleans. Pass `null` to delete a tracking consent metafield."
         }
       ],
-      "value": "export interface StylesConditionalValue<\n  T,\n  AcceptedConditions extends StylesBaseConditions = StylesBaseConditions,\n> {\n  /**\n   * The conditions that must be met for the value to be applied. At least one\n   * condition must be specified.\n   */\n  conditions: AcceptedConditions;\n  /**\n   * The value that will be applied if the conditions are met.\n   */\n  value: T;\n}"
+      "value": "export interface TrackingConsentMetafieldChange {\n  /**\n   * The identifier for the tracking consent metafield to update.\n   */\n  key: string;\n  /**\n   * The new value to store in the metafield. Set to `null` to delete the metafield.\n   *\n   * Consent metafield values are strings, not booleans. Pass `null` to delete\n   * a tracking consent metafield.\n   */\n  value: string | null;\n}"
     }
   },
-  "StylesBaseConditions": {
-    "src/surfaces/checkout/style/types.ts": {
-      "filePath": "src/surfaces/checkout/style/types.ts",
-      "name": "StylesBaseConditions",
+  "VisitorConsent": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "VisitorConsent",
       "description": "",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "focus",
-          "value": "true",
-          "description": "",
+          "name": "analytics",
+          "value": "boolean",
+          "description": "The visitor's consent for analytics tracking. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
           "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "hover",
-          "value": "true",
-          "description": "",
+          "name": "marketing",
+          "value": "boolean",
+          "description": "The visitor's consent for marketing and targeted advertising. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
           "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "resolution",
-          "value": "1 | 1.3 | 1.5 | 2 | 2.6 | 3 | 3.5 | 4",
-          "description": "",
+          "name": "preferences",
+          "value": "boolean",
+          "description": "The visitor's consent for storing preferences such as language and currency. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
           "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "viewportInlineSize",
-          "value": "{ min: ViewportInlineSize; }",
-          "description": "",
+          "name": "saleOfData",
+          "value": "boolean",
+          "description": "The visitor's consent for the sale or sharing of their personal data with third parties. `true` means the visitor actively granted consent, `false` means actively denied, and `undefined` means no decision has been made yet.",
           "isOptional": true
         }
       ],
-      "value": "export interface StylesBaseConditions {\n  viewportInlineSize?: {min: ViewportInlineSize};\n  hover?: true;\n  focus?: true;\n  resolution?: 1 | 1.3 | 1.5 | 2 | 2.6 | 3 | 3.5 | 4;\n}"
+      "value": "export interface VisitorConsent {\n  /**\n   * The visitor's consent for analytics tracking. `true` means the visitor\n   * actively granted consent, `false` means actively denied, and `undefined`\n   * means no decision has been made yet.\n   */\n  analytics?: boolean;\n  /**\n   * The visitor's consent for marketing and targeted advertising. `true` means\n   * the visitor actively granted consent, `false` means actively denied, and\n   * `undefined` means no decision has been made yet.\n   */\n  marketing?: boolean;\n  /**\n   * The visitor's consent for storing preferences such as language and currency.\n   * `true` means the visitor actively granted consent, `false` means actively\n   * denied, and `undefined` means no decision has been made yet.\n   */\n  preferences?: boolean;\n  /**\n   * The visitor's consent for the sale or sharing of their personal data with\n   * third parties. `true` means the visitor actively granted consent, `false`\n   * means actively denied, and `undefined` means no decision has been made yet.\n   */\n  saleOfData?: boolean;\n}"
     }
   },
-  "ViewportInlineSize": {
-    "src/surfaces/checkout/style/types.ts": {
-      "filePath": "src/surfaces/checkout/style/types.ts",
+  "TrackingConsentChangeResult": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
       "syntaxKind": "TypeAliasDeclaration",
-      "name": "ViewportInlineSize",
-      "value": "'extraSmall' | 'small' | 'medium' | 'large'",
+      "name": "TrackingConsentChangeResult",
+      "value": "TrackingConsentChangeResultSuccess | TrackingConsentChangeResultError",
       "description": ""
     }
   },
-  "StylesConditions": {
-    "src/surfaces/checkout/style/types.ts": {
-      "filePath": "src/surfaces/checkout/style/types.ts",
-      "name": "StylesConditions",
+  "TrackingConsentChangeResultSuccess": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentChangeResultSuccess",
+      "description": "The returned result of a successful tracking consent preference update.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'success'",
+          "description": "Indicates that the tracking consent update was applied successfully."
+        }
+      ],
+      "value": "export interface TrackingConsentChangeResultSuccess {\n  /**\n   * Indicates that the tracking consent update was applied successfully.\n   */\n  type: 'success';\n}"
+    }
+  },
+  "TrackingConsentChangeResultError": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentChangeResultError",
+      "description": "The returned result of an unsuccessful tracking consent preference update with a message detailing the type of error that occurred.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "A message that explains the error. This message is useful for debugging. It isn't localized and shouldn't be displayed to the buyer."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'error'",
+          "description": "Indicates that the tracking consent update couldn't be applied. Check the `message` property for details."
+        }
+      ],
+      "value": "export interface TrackingConsentChangeResultError {\n  /**\n   * Indicates that the tracking consent update couldn't be applied. Check the `message` property for details.\n   */\n  type: 'error';\n\n  /**\n   * A message that explains the error. This message is useful for debugging.\n   * It isn't localized and shouldn't be displayed to the buyer.\n   */\n  message: string;\n}"
+    }
+  },
+  "PaymentOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PaymentOption",
+      "description": "A payment option presented to the buyer.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "A session-scoped identifier for this payment option. This handle isn't globally unique; it's specific to the current checkout session or the shop."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "| 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite'",
+          "description": "The type of the payment option.\n\nShops can be configured to support many different payment options. Some options are available only to buyers in specific regions.\n\n| Type  | Description  |\n|---|---|\n| `creditCard`  |  A vaulted or manually entered credit card.  |\n| `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n| `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n| `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n| `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n| `other`  |  Another type of payment not defined here.  |\n| `paymentOnDelivery`  |  A payment collected on delivery.  |\n| `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n| `wallet`  |  An integrated wallet such as PayPal, Google Pay, or Apple Pay.  |\n| `customOnsite` | A custom payment option that's processed through a checkout extension with a payments app. |"
+        }
+      ],
+      "value": "export interface PaymentOption {\n  /**\n   * The type of the payment option.\n   *\n   * Shops can be configured to support many different payment options. Some options are available only to buyers in specific regions.\n   *\n   * | Type  | Description  |\n   * |---|---|\n   * | `creditCard`  |  A vaulted or manually entered credit card.  |\n   * | `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n   * | `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n   * | `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n   * | `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n   * | `other`  |  Another type of payment not defined here.  |\n   * | `paymentOnDelivery`  |  A payment collected on delivery.  |\n   * | `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n   * | `wallet`  |  An integrated wallet such as PayPal, Google Pay, or Apple Pay.  |\n   * | `customOnsite` | A custom payment option that's processed through a checkout extension with a payments app. |\n   */\n  type:\n    | 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite';\n\n  /**\n   * A session-scoped identifier for this payment option. This handle isn't globally unique; it's specific to the current checkout session or the shop.\n   */\n  handle: string;\n}"
+    }
+  },
+  "BuyerIdentity": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerIdentity",
+      "description": "Information about the buyer who is completing the checkout.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data). The `customer` and `purchasingCompany` properties require level 1 access. The `email` and `phone` properties require level 2 access.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "customer",
+          "value": "SubscribableSignalLike<Customer | undefined>",
+          "description": "The buyer's customer account, including their ID and whether they've accepted marketing. The value is `undefined` if the buyer isn't a known customer for this shop or if they haven't logged in yet.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "email",
+          "value": "SubscribableSignalLike<string | undefined>",
+          "description": "The email address the buyer provided during checkout. The value is `undefined` if the app doesn't have access to customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "phone",
+          "value": "SubscribableSignalLike<string | undefined>",
+          "description": "The phone number the buyer provided during checkout. The value is `undefined` if no phone number was provided or the app doesn't have access to customer data.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "purchasingCompany",
+          "value": "SubscribableSignalLike<PurchasingCompany | undefined>",
+          "description": "The company and company location that a B2B (business-to-business) customer is purchasing on behalf of. Use this to identify the business context of the order. The value is `undefined` if the buyer isn't a B2B customer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface BuyerIdentity {\n  /**\n   * The buyer's customer account, including their ID and whether they've accepted marketing. The value is `undefined` if the buyer isn't a\n   * known customer for this shop or if they haven't logged in yet.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  customer: SubscribableSignalLike<Customer | undefined>;\n\n  /**\n   * The email address the buyer provided during checkout. The value is `undefined` if the app doesn't have access to customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  email: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The phone number the buyer provided during checkout. The value is `undefined` if no phone number was provided or the app doesn't have access to customer data.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  phone: SubscribableSignalLike<string | undefined>;\n\n  /**\n   * The company and company location that a B2B (business-to-business) customer is purchasing on behalf of. Use this to identify the business context of the order. The value is `undefined` if the buyer isn't a B2B customer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  purchasingCompany: SubscribableSignalLike<PurchasingCompany | undefined>;\n}"
+    }
+  },
+  "Customer": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Customer",
+      "description": "Information about a customer who has previously purchased from this shop.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "acceptsEmailMarketing",
+          "value": "boolean",
+          "description": "Whether the customer has opted in to email marketing.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "acceptsMarketing",
+          "value": "boolean",
+          "description": "Whether the customer has opted in to receiving marketing communications from the merchant, such as email campaigns and promotional offers.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n\n> Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.",
+          "deprecationMessage": "Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "acceptsSmsMarketing",
+          "value": "boolean",
+          "description": "Whether the customer has opted in to SMS marketing.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "email",
+          "value": "string",
+          "description": "The email address associated with the customer's account. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "firstName",
+          "value": "string",
+          "description": "The customer's first name. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "fullName",
+          "value": "string",
+          "description": "The customer's full name, typically a combination of first and last name. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "An identifier for the customer in the format `gid://shopify/Customer/<id>`. This value is unique per shop.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/Customer/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "image",
+          "value": "ImageDetails",
+          "description": "The customer's profile image, such as a Gravatar avatar. Use this to personalize the extension UI for the logged-in buyer.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lastName",
+          "value": "string",
+          "description": "The customer's last name. The value is `undefined` if the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "ordersCount",
+          "value": "number",
+          "description": "The number of orders the customer has previously placed with this shop.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "phone",
+          "value": "string",
+          "description": "The phone number associated with the customer's account. The value is `undefined` if no phone number is on file or the app doesn't have the required access level.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storeCreditAccounts",
+          "value": "StoreCreditAccount[]",
+          "description": "The store credit accounts owned by this customer that can be used as payment during checkout. Each account has a balance representing available store credit.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isPrivate": true
+        }
+      ],
+      "value": "export interface Customer {\n  /**\n   * An identifier for the customer in the format `gid://shopify/Customer/<id>`. This value is unique per shop.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'gid://shopify/Customer/123'\n   */\n  id: string;\n  /**\n   * The email address associated with the customer's account. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  email?: string;\n  /**\n   * The phone number associated with the customer's account. The value is `undefined` if no phone number is on file or the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  phone?: string;\n  /**\n   * The customer's full name, typically a combination of first and last name. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  fullName?: string;\n  /**\n   * The customer's first name. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  firstName?: string;\n  /**\n   * The customer's last name. The value is `undefined` if the app doesn't have the required access level.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 2 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  lastName?: string;\n  /**\n   * The customer's profile image, such as a Gravatar avatar. Use this to personalize the extension UI for the logged-in buyer.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  image: ImageDetails;\n  /**\n   * Whether the customer has opted in to receiving marketing communications from the merchant, such as email campaigns and promotional offers.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * > Caution: This field is deprecated and will be removed in a future version. Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.\n   *\n   * @deprecated Use `acceptsEmailMarketing` or `acceptsSmsMarketing` instead.\n   */\n  acceptsMarketing: boolean;\n  /**\n   * Whether the customer has opted in to email marketing.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  acceptsEmailMarketing: boolean;\n  /**\n   * Whether the customer has opted in to SMS marketing.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  acceptsSmsMarketing: boolean;\n  /**\n   * The store credit accounts owned by this customer that can be used as payment during checkout. Each account has a balance representing available store credit.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @private\n   */\n  storeCreditAccounts: StoreCreditAccount[];\n  /**\n   * The number of orders the customer has previously placed with this shop.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  ordersCount: number;\n}"
+    }
+  },
+  "StoreCreditAccount": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "StoreCreditAccount",
+      "description": "A store credit account owned by the customer. Store credit is a form of payment that merchants can issue to customers for returns, refunds, or promotional purposes.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "balance",
+          "value": "Money",
+          "description": "The remaining balance available in this store credit account. This reflects the amount that can still be applied toward purchases."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for the store credit account in the format `gid://shopify/StoreCreditAccount/<id>`.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/StoreCreditAccount/1'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface StoreCreditAccount {\n  /**\n   * A globally-unique identifier for the store credit account in the format `gid://shopify/StoreCreditAccount/<id>`.\n   *\n   * @example 'gid://shopify/StoreCreditAccount/1'\n   */\n  id: string;\n  /**\n   * The remaining balance available in this store credit account. This reflects the amount that can still be applied toward purchases.\n   */\n  balance: Money;\n}"
+    }
+  },
+  "PurchasingCompany": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PurchasingCompany",
+      "description": "The company and location that the [B2B](/docs/apps/build/b2b) customer is purchasing on behalf of. This is present only when the buyer is logged in as a business customer.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "company",
+          "value": "Company",
+          "description": "The company the B2B customer belongs to.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "location",
+          "value": "CompanyLocation",
+          "description": "The specific company location associated with this B2B purchase.\n\n{% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
+        }
+      ],
+      "value": "export interface PurchasingCompany {\n  /**\n   * The company the B2B customer belongs to.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  company: Company;\n  /**\n   * The specific company location associated with this B2B purchase.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  location: CompanyLocation;\n}"
+    }
+  },
+  "Company": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Company",
       "description": "",
       "members": [
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "focus",
-          "value": "true",
-          "description": "",
+          "name": "externalId",
+          "value": "string",
+          "description": "A merchant-defined external identifier for the company. The value is `undefined` if the merchant hasn't set one.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
           "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "hover",
-          "value": "true",
-          "description": "",
-          "isOptional": true
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for the company in the format `gid://shopify/Company/<id>`.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/Company/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
         },
         {
-          "filePath": "src/surfaces/checkout/style/types.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "viewportInlineSize",
-          "value": "{ min: ViewportInlineSize; }",
-          "description": "",
-          "isOptional": true
+          "name": "name",
+          "value": "string",
+          "description": "The company's display name.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
         }
       ],
-      "value": "export interface StylesConditions {\n  viewportInlineSize?: {min: ViewportInlineSize};\n  hover?: true;\n  focus?: true;\n}"
+      "value": "export interface Company {\n  /**\n   * A globally-unique identifier for the company in the format `gid://shopify/Company/<id>`.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'gid://shopify/Company/123'\n   */\n  id: string;\n  /**\n   * The company's display name.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  name: string;\n  /**\n   * A merchant-defined external identifier for the company. The value is `undefined` if the merchant hasn't set one.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  externalId?: string;\n}"
     }
   },
-  "ShopifyGlobal": {
-    "src/surfaces/checkout/globals.ts": {
-      "filePath": "src/surfaces/checkout/globals.ts",
-      "name": "ShopifyGlobal",
+  "CompanyLocation": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CompanyLocation",
       "description": "",
-      "isPublicDocs": true,
       "members": [
         {
-          "filePath": "src/surfaces/checkout/globals.ts",
-          "syntaxKind": "MethodSignature",
-          "name": "extend",
-          "value": "<ExtensionTarget extends keyof ExtensionTargets>(target: ExtensionTarget, extend: () => ExtensionTargets[ExtensionTarget][\"output\"]) => void",
-          "description": ""
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "externalId",
+          "value": "string",
+          "description": "A merchant-defined external identifier for the company location. The value is `undefined` if the merchant hasn't set one.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true
         },
         {
-          "filePath": "src/surfaces/checkout/globals.ts",
-          "syntaxKind": "MethodSignature",
-          "name": "reload",
-          "value": "() => void",
-          "description": ""
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for the company location in the format `gid://shopify/CompanyLocation/<id>`.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/CompanyLocation/123'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The display name of the company location.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data)."
         }
       ],
-      "value": "export interface ShopifyGlobal {\n  extend<ExtensionTarget extends keyof ExtensionTargets>(\n    target: ExtensionTarget,\n    extend: () => ExtensionTargets[ExtensionTarget]['output'],\n  ): void;\n  reload(): void;\n}"
+      "value": "export interface CompanyLocation {\n  /**\n   * A globally-unique identifier for the company location in the format `gid://shopify/CompanyLocation/<id>`.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'gid://shopify/CompanyLocation/123'\n   */\n  id: string;\n  /**\n   * The display name of the company location.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  name: string;\n  /**\n   * A merchant-defined external identifier for the company location. The value is `undefined` if the merchant hasn't set one.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  externalId?: string;\n}"
     }
   },
-  "ExtensionTarget": {
-    "src/surfaces/checkout/extension-targets.ts": {
-      "filePath": "src/surfaces/checkout/extension-targets.ts",
+  "BuyerJourney": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerJourney",
+      "description": "Provides details on the buyer's progression through the checkout.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "activeStep",
+          "value": "SubscribableSignalLike<BuyerJourneyStepReference | undefined>",
+          "description": "The step of checkout the buyer is currently on. The value is `undefined` if the current step can't be determined."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "completed",
+          "value": "SubscribableSignalLike<boolean>",
+          "description": "Whether the buyer has completed submitting their order. When `true`, the buyer is on the order status page after submitting payment. When `false`, the buyer is still in the checkout flow."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "intercept",
+          "value": "(interceptor: Interceptor) => Promise<() => void>",
+          "description": "Installs a function for intercepting and preventing progress on checkout.\n\nThis returns a promise that resolves to a teardown function. Calling the teardown function removes the interceptor.\n\nTo block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#block-progress) capability in your extension's configuration.\n\nIf you do, then you're expected to inform the buyer why navigation was blocked, either by passing validation errors to the checkout UI or rendering the errors in your extension.\n\nIf the merchant hasn't allowed your extension to block checkout progress, show a warning in the [checkout editor](/docs/apps/build/checkout/test-checkout-ui-extensions#test-the-extension-in-the-checkout-editor)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "steps",
+          "value": "SubscribableSignalLike<BuyerJourneyStep[]>",
+          "description": "All possible steps the buyer can take to complete checkout. These steps vary depending on whether the checkout is one-page or three-page, and on the shop's configuration."
+        }
+      ],
+      "value": "export interface BuyerJourney {\n  /**\n   * Installs a function for intercepting and preventing progress on checkout.\n   *\n   * This returns a promise that resolves to a teardown function. Calling the\n   * teardown function removes the interceptor.\n   *\n   * To block checkout progress, you must set the [block_progress](/docs/api/checkout-ui-extensions/{API_VERSION}/configuration#block-progress)\n   * capability in your extension's configuration.\n   *\n   * If you do, then you're expected to inform the buyer why navigation was blocked,\n   * either by passing validation errors to the checkout UI or rendering the errors in your extension.\n   *\n   * If the merchant hasn't allowed your extension to block checkout progress, show a warning in the [checkout editor](/docs/apps/build/checkout/test-checkout-ui-extensions#test-the-extension-in-the-checkout-editor).\n   */\n  intercept(interceptor: Interceptor): Promise<() => void>;\n\n  /**\n   * Whether the buyer has completed submitting their order. When `true`, the buyer is on the order status page after submitting payment. When `false`, the buyer is still in the checkout flow.\n   */\n  completed: SubscribableSignalLike<boolean>;\n  /**\n   * All possible steps the buyer can take to complete checkout. These steps vary depending on whether the checkout is one-page or three-page, and on the shop's configuration.\n   */\n  steps: SubscribableSignalLike<BuyerJourneyStep[]>;\n  /**\n   * The step of checkout the buyer is currently on. The value is `undefined` if the current step can't be determined.\n   */\n  activeStep: SubscribableSignalLike<BuyerJourneyStepReference | undefined>;\n}"
+    }
+  },
+  "BuyerJourneyStepReference": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerJourneyStepReference",
+      "description": "What step of checkout the buyer is currently on.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "BuyerJourneyStepHandle",
+          "description": "The handle identifying which step the buyer is on, such as `'information'`, `'shipping'`, or `'payment'`. See `BuyerJourneyStepHandle` for all values."
+        }
+      ],
+      "value": "interface BuyerJourneyStepReference {\n  /**\n   * The handle identifying which step the buyer is on, such as `'information'`,\n   * `'shipping'`, or `'payment'`. See `BuyerJourneyStepHandle` for all values.\n   */\n  handle: BuyerJourneyStepHandle;\n}"
+    }
+  },
+  "BuyerJourneyStepHandle": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
       "syntaxKind": "TypeAliasDeclaration",
-      "name": "ExtensionTarget",
-      "value": "keyof ExtensionTargets",
-      "description": "",
-      "isPublicDocs": true
+      "name": "BuyerJourneyStepHandle",
+      "value": "'cart' | 'checkout' | 'information' | 'shipping' | 'payment' | 'review' | 'thank-you' | 'unknown'",
+      "description": "| handle  | Description  |\n|---|---|\n| `cart`  |  The cart page.  |\n| `checkout`  |  A one-page checkout, including Shop Pay.  |\n| `information`  |  The contact information step of a three-page checkout.  |\n| `shipping`  |  The shipping step of a three-page checkout.  |\n| `payment`  |  The payment step of a three-page checkout.  |\n| `review`  |  The step after payment where the buyer confirms the purchase. Not all shops are configured to have a review step.  |\n| `thank-you`  |  The page displayed after the purchase, thanking the buyer.  |\n| `unknown` |  An unknown step in the buyer journey.  |"
     }
   },
-  "ExtensionTargets": {
-    "src/surfaces/checkout/extension-targets.ts": {
-      "filePath": "src/surfaces/checkout/extension-targets.ts",
-      "name": "ExtensionTargets",
-      "description": "",
-      "isPublicDocs": true,
-      "members": [
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::Actions::RenderBefore",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Actions::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately before any actions within each step.",
-          "deprecationMessage": "Use `purchase.checkout.actions.render-before` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::CartLineDetails::RenderAfter",
-          "value": "RenderExtension<\n    CheckoutApi &\n      CartLineItemApi &\n      StandardApi<'Checkout::CartLineDetails::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders on every line item, inside the details under the line item properties element.",
-          "deprecationMessage": "Use `purchase.checkout.cart-line-item.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::CartLineDetails::RenderLineComponents",
-          "value": "RenderExtension<\n    CartLineItemApi &\n      StandardApi<'Checkout::CartLineDetails::RenderLineComponents'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders on every bundle line item, inside the details under the line item properties element. It replaces the default bundle products rendering.",
-          "deprecationMessage": "Use `purchase.cart-line-item.line-components.render` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::CartLines::RenderAfter",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::CartLines::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after all line items.",
-          "deprecationMessage": "Use `purchase.checkout.cart-line-list.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::Contact::RenderAfter",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Contact::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately after the contact form element.",
-          "deprecationMessage": "Use `purchase.checkout.contact.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::CustomerInformation::RenderAfter",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::CustomerInformation::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after a purchase below the customer information.",
-          "deprecationMessage": "Use `purchase.thank-you.customer-information.render-after` or\n`customer-account.order-status.customer-information.render-after` from `@shopify/ui-extension/customer-account` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::DeliveryAddress::RenderBefore",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::DeliveryAddress::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered between the shipping address header and shipping address form elements.",
-          "deprecationMessage": "Use `purchase.checkout.delivery-address.render-before` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::Dynamic::Render",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Dynamic::Render'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that isn't tied to a specific checkout section or feature. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets).",
-          "deprecationMessage": "Use `purchase.checkout.block.render` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::GiftCard::Render",
-          "value": "RenderExtension<\n    RedeemableApi & CheckoutApi & StandardApi<'Checkout::GiftCard::Render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
-          "description": "A static extension target that renders the gift card entry form fields after the buyer ticks a box to use a gift card. This does not replace the native gift card entry form which is rendered in a separate part of checkout.",
-          "deprecationMessage": "Use `purchase.checkout.gift-card.render` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::PaymentMethod::HostedFields::RenderAfter",
-          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PaymentMethod::HostedFields::RenderAfter'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
-          "description": "A static extension target that renders after the hosted fields of a credit card payment method. for a credit card payment method when selected by the buyer.",
-          "deprecationMessage": "Use `purchase.checkout.payment-option-item.hosted-fields.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::PaymentMethod::Render",
-          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PaymentMethod::Render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
-          "description": "A static extension target that renders the form fields for a payment method when selected by the buyer.",
-          "deprecationMessage": "Use `purchase.checkout.payment-option-item.details.render` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::PaymentMethod::RenderRequiredAction",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::PaymentMethod::RenderRequiredAction'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders a form modal when a buyer selects the custom onsite payment method.",
-          "deprecationMessage": "Use `purchase.checkout.payment-option-item.action-required.render` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::PickupLocations::RenderAfter",
-          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupLocations::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after pickup location options.",
-          "deprecationMessage": "Use `purchase.checkout.pickup-location-list.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::PickupLocations::RenderBefore",
-          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupLocations::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered before pickup location options.",
-          "deprecationMessage": "Use `purchase.checkout.pickup-location-list.render-before` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::PickupPoints::RenderAfter",
-          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupPoints::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately after the pickup points.",
-          "deprecationMessage": "Use `purchase.checkout.pickup-point-list.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::PickupPoints::RenderBefore",
-          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::PickupPoints::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately before the pickup points.",
-          "deprecationMessage": "Use `purchase.checkout.pickup-point-list.render-before` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::Reductions::RenderAfter",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Reductions::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered in the order summary, after the discount form and discount tag elements.",
-          "deprecationMessage": "Use `purchase.checkout.reductions.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::Reductions::RenderBefore",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'Checkout::Reductions::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered in the order summary, before the discount form element.",
-          "deprecationMessage": "Use `purchase.checkout.reductions.render-before` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ShippingMethodDetails::RenderAfter",
-          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethodDetails::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after the shipping method details within the shipping method option list, for each option.",
-          "deprecationMessage": "Use `purchase.checkout.shipping-option-item.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ShippingMethodDetails::RenderExpanded",
-          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethodDetails::RenderExpanded'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered under the shipping method within the shipping method option list, for each option.",
-          "deprecationMessage": "Use `purchase.checkout.shipping-option-item.details.render` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ShippingMethods::RenderAfter",
-          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethods::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after the shipping method options.",
-          "deprecationMessage": "Use `purchase.checkout.shipping-option-list.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ShippingMethods::RenderBefore",
-          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'Checkout::ShippingMethods::RenderBefore'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered between the shipping method header and shipping method options.",
-          "deprecationMessage": "Use `purchase.checkout.shipping-option-list.render-before` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ThankYou::CartLineDetails::RenderAfter",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      CartLineItemApi &\n      StandardApi<'Checkout::ThankYou::CartLineDetails::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders on every line item, inside the details under the line item properties element on the **Thank you** page.",
-          "deprecationMessage": "Use `purchase.thank-you.cart-line-item.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ThankYou::CartLines::RenderAfter",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'Checkout::ThankYou::CartLines::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after all line items on the **Thank you** page.",
-          "deprecationMessage": "Use `purchase.thank-you.cart-line-list.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ThankYou::CustomerInformation::RenderAfter",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'Checkout::ThankYou::CustomerInformation::RenderAfter'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after a purchase below the customer information on the **Thank you** page.",
-          "deprecationMessage": "Use `purchase.thank-you.customer-information.render-after` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "Checkout::ThankYou::Dynamic::Render",
-          "value": "RenderExtension<\n    OrderConfirmationApi & StandardApi<'Checkout::ThankYou::Dynamic::Render'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Thank you** page. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets).",
-          "deprecationMessage": "Use `purchase.thank-you.block.render` instead.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.address-autocomplete.format-suggestion",
-          "value": "RunnableExtension<\n    AddressAutocompleteStandardApi<'purchase.address-autocomplete.format-suggestion'> &\n      AddressAutocompleteFormatSuggestionApi,\n    AddressAutocompleteFormatSuggestionOutput\n  >",
-          "description": "An extension target that formats the selected address suggestion provided by a `purchase.address-autocomplete.suggest` target. This address is used to auto-populate the fields in the address form.\n\nIt must return a formatted address.\n\nThis target does not support rendering UI components."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.address-autocomplete.suggest",
-          "value": "RunnableExtension<\n    AddressAutocompleteStandardApi<'purchase.address-autocomplete.suggest'> &\n      AddressAutocompleteSuggestApi,\n    AddressAutocompleteSuggestOutput\n  >",
-          "description": "An extension target that provides address autocomplete suggestions. These suggestions are shown to buyers as they interact with address forms during checkout.\n\nIt must return a list of address suggestions. If a formatted address is provided with each suggestion, it will be used to auto-populate the fields in the address form when the buyer selects a suggestion.\n\nThis target does not support rendering UI components."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.cart-line-item.line-components.render",
-          "value": "RenderExtension<\n    CartLineItemApi &\n      StandardApi<'purchase.cart-line-item.line-components.render'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders on every bundle line item, inside the details under the line item properties element. It replaces the default bundle products rendering.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.actions.render-before",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.actions.render-before'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately before any actions within each step."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.block.render",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.block.render'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that isn't tied to a specific checkout section or feature. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.cart-line-item.render-after",
-          "value": "RenderExtension<\n    CheckoutApi &\n      CartLineItemApi &\n      StandardApi<'purchase.checkout.cart-line-item.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders on every line item, inside the details under the line item properties element."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.cart-line-list.render-after",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.cart-line-list.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after all line items."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.chat.render",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.chat.render'>,\n    AllowedComponents<'Chat'>\n  >",
-          "description": "A static extension target that is rendered on top of the checkout page as an overlay. It is positioned in the bottom right corner of the screen."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.contact.render-after",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.contact.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately after the contact form element."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.delivery-address.render-after",
-          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.delivery-address.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after the shipping address form elements."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.delivery-address.render-before",
-          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.delivery-address.render-before'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered between the shipping address header and shipping address form elements."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.footer.render-after",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.footer.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered below the footer."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.gift-card.render",
-          "value": "RenderExtension<\n    RedeemableApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.gift-card.render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
-          "description": "A static extension target that renders the gift card entry form fields after the buyer ticks a box to use a gift card. This does not replace the native gift card entry form which is rendered in a separate part of checkout.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.header.render-after",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.header.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered below the header."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.payment-method-list.render-after",
-          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.payment-method-list.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders below the list of payment methods."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.payment-method-list.render-before",
-          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.payment-method-list.render-before'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders between the payment heading and payment method list."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.payment-option-item.action-required.render",
-          "value": "RenderExtension<\n    CheckoutApi &\n      StandardApi<'purchase.checkout.payment-option-item.action-required.render'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders a form modal when a buyer selects the custom onsite payment method.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.payment-option-item.details.render",
-          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.payment-option-item.details.render'>,\n    AnyCheckoutComponentExcept<'Image' | 'Banner'>\n  >",
-          "description": "A static extension target that renders the form fields for a payment method when selected by the buyer.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.payment-option-item.hosted-fields.render-after",
-          "value": "RenderExtension<\n    PaymentOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.payment-option-item.hosted-fields.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders after the hosted fields of a credit card payment method.",
-          "isPrivate": true
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.pickup-location-list.render-after",
-          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-location-list.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after pickup location options."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.pickup-location-list.render-before",
-          "value": "RenderExtension<\n    PickupLocationListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-location-list.render-before'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered before pickup location options."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.pickup-location-option-item.render-after",
-          "value": "RenderExtension<\n    PickupLocationItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-location-option-item.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after the pickup location details within the local pickup option list, for each option."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.pickup-point-list.render-after",
-          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-point-list.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately after the pickup points."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.pickup-point-list.render-before",
-          "value": "RenderExtension<\n    PickupPointListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.pickup-point-list.render-before'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered immediately before the pickup points."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.reductions.render-after",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.reductions.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered in the order summary, after the discount form and discount tag elements."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.reductions.render-before",
-          "value": "RenderExtension<\n    CheckoutApi & StandardApi<'purchase.checkout.reductions.render-before'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered in the order summary, before the discount form element."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.shipping-option-item.details.render",
-          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-item.details.render'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered under the shipping method within the shipping method option list, for each option."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.shipping-option-item.render-after",
-          "value": "RenderExtension<\n    ShippingOptionItemApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-item.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after the shipping method details within the shipping method option list, for each option."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.shipping-option-list.render-after",
-          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-list.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after the shipping method options."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.checkout.shipping-option-list.render-before",
-          "value": "RenderExtension<\n    ShippingOptionListApi &\n      CheckoutApi &\n      StandardApi<'purchase.checkout.shipping-option-list.render-before'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered between the shipping method header and shipping method options."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.announcement.render",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.announcement.render'>,\n    AnyThankYouComponent\n  >",
-          "description": "A static extension target that is rendered on top of the **Thank you page** as a dismissable announcement."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.block.render",
-          "value": "RenderExtension<\n    OrderConfirmationApi & StandardApi<'purchase.thank-you.block.render'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A [block extension target](/docs/api/checkout-ui-extensions/extension-targets-overview#block-extension-targets) that renders exclusively on the **Thank you** page. Unlike static extension targets, block extension targets render where the merchant sets them using the [checkout editor](/apps/checkout/test-ui-extensions#test-the-extension-in-the-checkout-editor).\n\nThe [supported locations](/docs/api/checkout-ui-extensions/extension-targets-overview#supported-locations) for block extension targets can be previewed during development by [using a URL parameter](/docs/apps/checkout/best-practices/testing-ui-extensions#block-extension-targets)."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.cart-line-item.render-after",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      CartLineItemApi &\n      StandardApi<'purchase.thank-you.cart-line-item.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that renders on every line item, inside the details under the line item properties element on the **Thank you** page."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.cart-line-list.render-after",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.cart-line-list.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after all line items on the **Thank you** page."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.chat.render",
-          "value": "RenderExtension<\n    OrderConfirmationApi & StandardApi<'purchase.thank-you.chat.render'>,\n    AllowedComponents<'Chat'>\n  >",
-          "description": "A static extension target that is rendered on top of the **Thank you page** as an overlay. It is positioned in the bottom right corner of the screen."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.customer-information.render-after",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.customer-information.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered after a purchase below the customer information on the **Thank you** page."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.footer.render-after",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.footer.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered below the footer on the **Thank you** page."
-        },
-        {
-          "filePath": "src/surfaces/checkout/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "purchase.thank-you.header.render-after",
-          "value": "RenderExtension<\n    OrderConfirmationApi &\n      StandardApi<'purchase.thank-you.header.render-after'>,\n    AnyCheckoutComponent\n  >",
-          "description": "A static extension target that is rendered below the header on the **Thank you** page."
+  "Interceptor": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "Interceptor",
+      "description": "A function for intercepting and preventing navigation on checkout. You can block navigation by returning an object with `{behavior: 'block', reason: 'your reason here', errors?: ValidationError[]}`. If you do, then you're expected to also update some part of your UI to reflect the reason why navigation was blocked, either by targeting checkout UI fields, passing errors to the page level, or rendering the errors in your extension.",
+      "params": [
+        {
+          "name": "interceptorProps",
+          "description": "",
+          "value": "InterceptorProps",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts"
         }
       ],
-      "value": "export interface ExtensionTargets\n  extends RenderExtensionTargets,\n    RunnableExtensionTargets {}"
+      "returns": {
+        "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+        "description": "",
+        "name": "InterceptorRequest | Promise<InterceptorRequest>",
+        "value": "InterceptorRequest | Promise<InterceptorRequest>"
+      },
+      "value": "(\n  interceptorProps: InterceptorProps,\n) => InterceptorRequest | Promise<InterceptorRequest>"
     }
   },
-  "RenderExtension": {
-    "src/extension.ts": {
-      "filePath": "src/extension.ts",
-      "name": "RenderExtension",
-      "description": "Defines the structure of a render extension, which displays UI in the Shopify admin.",
+  "InterceptorProps": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorProps",
+      "description": "",
       "members": [
         {
-          "filePath": "src/extension.ts",
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
           "syntaxKind": "PropertySignature",
-          "name": "api",
-          "value": "Api",
-          "description": "The API object providing access to extension capabilities, data, and methods. The specific API type depends on the extension target and determines what functionality is available to your extension, such as authentication, storage, data access, and GraphQL querying."
-        },
-        {
-          "filePath": "src/extension.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "components",
-          "value": "ComponentsSet",
-          "description": "The set of UI components available for rendering your extension. This defines which Polaris components and custom components can be used to build your extension's interface. The available components vary by extension target."
-        },
-        {
-          "filePath": "src/extension.ts",
-          "syntaxKind": "PropertySignature",
-          "name": "output",
-          "value": "void | Promise<void>",
-          "description": "The render function output. Your extension's render function should return void or a Promise that resolves to void. Use this to perform any necessary setup, rendering, or async operations when your extension loads."
+          "name": "canBlockProgress",
+          "value": "boolean",
+          "description": "Whether the interceptor can block the buyer's progress through checkout. When `true`, the merchant has granted your extension the `block_progress` capability. When `false`, you can still validate but can't prevent the buyer from continuing."
         }
       ],
-      "value": "export interface RenderExtension<Api, ComponentsSet extends string> {\n  /**\n   * The API object providing access to extension capabilities, data, and methods. The specific API type depends on the extension target and determines what functionality is available to your extension, such as authentication, storage, data access, and GraphQL querying.\n   */\n  api: Api;\n  /**\n   * The set of UI components available for rendering your extension. This defines which Polaris components and custom components can be used to build your extension's interface. The available components vary by extension target.\n   */\n  components: ComponentsSet;\n  /**\n   * The render function output. Your extension's render function should return void or a Promise that resolves to void. Use this to perform any necessary setup, rendering, or async operations when your extension loads.\n   */\n  output: void | Promise<void>;\n}"
+      "value": "export interface InterceptorProps {\n  /**\n   * Whether the interceptor can block the buyer's progress through checkout. When `true`, the merchant has granted your extension the `block_progress` capability. When `false`, you can still validate but can't prevent the buyer from continuing.\n   */\n  canBlockProgress: boolean;\n}"
+    }
+  },
+  "InterceptorRequest": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "InterceptorRequest",
+      "value": "InterceptorRequestAllow | InterceptorRequestBlock",
+      "description": ""
+    }
+  },
+  "InterceptorRequestAllow": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorRequestAllow",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'allow'",
+          "description": "Indicates that the interceptor allows the buyer's journey to continue."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "perform",
+          "value": "(result: InterceptorResult) => void | Promise<void>",
+          "description": "This callback is called when all interceptors finish. We recommend setting errors or reasons for blocking at this stage, so that all the errors in the UI show up at once.\n\nRuns after all intercept results are collected. Use it for local state updates such as setting an error flag. By the time it runs, the navigation decision is final, so blocking logic belongs in the intercept handler itself, not here.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface InterceptorRequestAllow {\n  /**\n   * Indicates that the interceptor allows the buyer's journey to continue.\n   */\n  behavior: 'allow';\n\n  /**\n   * This callback is called when all interceptors finish. We recommend\n   * setting errors or reasons for blocking at this stage, so that all the errors in\n   * the UI show up at once.\n   *\n   * Runs after all intercept results are collected. Use it for local state\n   * updates such as setting an error flag. By the time it runs, the navigation\n   * decision is final, so blocking logic belongs in the intercept handler\n   * itself, not here.\n   * @param result InterceptorResult with behavior as either 'allow' or 'block'\n   */\n  perform?(result: InterceptorResult): void | Promise<void>;\n}"
+    }
+  },
+  "InterceptorResult": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "InterceptorResult",
+      "value": "InterceptorResultAllow | InterceptorResultBlock",
+      "description": ""
+    }
+  },
+  "InterceptorResultAllow": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorResultAllow",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'allow'",
+          "description": "Indicates that the buyer was allowed to progress through checkout."
+        }
+      ],
+      "value": "interface InterceptorResultAllow {\n  /**\n   * Indicates that the buyer was allowed to progress through checkout.\n   */\n  behavior: 'allow';\n}"
+    }
+  },
+  "InterceptorResultBlock": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorResultBlock",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'block'",
+          "description": "Indicates that some part of the checkout UI intercepted and prevented the buyer's progress. The buyer typically needs to take some action to resolve this issue and to move on to the next step."
+        }
+      ],
+      "value": "interface InterceptorResultBlock {\n  /**\n   * Indicates that some part of the checkout UI intercepted and prevented\n   * the buyer's progress. The buyer typically needs to take some action\n   * to resolve this issue and to move on to the next step.\n   */\n  behavior: 'block';\n}"
+    }
+  },
+  "InterceptorRequestBlock": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "InterceptorRequestBlock",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "behavior",
+          "value": "'block'",
+          "description": "Indicates that the interceptor blocks the buyer's journey from continuing."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "errors",
+          "value": "ValidationError[]",
+          "description": "Used to pass errors to the checkout UI, outside your extension's UI boundaries.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "perform",
+          "value": "(result: InterceptorResult) => void | Promise<void>",
+          "description": "This callback is called when all interceptors finish. We recommend setting errors or reasons for blocking at this stage, so that all the errors in the UI show up at once.\n\nRuns after all intercept results are collected. Use it for local state updates such as setting an error flag. By the time it runs, the navigation decision is final, so blocking logic belongs in the intercept handler itself, not here.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "reason",
+          "value": "string",
+          "description": "The reason for blocking the interceptor request. This value isn't presented to the buyer, so it doesn't need to be localized. The value is used only for Shopify's own internal debugging and metrics."
+        }
+      ],
+      "value": "interface InterceptorRequestBlock {\n  /**\n   * Indicates that the interceptor blocks the buyer's journey from continuing.\n   */\n  behavior: 'block';\n\n  /**\n   * The reason for blocking the interceptor request. This value isn't presented to\n   * the buyer, so it doesn't need to be localized. The value is used only for Shopify's\n   * own internal debugging and metrics.\n   */\n  reason: string;\n\n  /**\n   * Used to pass errors to the checkout UI, outside your extension's UI boundaries.\n   */\n  errors?: ValidationError[];\n\n  /**\n   * This callback is called when all interceptors finish. We recommend\n   * setting errors or reasons for blocking at this stage, so that all the errors in\n   * the UI show up at once.\n   *\n   * Runs after all intercept results are collected. Use it for local state\n   * updates such as setting an error flag. By the time it runs, the navigation\n   * decision is final, so blocking logic belongs in the intercept handler\n   * itself, not here.\n   * @param result InterceptorResult with behavior as either 'allow' or 'block'\n   */\n  perform?(result: InterceptorResult): void | Promise<void>;\n}"
+    }
+  },
+  "ValidationError": {
+    "src/surfaces/checkout/api/shared.ts": {
+      "filePath": "src/surfaces/checkout/api/shared.ts",
+      "name": "ValidationError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": "The error message to display to the buyer. Use this to explain what went wrong and how to fix it."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/shared.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "target",
+          "value": "string",
+          "description": "The checkout UI field that the error is associated with. When provided, checkout highlights the matching field so the buyer knows where to fix the issue. The value is `undefined` if the error isn't tied to a specific field.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'$.cart.deliveryGroups[0].deliveryAddress.countryCode'\n\nSee the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)\nfor more information.",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface ValidationError {\n  /**\n   * The error message to display to the buyer. Use this to explain what\n   * went wrong and how to fix it.\n   */\n  message: string;\n  /**\n   * The checkout UI field that the error is associated with. When provided,\n   * checkout highlights the matching field so the buyer knows where to fix\n   * the issue. The value is `undefined` if the error isn't tied to a\n   * specific field.\n   *\n   * @example '$.cart.deliveryGroups[0].deliveryAddress.countryCode'\n   *\n   * See the [supported targets](/docs/api/functions/reference/cart-checkout-validation/graphql#supported-targets)\n   * for more information.\n   */\n  target?: string;\n}"
+    }
+  },
+  "BuyerJourneyStep": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "BuyerJourneyStep",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "disabled",
+          "value": "boolean",
+          "description": "Whether this step is disabled. When `true`, the buyer hasn't reached this step yet and can't navigate to it. When `false`, the step is accessible.\n\nFor example, if the buyer hasn't reached the `shipping` step yet, then `shipping` is disabled."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "BuyerJourneyStepHandle",
+          "description": "The handle that uniquely identifies the buyer journey step, such as `'information'`, `'shipping'`, or `'payment'`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "label",
+          "value": "string",
+          "description": "The localized label of the buyer journey step, suitable for rendering in navigation UI."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "to",
+          "value": "string",
+          "description": "The URL of the buyer journey step, using the `shopify:` protocol.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'shopify:cart'",
+                  "title": "Example"
+                }
+              ]
+            },
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'shopify:checkout/information'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface BuyerJourneyStep {\n  /**\n   * The handle that uniquely identifies the buyer journey step, such as `'information'`, `'shipping'`, or `'payment'`.\n   */\n  handle: BuyerJourneyStepHandle;\n  /**\n   * The localized label of the buyer journey step, suitable for rendering in navigation UI.\n   */\n  label: string;\n  /**\n   * The URL of the buyer journey step, using the `shopify:` protocol.\n   *\n   * @example 'shopify:cart'\n   * @example 'shopify:checkout/information'\n   */\n  to: string;\n  /**\n   * Whether this step is disabled. When `true`, the buyer hasn't reached this step yet and can't navigate to it. When `false`, the step is accessible.\n   *\n   * For example, if the buyer hasn't reached the `shipping` step yet, then `shipping` is disabled.\n   */\n  disabled: boolean;\n}"
+    }
+  },
+  "CheckoutSettings": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CheckoutSettings",
+      "description": "Settings describing the behavior of the buyer's checkout.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "orderSubmission",
+          "value": "'DRAFT_ORDER' | 'ORDER'",
+          "description": "The type of order created when the buyer completes checkout.\n\n- `'DRAFT_ORDER'`: The checkout creates a draft order that the merchant must manually confirm before fulfillment. Common for B2B checkouts with deferred payment terms.\n- `'ORDER'`: The checkout creates a confirmed order immediately upon completion."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "paymentTermsTemplate",
+          "value": "PaymentTermsTemplate",
+          "description": "The payment terms configured by the merchant for B2B orders, such as net-30 or net-60. The value is `undefined` if no payment terms are configured.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shippingAddress",
+          "value": "ShippingAddressSettings",
+          "description": "Settings that control how the shipping address behaves during checkout, such as whether the buyer can edit the address."
+        }
+      ],
+      "value": "export interface CheckoutSettings {\n  /**\n   * The type of order created when the buyer completes checkout.\n   *\n   * - `'DRAFT_ORDER'`: The checkout creates a draft order that the merchant must manually confirm before fulfillment. Common for B2B checkouts with deferred payment terms.\n   * - `'ORDER'`: The checkout creates a confirmed order immediately upon completion.\n   */\n  orderSubmission: 'DRAFT_ORDER' | 'ORDER';\n  /**\n   * The payment terms configured by the merchant for B2B orders, such as net-30 or net-60. The value is `undefined` if no payment terms are configured.\n   */\n  paymentTermsTemplate?: PaymentTermsTemplate;\n  /**\n   * Settings that control how the shipping address behaves during checkout, such as whether the buyer can edit the address.\n   */\n  shippingAddress: ShippingAddressSettings;\n}"
+    }
+  },
+  "PaymentTermsTemplate": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "PaymentTermsTemplate",
+      "description": "A payment terms template configured by the merchant, defining when payment is due for B2B orders. Common examples include \"Net 30\" (due in 30 days) or \"Due on receipt\".",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "dueDate",
+          "value": "string",
+          "description": "The due date for payment in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DDTHH:mm:ss.sssZ`). The value is `undefined` if the payment terms don't have a fixed due date.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "dueInDays",
+          "value": "number",
+          "description": "The number of days the buyer has to pay after the order is placed, such as `30` for \"Net 30\" terms. The value is `undefined` if the payment terms aren't net-based.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "A globally-unique identifier for the payment terms template in the format `gid://shopify/PaymentTermsTemplate/<id>`.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'gid://shopify/PaymentTermsTemplate/1'",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": "The name of the payment terms translated to the buyer's current language, such as \"Net 30\" or \"Due on receipt\"."
+        }
+      ],
+      "value": "export interface PaymentTermsTemplate {\n  /**\n   * A globally-unique identifier for the payment terms template in the format `gid://shopify/PaymentTermsTemplate/<id>`.\n   *\n   * @example 'gid://shopify/PaymentTermsTemplate/1'\n   */\n  id: string;\n  /**\n   * The name of the payment terms translated to the buyer's current language, such as \"Net 30\" or \"Due on receipt\".\n   */\n  name: string;\n  /**\n   * The due date for payment in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (`YYYY-MM-DDTHH:mm:ss.sssZ`). The value is `undefined` if the payment terms don't have a fixed due date.\n   */\n  dueDate?: string;\n  /**\n   * The number of days the buyer has to pay after the order is placed, such as `30` for \"Net 30\" terms. The value is `undefined` if the payment terms aren't net-based.\n   */\n  dueInDays?: number;\n}"
+    }
+  },
+  "ShippingAddressSettings": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "ShippingAddressSettings",
+      "description": "Settings describing the behavior of the shipping address.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isEditable",
+          "value": "boolean",
+          "description": "Whether the buyer is allowed to edit the shipping address during checkout. When `false`, the shipping address is locked and can't be changed, which is common for B2B orders with a predefined ship-to address."
+        }
+      ],
+      "value": "export interface ShippingAddressSettings {\n  /**\n   * Whether the buyer is allowed to edit the shipping address during checkout. When `false`, the shipping address is locked and can't be changed, which is common for B2B orders with a predefined ship-to address.\n   */\n  isEditable: boolean;\n}"
+    }
+  },
+  "CartCost": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartCost",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subtotalAmount",
+          "value": "SubscribableSignalLike<Money>",
+          "description": "The sum of all line item prices at the current step of checkout, before shipping and taxes are applied. Use this value to display the base cost of the items the buyer purchased."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "totalAmount",
+          "value": "SubscribableSignalLike<Money>",
+          "description": "The minimum total at the current step of checkout. Costs not yet calculated, such as shipping on the information step, aren't included. Gift cards and store credits are excluded from this total."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "totalShippingAmount",
+          "value": "SubscribableSignalLike<Money | undefined>",
+          "description": "The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been calculated yet, such as when the buyer is still on the information step.\n\n`undefined` until the buyer selects a shipping method (typically after the information step)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "totalTaxAmount",
+          "value": "SubscribableSignalLike<Money | undefined>",
+          "description": "The total tax the buyer can expect to pay, or the total tax already included in product and shipping prices (for tax-inclusive regions). The value is `undefined` if taxes haven't been calculated yet.\n\n`undefined` when taxes haven't been calculated or aren't available for the buyer's region."
+        }
+      ],
+      "value": "export interface CartCost {\n  /**\n   * The sum of all line item prices at the current step of checkout, before shipping and taxes are applied. Use this value to display the base cost of the items the buyer purchased.\n   */\n  subtotalAmount: SubscribableSignalLike<Money>;\n\n  /**\n   * The total shipping cost after shipping discounts have been applied. The value is `undefined` if shipping hasn't been calculated yet, such as when the buyer is still on the information step.\n   *\n   * `undefined` until the buyer selects a shipping method (typically after the\n   * information step).\n   */\n  totalShippingAmount: SubscribableSignalLike<Money | undefined>;\n\n  /**\n   * The total tax the buyer can expect to pay, or the total tax already included in product and shipping prices (for tax-inclusive regions). The value is `undefined` if taxes haven't been calculated yet.\n   *\n   * `undefined` when taxes haven't been calculated or aren't available for the\n   * buyer's region.\n   */\n  totalTaxAmount: SubscribableSignalLike<Money | undefined>;\n\n  /**\n   * The minimum total at the current step of checkout. Costs not yet calculated, such as shipping on the information step, aren't included. Gift cards and store credits are excluded from this total.\n   */\n  totalAmount: SubscribableSignalLike<Money>;\n}"
+    }
+  },
+  "CustomerPrivacy": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CustomerPrivacy",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "allowedProcessing",
+          "value": "AllowedProcessing",
+          "description": "Flags indicating whether each type of data processing is permitted, based on the visitor's consent, the merchant's privacy configuration, and the visitor's geographic location."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "TrackingConsentMetafield[]",
+          "description": "The tracking consent metafields that have been stored for this visitor. These contain app-specific consent data beyond the standard categories.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "`[{key: 'analyticsType', value: 'granular'}, {key: 'marketingType', value: 'granular'}]`, or `[]`",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "region",
+          "value": "CustomerPrivacyRegion",
+          "description": "The visitor's geographic location, used to determine whether more granular consent controls should be displayed based on regional privacy regulations.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "`{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "saleOfDataRegion",
+          "value": "boolean",
+          "description": "Whether the visitor is located in a region that requires an explicit opt-out option for the sale or sharing of personal data, such as California (CCPA) or other jurisdictions with similar regulations."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shouldShowBanner",
+          "value": "boolean",
+          "description": "Whether a consent banner should be displayed by default when the page loads. Use this as the initial open/expanded state of the consent banner.\n\nThis is determined by the visitor's current privacy consent, the shop's [region visibility configuration](https://help.shopify.com/en/manual/privacy-and-security/privacy/customer-privacy-settings/privacy-settings#add-a-cookie-banner) settings, and the region in which the visitor is located."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "visitorConsent",
+          "value": "VisitorConsent",
+          "description": "The visitor's current privacy consent settings. Each property represents a consent category and is `true` (actively granted), `false` (actively denied), or `undefined` (no decision made yet)."
+        }
+      ],
+      "value": "export interface CustomerPrivacy {\n  /**\n   * Flags indicating whether each type of data processing is permitted, based on the visitor's consent, the merchant's privacy configuration, and the visitor's geographic location.\n   */\n  allowedProcessing: AllowedProcessing;\n  /**\n   * The tracking consent metafields that have been stored for this visitor. These contain app-specific consent data beyond the standard categories.\n   *\n   * @example `[{key: 'analyticsType', value: 'granular'}, {key: 'marketingType', value: 'granular'}]`, or `[]`\n   */\n  metafields: TrackingConsentMetafield[];\n  /**\n   * The visitor's current privacy consent settings. Each property represents a consent category and is `true` (actively granted), `false` (actively denied), or `undefined` (no decision made yet).\n   */\n  visitorConsent: VisitorConsent;\n  /**\n   * Whether a consent banner should be displayed by default when the page loads. Use this as the initial open/expanded state of the consent banner.\n   *\n   * This is determined by the visitor's current privacy consent, the shop's [region visibility configuration](https://help.shopify.com/en/manual/privacy-and-security/privacy/customer-privacy-settings/privacy-settings#add-a-cookie-banner) settings, and the region in which the visitor is located.\n   */\n  shouldShowBanner: boolean;\n  /**\n   * Whether the visitor is located in a region that requires an explicit opt-out option for the sale or sharing of personal data, such as California (CCPA) or other jurisdictions with similar regulations.\n   */\n  saleOfDataRegion: boolean;\n  /**\n   * The visitor's geographic location, used to determine whether more granular consent controls should be displayed based on regional privacy regulations.\n   *\n   * @example `{countryCode: 'CA', provinceCode: 'ON'}` for a visitor in Ontario, Canada; `{countryCode: 'US', provinceCode: undefined}` for a visitor in the United States if geolocation fails to detect the state; or `undefined` if neither country nor province is detected or geolocation fails.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   */\n  region?: CustomerPrivacyRegion;\n}"
+    }
+  },
+  "AllowedProcessing": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AllowedProcessing",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "analytics",
+          "value": "boolean",
+          "description": "Whether analytics data can be collected based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. Analytics data includes how the shop was used and what interactions occurred.\n\nWhether analytics data can be collected right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.analytics`, before calling `shopify.analytics.publish()`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "marketing",
+          "value": "boolean",
+          "description": "Whether marketing data can be collected based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. Marketing data includes attribution and targeted advertising preferences.\n\nWhether marketing data can be collected right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.marketing`, before performing marketing-related data collection."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "preferences",
+          "value": "boolean",
+          "description": "Whether preference data can be collected based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. Preference data includes language, currency, and sizing choices.\n\nWhether preference data can be collected right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.preferences`, before storing or reading buyer preference data."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "saleOfData",
+          "value": "boolean",
+          "description": "Whether data can be shared with third parties based on the visitor's consent, the merchant's privacy configuration, and the visitor's region. This typically applies to behavioral advertising data.\n\nWhether buyer data can be shared with or sold to third parties right now. Combines the buyer's consent, the merchant's privacy configuration, and the buyer's region into a single boolean. Check this flag, not `visitorConsent.saleOfData`, before sharing or selling buyer data with third parties."
+        }
+      ],
+      "value": "export interface AllowedProcessing {\n  /**\n   * Whether analytics data can be collected based on the visitor's consent,\n   * the merchant's privacy configuration, and the visitor's region. Analytics\n   * data includes how the shop was used and what interactions occurred.\n   *\n   * Whether analytics data can be collected right now. Combines the buyer's\n   * consent, the merchant's privacy configuration, and the buyer's region into\n   * a single boolean. Check this flag, not `visitorConsent.analytics`, before\n   * calling `shopify.analytics.publish()`.\n   */\n  analytics: boolean;\n  /**\n   * Whether marketing data can be collected based on the visitor's consent,\n   * the merchant's privacy configuration, and the visitor's region. Marketing\n   * data includes attribution and targeted advertising preferences.\n   *\n   * Whether marketing data can be collected right now. Combines the buyer's\n   * consent, the merchant's privacy configuration, and the buyer's region into\n   * a single boolean. Check this flag, not `visitorConsent.marketing`, before\n   * performing marketing-related data collection.\n   */\n  marketing: boolean;\n  /**\n   * Whether preference data can be collected based on the visitor's consent,\n   * the merchant's privacy configuration, and the visitor's region. Preference\n   * data includes language, currency, and sizing choices.\n   *\n   * Whether preference data can be collected right now. Combines the buyer's\n   * consent, the merchant's privacy configuration, and the buyer's region into\n   * a single boolean. Check this flag, not `visitorConsent.preferences`,\n   * before storing or reading buyer preference data.\n   */\n  preferences: boolean;\n  /**\n   * Whether data can be shared with third parties based on the visitor's\n   * consent, the merchant's privacy configuration, and the visitor's region.\n   * This typically applies to behavioral advertising data.\n   *\n   * Whether buyer data can be shared with or sold to third parties right now.\n   * Combines the buyer's consent, the merchant's privacy configuration, and\n   * the buyer's region into a single boolean. Check this flag, not\n   * `visitorConsent.saleOfData`, before sharing or selling buyer data with\n   * third parties.\n   */\n  saleOfData: boolean;\n}"
+    }
+  },
+  "TrackingConsentMetafield": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "TrackingConsentMetafield",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "string",
+          "description": "The identifier for the tracking consent metafield, such as `'analyticsType'` or `'marketingType'`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The value stored in the tracking consent metafield, such as `'granular'` or a stringified JSON object."
+        }
+      ],
+      "value": "export interface TrackingConsentMetafield {\n  /**\n   * The identifier for the tracking consent metafield, such as `'analyticsType'` or `'marketingType'`.\n   */\n  key: string;\n  /**\n   * The value stored in the tracking consent metafield, such as `'granular'` or a stringified JSON object.\n   */\n  value: string;\n}"
+    }
+  },
+  "CustomerPrivacyRegion": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CustomerPrivacyRegion",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "countryCode",
+          "value": "CountryCode",
+          "description": "The buyer's country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if geolocation failed.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CA' for Canada, 'US' for United States, 'GB' for Great Britain",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "provinceCode",
+          "value": "string",
+          "description": "The buyer's province, state, or region code in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format. The value is `undefined` if geolocation failed or only the country was detected.\n\n{% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'ON' for Ontario, 'ENG' for England, 'CA' for California",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface CustomerPrivacyRegion {\n  /**\n   * The buyer's country code in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) format. The value is `undefined` if geolocation failed.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'CA' for Canada, 'US' for United States, 'GB' for Great Britain\n   */\n  countryCode?: CountryCode;\n  /**\n   * The buyer's province, state, or region code in [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) format. The value is `undefined` if geolocation failed or only the country was detected.\n   *\n   * {% include /apps/checkout/privacy-icon.md %} Requires level 1 access to [protected customer data](/docs/apps/store/data-protection/protected-customer-data).\n   *\n   * @example 'ON' for Ontario, 'ENG' for England, 'CA' for California\n   */\n  provinceCode?: string;\n}"
+    }
+  },
+  "CartDiscountCode": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartDiscountCode",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "string",
+          "description": "The discount code string entered by the buyer during checkout or applied programmatically, such as `\"SAVE10\"` or `\"FREESHIP\"`. Use this to display which discount codes were applied."
+        }
+      ],
+      "value": "export interface CartDiscountCode {\n  /**\n   * The discount code string entered by the buyer during checkout or applied programmatically, such as `\"SAVE10\"` or `\"FREESHIP\"`. Use this to display which discount codes were applied.\n   */\n  code: string;\n}"
+    }
+  },
+  "CartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartInstructions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attributes",
+          "value": "AttributesCartInstructions",
+          "description": "Whether the extension can update custom attributes using `applyAttributeChange()`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "delivery",
+          "value": "DeliveryCartInstructions",
+          "description": "Whether the extension can modify the shipping address using `applyShippingAddressChange()`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "discounts",
+          "value": "DiscountsCartInstructions",
+          "description": "Whether the extension can add or remove discount codes using `applyDiscountCodeChange()`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lines",
+          "value": "CartLinesCartInstructions",
+          "description": "Whether the extension can add, remove, or update cart lines using `applyCartLinesChange()`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafields",
+          "value": "MetafieldsCartInstructions",
+          "description": "Whether the extension can add, update, or delete cart metafields using `applyMetafieldChange()`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "notes",
+          "value": "NotesCartInstructions",
+          "description": "Whether the extension can update the order note using `applyNoteChange()`."
+        }
+      ],
+      "value": "export interface CartInstructions {\n  /**\n   * Whether the extension can update custom attributes using `applyAttributeChange()`.\n   */\n  attributes: AttributesCartInstructions;\n\n  /**\n   * Whether the extension can modify the shipping address using `applyShippingAddressChange()`.\n   */\n  delivery: DeliveryCartInstructions;\n\n  /**\n   * Whether the extension can add or remove discount codes using `applyDiscountCodeChange()`.\n   */\n  discounts: DiscountsCartInstructions;\n\n  /**\n   * Whether the extension can add, remove, or update cart lines using `applyCartLinesChange()`.\n   */\n  lines: CartLinesCartInstructions;\n\n  /**\n   * Whether the extension can add, update, or delete cart metafields using `applyMetafieldChange()`.\n   */\n  metafields: MetafieldsCartInstructions;\n\n  /**\n   * Whether the extension can update the order note using `applyNoteChange()`.\n   */\n  notes: NotesCartInstructions;\n}"
+    }
+  },
+  "AttributesCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "AttributesCartInstructions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateAttributes",
+          "value": "boolean",
+          "description": "Whether attributes can be updated using `applyAttributeChange()`. When `false`, the checkout configuration doesn't allow attribute changes. Even when `true`, calls to `applyAttributeChange()` can still fail during accelerated checkout (Apple Pay, Google Pay)."
+        }
+      ],
+      "value": "export interface AttributesCartInstructions {\n  /**\n   * Whether attributes can be updated using `applyAttributeChange()`. When\n   * `false`, the checkout configuration doesn't allow attribute changes.\n   * Even when `true`, calls to `applyAttributeChange()` can still fail\n   * during accelerated checkout (Apple Pay, Google Pay).\n   */\n  canUpdateAttributes: boolean;\n}"
+    }
+  },
+  "DeliveryCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DeliveryCartInstructions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canSelectCustomAddress",
+          "value": "boolean",
+          "description": "Whether the shipping address can be modified using `applyShippingAddressChange()`. When `false`, the buyer is using an accelerated checkout flow (Apple Pay, Google Pay) where the address can't be changed."
+        }
+      ],
+      "value": "export interface DeliveryCartInstructions {\n  /**\n   * Whether the shipping address can be modified using\n   * `applyShippingAddressChange()`. When `false`, the buyer is using an\n   * accelerated checkout flow (Apple Pay, Google Pay) where the address\n   * can't be changed.\n   */\n  canSelectCustomAddress: boolean;\n}"
+    }
+  },
+  "DiscountsCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "DiscountsCartInstructions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateDiscountCodes",
+          "value": "boolean",
+          "description": "Whether discount codes can be updated using `applyDiscountCodeChange()`. When `false`, the checkout configuration doesn't allow discount code changes. Even when `true`, calls to `applyDiscountCodeChange()` can still fail during accelerated checkout (Apple Pay, Google Pay)."
+        }
+      ],
+      "value": "export interface DiscountsCartInstructions {\n  /**\n   * Whether discount codes can be updated using `applyDiscountCodeChange()`.\n   * When `false`, the checkout configuration doesn't allow discount code\n   * changes. Even when `true`, calls to `applyDiscountCodeChange()` can\n   * still fail during accelerated checkout (Apple Pay, Google Pay).\n   */\n  canUpdateDiscountCodes: boolean;\n}"
+    }
+  },
+  "CartLinesCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "CartLinesCartInstructions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canAddCartLine",
+          "value": "boolean",
+          "description": "Whether new cart lines can be added using `applyCartLinesChange()`. When `false`, the checkout configuration doesn't allow adding lines (for example, draft orders). Even when `true`, calls can still fail during accelerated checkout (Apple Pay, Google Pay)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canRemoveCartLine",
+          "value": "boolean",
+          "description": "Whether cart lines can be removed using `applyCartLinesChange()`. When `false`, the checkout configuration doesn't allow removing lines. Even when `true`, calls can still fail during accelerated checkout."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateCartLine",
+          "value": "boolean",
+          "description": "Whether cart lines can be updated using `applyCartLinesChange()`. When `false`, the checkout configuration doesn't allow updating lines. Even when `true`, calls can still fail during accelerated checkout."
+        }
+      ],
+      "value": "export interface CartLinesCartInstructions {\n  /**\n   * Whether new cart lines can be added using `applyCartLinesChange()`. When\n   * `false`, the checkout configuration doesn't allow adding lines (for\n   * example, draft orders). Even when `true`, calls can still fail during\n   * accelerated checkout (Apple Pay, Google Pay).\n   */\n  canAddCartLine: boolean;\n\n  /**\n   * Whether cart lines can be removed using `applyCartLinesChange()`. When\n   * `false`, the checkout configuration doesn't allow removing lines.\n   * Even when `true`, calls can still fail during accelerated checkout.\n   */\n  canRemoveCartLine: boolean;\n\n  /**\n   * Whether cart lines can be updated using `applyCartLinesChange()`. When\n   * `false`, the checkout configuration doesn't allow updating lines.\n   * Even when `true`, calls can still fail during accelerated checkout.\n   */\n  canUpdateCartLine: boolean;\n}"
+    }
+  },
+  "MetafieldsCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "MetafieldsCartInstructions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canDeleteCartMetafield",
+          "value": "boolean",
+          "description": "Whether the extension can delete cart metafields using `applyMetafieldChange()`."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canSetCartMetafields",
+          "value": "boolean",
+          "description": "Whether the extension can add or update cart metafields using `applyMetafieldChange()`."
+        }
+      ],
+      "value": "export interface MetafieldsCartInstructions {\n  /**\n   * Whether the extension can add or update cart metafields using\n   * `applyMetafieldChange()`.\n   */\n  canSetCartMetafields: boolean;\n\n  /**\n   * Whether the extension can delete cart metafields using\n   * `applyMetafieldChange()`.\n   */\n  canDeleteCartMetafield: boolean;\n}"
+    }
+  },
+  "NotesCartInstructions": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "NotesCartInstructions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "canUpdateNote",
+          "value": "boolean",
+          "description": "Whether the order note can be updated using `applyNoteChange()`. When `false`, the checkout configuration doesn't allow note changes. Even when `true`, calls to `applyNoteChange()` can still fail during accelerated checkout (Apple Pay, Google Pay)."
+        }
+      ],
+      "value": "export interface NotesCartInstructions {\n  /**\n   * Whether the order note can be updated using `applyNoteChange()`. When\n   * `false`, the checkout configuration doesn't allow note changes. Even\n   * when `true`, calls to `applyNoteChange()` can still fail during\n   * accelerated checkout (Apple Pay, Google Pay).\n   */\n  canUpdateNote: boolean;\n}"
+    }
+  },
+  "LocalizedField": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "name": "LocalizedField",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "key",
+          "value": "LocalizedFieldKey",
+          "description": "The identifier for the localized field, indicating the type of information collected (for example, a tax credential or shipping credential for a specific country)."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "title",
+          "value": "string",
+          "description": "The localized display label for the field, suitable for rendering in the UI.",
+          "examples": [
+            {
+              "title": "Example",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "'CPF/CNPJ' for a Brazilian tax credential",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": "The current value entered by the buyer for this field."
+        }
+      ],
+      "value": "export interface LocalizedField {\n  /**\n   * The identifier for the localized field, indicating the type of information\n   * collected (for example, a tax credential or shipping credential for a\n   * specific country).\n   */\n  key: LocalizedFieldKey;\n\n  /**\n   * The localized display label for the field, suitable for rendering in the UI.\n   *\n   * @example 'CPF/CNPJ' for a Brazilian tax credential\n   */\n  title: string;\n\n  /**\n   * The current value entered by the buyer for this field.\n   */\n  value: string;\n}"
+    }
+  },
+  "LocalizedFieldKey": {
+    "src/shared.ts": {
+      "filePath": "src/shared.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "LocalizedFieldKey",
+      "value": "'SHIPPING_CREDENTIAL_BR' | 'SHIPPING_CREDENTIAL_CL' | 'SHIPPING_CREDENTIAL_CN' | 'SHIPPING_CREDENTIAL_CO' | 'SHIPPING_CREDENTIAL_CR' | 'SHIPPING_CREDENTIAL_EC' | 'SHIPPING_CREDENTIAL_ES' | 'SHIPPING_CREDENTIAL_GT' | 'SHIPPING_CREDENTIAL_ID' | 'SHIPPING_CREDENTIAL_KR' | 'SHIPPING_CREDENTIAL_MY' | 'SHIPPING_CREDENTIAL_MX' | 'SHIPPING_CREDENTIAL_PE' | 'SHIPPING_CREDENTIAL_PT' | 'SHIPPING_CREDENTIAL_PY' | 'SHIPPING_CREDENTIAL_TR' | 'SHIPPING_CREDENTIAL_TW' | 'SHIPPING_CREDENTIAL_TYPE_CO' | 'TAX_CREDENTIAL_BR' | 'TAX_CREDENTIAL_CL' | 'TAX_CREDENTIAL_CO' | 'TAX_CREDENTIAL_CR' | 'TAX_CREDENTIAL_EC' | 'TAX_CREDENTIAL_ES' | 'TAX_CREDENTIAL_GT' | 'TAX_CREDENTIAL_ID' | 'TAX_CREDENTIAL_IT' | 'TAX_CREDENTIAL_MX' | 'TAX_CREDENTIAL_MY' | 'TAX_CREDENTIAL_PE' | 'TAX_CREDENTIAL_PT' | 'TAX_CREDENTIAL_PY' | 'TAX_CREDENTIAL_TR' | 'TAX_CREDENTIAL_TYPE_CO' | 'TAX_CREDENTIAL_TYPE_MX' | 'TAX_CREDENTIAL_USE_MX' | 'TAX_EMAIL_IT'",
+      "description": "A union of keys for the localized fields that are required by certain countries."
+    }
+  },
+  "SelectedPaymentOption": {
+    "src/surfaces/checkout/api/standard/standard.ts": {
+      "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "SelectedPaymentOption",
+      "value": "PaymentOption",
+      "description": "A payment option that the buyer has actively selected. This is the same shape as `PaymentOption` and appears in `selectedPaymentOptions`.",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handle",
+          "value": "string",
+          "description": "A session-scoped identifier for this payment option. This handle isn't globally unique; it's specific to the current checkout session or the shop."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/standard/standard.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "| 'creditCard'\n    | 'deferred'\n    | 'local'\n    | 'manualPayment'\n    | 'offsite'\n    | 'other'\n    | 'paymentOnDelivery'\n    | 'redeemable'\n    | 'wallet'\n    | 'customOnsite'",
+          "description": "The type of the payment option.\n\nShops can be configured to support many different payment options. Some options are available only to buyers in specific regions.\n\n| Type  | Description  |\n|---|---|\n| `creditCard`  |  A vaulted or manually entered credit card.  |\n| `deferred`  |  A [deferred payment](https://help.shopify.com/en/manual/orders/deferred-payments), such as invoicing the buyer and collecting payment at a later time.  |\n| `local`  |  A [local payment option](https://help.shopify.com/en/manual/payments/shopify-payments/local-payment-methods) specific to the current region or market  |\n| `manualPayment`  |  A manual payment option such as an in-person retail transaction.  |\n| `offsite`  |  A payment processed outside of Shopify's checkout, excluding integrated wallets.  |\n| `other`  |  Another type of payment not defined here.  |\n| `paymentOnDelivery`  |  A payment collected on delivery.  |\n| `redeemable`  |  A redeemable payment option such as a gift card or store credit.  |\n| `wallet`  |  An integrated wallet such as PayPal, Google Pay, or Apple Pay.  |\n| `customOnsite` | A custom payment option that's processed through a checkout extension with a payments app. |"
+        }
+      ]
     }
   },
   "AnyCheckoutComponent": {
@@ -7893,7 +7810,7 @@
           "syntaxKind": "PropertySignature",
           "name": "buyerJourney",
           "value": "BuyerJourney",
-          "description": "Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.\n\nRefer to [buyer journey](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/buyer-journey#examples) examples for more information."
+          "description": "Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues."
         }
       ],
       "value": "export interface Docs_Standard_BuyerJourneyApi\n  extends Pick<StandardApi, 'buyerJourney'> {}"
@@ -8564,7 +8481,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Abbreviation.ts",
@@ -10573,7 +10490,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Abbreviation.ts",
@@ -11006,7 +10923,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Announcement.ts",
@@ -13031,7 +12948,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Announcement.ts",
@@ -13453,7 +13370,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Badge.ts",
@@ -15488,7 +15405,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Badge.ts",
@@ -15965,7 +15882,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Banner.ts",
@@ -18017,7 +17934,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Banner.ts",
@@ -18995,7 +18912,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Box.ts",
@@ -21184,7 +21101,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Box.ts",
@@ -21631,7 +21548,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Button.ts",
@@ -23700,7 +23617,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Button.ts",
@@ -24303,7 +24220,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Checkbox.ts",
@@ -26380,7 +26297,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Checkbox.ts",
@@ -26895,7 +26812,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Chip.ts",
@@ -28904,7 +28821,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Chip.ts",
@@ -29296,7 +29213,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Choice.ts",
@@ -31332,7 +31249,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Choice.ts",
@@ -31823,7 +31740,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ChoiceList.ts",
@@ -33883,7 +33800,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ChoiceList.ts",
@@ -34982,7 +34899,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Clickable.ts",
@@ -37222,7 +37139,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Clickable.ts",
@@ -37677,7 +37594,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ClickableChip.ts",
@@ -39728,7 +39645,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ClickableChip.ts",
@@ -40174,7 +40091,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ClipboardItem.ts",
@@ -42190,7 +42107,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ClipboardItem.ts",
@@ -42678,7 +42595,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ConsentCheckbox.ts",
@@ -44763,7 +44680,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ConsentCheckbox.ts",
@@ -45354,7 +45271,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ConsentPhoneField.ts",
@@ -47434,7 +47351,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ConsentPhoneField.ts",
@@ -48774,7 +48691,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/DateField.ts",
@@ -50937,7 +50854,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/DateField.ts",
@@ -51758,7 +51675,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/DatePicker.ts",
@@ -53892,7 +53809,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/DatePicker.ts",
@@ -54499,7 +54416,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Details.ts",
@@ -56507,7 +56424,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Details.ts",
@@ -56875,7 +56792,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Divider.ts",
@@ -58893,7 +58810,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Divider.ts",
@@ -59382,7 +59299,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/DropZone.ts",
@@ -61440,7 +61357,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/DropZone.ts",
@@ -62093,7 +62010,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/EmailField.ts",
@@ -64191,7 +64108,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/EmailField.ts",
@@ -64718,7 +64635,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Form.ts",
@@ -66738,7 +66655,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Form.ts",
@@ -67808,7 +67725,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Grid.ts",
@@ -70096,7 +70013,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Grid.ts",
@@ -70925,7 +70842,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/GridItem.ts",
@@ -73141,7 +73058,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/GridItem.ts",
@@ -73456,7 +73373,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Heading.ts",
@@ -75465,7 +75382,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Heading.ts",
@@ -75816,7 +75733,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Icon.ts",
@@ -77825,7 +77742,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Icon.ts",
@@ -78459,7 +78376,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Image.ts",
@@ -80547,7 +80464,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Image.ts",
@@ -80981,7 +80898,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Link.ts",
@@ -83024,7 +82941,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Link.ts",
@@ -83433,7 +83350,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ListItem.ts",
@@ -85442,7 +85359,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ListItem.ts",
@@ -86617,7 +86534,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Map.ts",
@@ -88738,7 +88655,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Map.ts",
@@ -89337,7 +89254,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/MapMarker.ts",
@@ -91400,7 +91317,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/MapMarker.ts",
@@ -91959,7 +91876,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Modal.ts",
@@ -94020,7 +93937,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Modal.ts",
@@ -94959,7 +94876,7 @@
           "filePath": "src/surfaces/checkout/components/NumberField.ts",
           "syntaxKind": "PropertySignature",
           "name": "icon",
-          "value": "'' | 'cart' | 'note' | 'settings' | 'reset' | 'map' | 'menu' | 'search' | 'circle' | 'filter' | 'image' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x'",
+          "value": "IconProps['type']",
           "description": "The type of icon to be displayed in the field.",
           "isOptional": true,
           "defaultValue": "''"
@@ -95222,7 +95139,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/NumberField.ts",
@@ -96161,7 +96078,7 @@
           "filePath": "src/surfaces/checkout/components/NumberField.ts",
           "syntaxKind": "PropertySignature",
           "name": "icon",
-          "value": "'' | 'cart' | 'note' | 'settings' | 'reset' | 'map' | 'menu' | 'search' | 'circle' | 'filter' | 'image' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x'",
+          "value": "IconProps['type']",
           "description": "The type of icon to be displayed in the field.",
           "isOptional": true
         },
@@ -97348,7 +97265,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/NumberField.ts",
@@ -97689,7 +97606,7 @@
           "filePath": "src/surfaces/checkout/components/NumberField.ts",
           "syntaxKind": "PropertySignature",
           "name": "icon",
-          "value": "'' | 'cart' | 'note' | 'settings' | 'reset' | 'map' | 'menu' | 'search' | 'circle' | 'filter' | 'image' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x'",
+          "value": "IconProps['type']",
           "description": "The type of icon to be displayed in the field.",
           "isOptional": true
         },
@@ -97948,7 +97865,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Option.ts",
@@ -99975,7 +99892,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Option.ts",
@@ -100351,7 +100268,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/OrderedList.ts",
@@ -102360,7 +102277,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/OrderedList.ts",
@@ -102758,7 +102675,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Paragraph.ts",
@@ -104780,7 +104697,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Paragraph.ts",
@@ -105394,7 +105311,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/PasswordField.ts",
@@ -107507,7 +107424,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/PasswordField.ts",
@@ -108020,7 +107937,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/PaymentIcon.ts",
@@ -110029,7 +109946,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/PaymentIcon.ts",
@@ -110541,7 +110458,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Popover.ts",
@@ -112618,7 +112535,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Popover.ts",
@@ -113143,7 +113060,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/PressButton.ts",
@@ -115191,7 +115108,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/PressButton.ts",
@@ -115634,7 +115551,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ProductThumbnail.ts",
@@ -117644,7 +117561,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ProductThumbnail.ts",
@@ -118085,7 +118002,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Progress.ts",
@@ -120103,7 +120020,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Progress.ts",
@@ -120568,7 +120485,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/QRCode.ts",
@@ -122610,7 +122527,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/QRCode.ts",
@@ -122995,7 +122912,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/QueryContainer.ts",
@@ -125013,7 +124930,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/QueryContainer.ts",
@@ -125835,7 +125752,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ScrollBox.ts",
@@ -128033,7 +127950,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/ScrollBox.ts",
@@ -128354,7 +128271,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Section.ts",
@@ -130371,7 +130288,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Section.ts",
@@ -130840,7 +130757,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Select.ts",
@@ -132899,7 +132816,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Select.ts",
@@ -133487,7 +133404,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Sheet.ts",
@@ -135562,7 +135479,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Sheet.ts",
@@ -135944,7 +135861,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/SkeletonParagraph.ts",
@@ -137962,7 +137879,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/SkeletonParagraph.ts",
@@ -138312,7 +138229,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Spinner.ts",
@@ -140321,7 +140238,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Spinner.ts",
@@ -141231,7 +141148,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Stack.ts",
@@ -143474,7 +143391,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Stack.ts",
@@ -143780,7 +143697,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Summary.ts",
@@ -145789,7 +145706,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Summary.ts",
@@ -146227,7 +146144,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Switch.ts",
@@ -148296,7 +148213,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Switch.ts",
@@ -148776,7 +148693,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Text.ts",
@@ -150807,7 +150724,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Text.ts",
@@ -151412,7 +151329,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/TextArea.ts",
@@ -153517,7 +153434,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/TextArea.ts",
@@ -154013,7 +153930,7 @@
           "filePath": "src/surfaces/checkout/components/TextField.ts",
           "syntaxKind": "PropertySignature",
           "name": "icon",
-          "value": "'' | 'cart' | 'note' | 'settings' | 'reset' | 'map' | 'menu' | 'search' | 'circle' | 'filter' | 'image' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x'",
+          "value": "IconProps['type']",
           "description": "The type of icon to be displayed in the field.",
           "isOptional": true,
           "defaultValue": "''"
@@ -154258,7 +154175,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/TextField.ts",
@@ -155188,7 +155105,7 @@
           "filePath": "src/surfaces/checkout/components/TextField.ts",
           "syntaxKind": "PropertySignature",
           "name": "icon",
-          "value": "'' | 'cart' | 'note' | 'settings' | 'reset' | 'map' | 'menu' | 'search' | 'circle' | 'filter' | 'image' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x'",
+          "value": "IconProps['type']",
           "description": "The type of icon to be displayed in the field.",
           "isOptional": true
         },
@@ -156373,7 +156290,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/TextField.ts",
@@ -156696,7 +156613,7 @@
           "filePath": "src/surfaces/checkout/components/TextField.ts",
           "syntaxKind": "PropertySignature",
           "name": "icon",
-          "value": "'' | 'cart' | 'note' | 'settings' | 'reset' | 'map' | 'menu' | 'search' | 'circle' | 'filter' | 'image' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x'",
+          "value": "IconProps['type']",
           "description": "The type of icon to be displayed in the field.",
           "isOptional": true
         },
@@ -156895,7 +156812,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Time.ts",
@@ -158913,7 +158830,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/Time.ts",
@@ -159295,7 +159212,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/UnorderedList.ts",
@@ -161304,7 +161221,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/UnorderedList.ts",
@@ -161828,7 +161745,7 @@
           "syntaxKind": "MethodSignature",
           "name": "addEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void; }",
-          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
+          "description": "\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)\n\nThe **`addEventListener()`** method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/UrlField.ts",
@@ -163916,7 +163833,7 @@
           "syntaxKind": "MethodSignature",
           "name": "removeEventListener",
           "value": "{ <K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void; (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void; }",
-          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
+          "description": "\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)\n\nThe **`removeEventListener()`** method of the EventTarget interface removes an event listener previously registered with EventTarget.addEventListener() from the target.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)"
         },
         {
           "filePath": "src/surfaces/checkout/components/UrlField.ts",
@@ -164756,7 +164673,7 @@
       "filePath": "src/surfaces/checkout/components/components.ts",
       "syntaxKind": "TypeAliasDeclaration",
       "name": "IconType",
-      "value": "'product' | 'variant' | 'cart' | 'payment' | 'wallet' | 'code' | 'phone' | 'target' | 'metafields' | 'note' | 'settings' | 'key' | 'paste' | 'play' | 'reset' | 'select' | 'button' | 'link' | 'map' | 'menu' | 'search' | 'table' | 'circle' | 'filter' | 'image' | 'text' | 'view' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x' | 'color' | 'adjust' | 'affiliate' | 'airplane' | 'alert-bubble' | 'alert-diamond' | 'alert-location' | 'alert-octagon' | 'alert-octagon-filled' | 'app-extension' | 'apps' | 'archive' | 'arrow-down-circle' | 'arrow-down-right' | 'arrow-left-circle' | 'arrow-right-circle' | 'arrow-up-circle' | 'arrows-in-horizontal' | 'arrows-out-horizontal' | 'attachment' | 'automation' | 'backspace' | 'bank' | 'barcode' | 'battery-low' | 'bill' | 'blank' | 'blog' | 'bolt' | 'bolt-filled' | 'book' | 'book-open' | 'bug' | 'business-entity' | 'button-press' | 'calculator' | 'calendar-check' | 'calendar-compare' | 'calendar-list' | 'calendar-time' | 'camera-flip' | 'caret-left' | 'caret-right' | 'caret-up' | 'cart-abandoned' | 'cart-discount' | 'cart-down' | 'cart-filled' | 'cart-sale' | 'cart-send' | 'cart-up' | 'cash-euro' | 'cash-pound' | 'cash-rupee' | 'cash-yen' | 'catalog-product' | 'channels' | 'chart-cohort' | 'chart-donut' | 'chart-funnel' | 'chart-histogram-first' | 'chart-histogram-first-last' | 'chart-histogram-flat' | 'chart-histogram-full' | 'chart-histogram-growth' | 'chart-histogram-last' | 'chart-histogram-second-last' | 'chart-horizontal' | 'chart-line' | 'chart-popular' | 'chart-stacked' | 'chart-vertical' | 'chat' | 'chat-new' | 'chat-referral' | 'checkbox' | 'chevron-down-circle' | 'chevron-left-circle' | 'chevron-right-circle' | 'chevron-up-circle' | 'circle-dashed' | 'clipboard-check' | 'clipboard-checklist' | 'clock-revert' | 'code-add' | 'collection' | 'collection-featured' | 'collection-list' | 'collection-reference' | 'color-none' | 'compass' | 'complete' | 'compose' | 'confetti' | 'connect' | 'content' | 'contract' | 'corner-pill' | 'corner-round' | 'corner-square' | 'credit-card-cancel' | 'credit-card-percent' | 'credit-card-reader' | 'credit-card-reader-chip' | 'credit-card-reader-tap' | 'credit-card-secure' | 'credit-card-tap-chip' | 'crop' | 'currency-convert' | 'cursor' | 'cursor-banner' | 'cursor-option' | 'data-presentation' | 'data-table' | 'database' | 'database-add' | 'database-connect' | 'desktop' | 'disabled-filled' | 'discount-add' | 'discount-automatic' | 'discount-code' | 'discount-remove' | 'dns-settings' | 'dock-floating' | 'dock-side' | 'domain' | 'domain-landing-page' | 'domain-new' | 'domain-redirect' | 'download' | 'drag-drop' | 'drag-handle' | 'drawer' | 'duplicate' | 'email-follow-up' | 'email-newsletter' | 'enabled' | 'enter' | 'envelope' | 'envelope-soft-pack' | 'eraser' | 'exchange' | 'exit' | 'export' | 'eye-check-mark' | 'eye-dropper' | 'eye-dropper-list' | 'eye-first' | 'eyeglasses' | 'fav' | 'favicon' | 'file' | 'file-list' | 'filter-active' | 'flag' | 'flip-horizontal' | 'flip-vertical' | 'flower' | 'folder' | 'folder-add' | 'folder-down' | 'folder-remove' | 'folder-up' | 'food' | 'foreground' | 'forklift' | 'forms' | 'games' | 'gauge' | 'gift' | 'git-branch' | 'git-commit' | 'git-repository' | 'globe-asia' | 'globe-europe' | 'globe-lines' | 'globe-list' | 'graduation-hat' | 'hashtag' | 'hashtag-decimal' | 'hashtag-list' | 'heart' | 'hide' | 'hide-filled' | 'home' | 'home-filled' | 'icons' | 'identity-card' | 'image-add' | 'image-alt' | 'image-explore' | 'image-magic' | 'image-none' | 'image-with-text-overlay' | 'images' | 'import' | 'in-progress' | 'incentive' | 'incoming' | 'incomplete' | 'inheritance' | 'inventory' | 'inventory-edit' | 'inventory-list' | 'inventory-transfer' | 'inventory-updated' | 'iq' | 'keyboard' | 'keyboard-filled' | 'keyboard-hide' | 'keypad' | 'label-printer' | 'language' | 'language-translate' | 'layout-block' | 'layout-buy-button' | 'layout-buy-button-horizontal' | 'layout-buy-button-vertical' | 'layout-column-1' | 'layout-columns-2' | 'layout-columns-3' | 'layout-footer' | 'layout-header' | 'layout-logo-block' | 'layout-popup' | 'layout-rows-2' | 'layout-section' | 'layout-sidebar-left' | 'layout-sidebar-right' | 'lightbulb' | 'link-list' | 'list-bulleted-filled' | 'list-numbered' | 'live' | 'live-critical' | 'live-none' | 'location-none' | 'markets' | 'markets-euro' | 'markets-rupee' | 'markets-yen' | 'maximize' | 'measurement-size' | 'measurement-size-list' | 'measurement-volume' | 'measurement-volume-list' | 'measurement-weight' | 'measurement-weight-list' | 'media-receiver' | 'megaphone' | 'mention' | 'menu-filled' | 'merge' | 'metaobject' | 'metaobject-list' | 'metaobject-reference' | 'microphone' | 'minimize' | 'minus-circle' | 'money' | 'money-none' | 'money-split' | 'moon' | 'nature' | 'note-add' | 'notification' | 'order-batches' | 'order-draft' | 'order-filled' | 'order-first' | 'order-fulfilled' | 'order-repeat' | 'order-unfulfilled' | 'orders-status' | 'outdent' | 'outgoing' | 'package' | 'package-cancel' | 'package-fulfilled' | 'package-on-hold' | 'package-reassign' | 'package-returned' | 'page' | 'page-add' | 'page-attachment' | 'page-clock' | 'page-down' | 'page-heart' | 'page-list' | 'page-reference' | 'page-remove' | 'page-report' | 'page-up' | 'pagination-end' | 'pagination-start' | 'paint-brush-flat' | 'paint-brush-round' | 'paper-check' | 'partially-complete' | 'passkey' | 'pause-circle' | 'payment-capture' | 'payout' | 'payout-dollar' | 'payout-euro' | 'payout-pound' | 'payout-rupee' | 'payout-yen' | 'person' | 'person-add' | 'person-exit' | 'person-filled' | 'person-list' | 'person-lock' | 'person-remove' | 'person-segment' | 'personalized-text' | 'phablet' | 'phone-in' | 'phone-out' | 'pin' | 'pin-remove' | 'plan' | 'play-circle' | 'plus-circle' | 'plus-circle-down' | 'plus-circle-filled' | 'plus-circle-up' | 'point-of-sale' | 'point-of-sale-register' | 'price-list' | 'print' | 'product-add' | 'product-cost' | 'product-filled' | 'product-list' | 'product-reference' | 'product-remove' | 'product-return' | 'product-unavailable' | 'profile-filled' | 'receipt' | 'receipt-dollar' | 'receipt-euro' | 'receipt-folded' | 'receipt-paid' | 'receipt-pound' | 'receipt-refund' | 'receipt-rupee' | 'receipt-yen' | 'receivables' | 'redo' | 'referral-code' | 'refresh' | 'remove-background' | 'replace' | 'replay' | 'reward' | 'rocket' | 'rotate-left' | 'rotate-right' | 'sandbox' | 'save' | 'scan-qr-code' | 'search-add' | 'search-list' | 'search-recent' | 'search-resource' | 'send' | 'share' | 'shield-check-mark' | 'shield-none' | 'shield-pending' | 'shield-person' | 'shipping-label' | 'shipping-label-cancel' | 'shopcodes' | 'slideshow' | 'smiley-happy' | 'smiley-joy' | 'smiley-neutral' | 'smiley-sad' | 'social-ad' | 'social-post' | 'sort' | 'sort-ascending' | 'sort-descending' | 'sound' | 'sports' | 'star-circle' | 'star-list' | 'status' | 'status-active' | 'stop-circle' | 'store-import' | 'store-managed' | 'store-online' | 'sun' | 'table-masonry' | 'tablet' | 'tax' | 'team' | 'text-align-center' | 'text-align-left' | 'text-align-right' | 'text-block' | 'text-bold' | 'text-color' | 'text-font' | 'text-font-list' | 'text-grammar' | 'text-in-columns' | 'text-in-rows' | 'text-indent' | 'text-indent-remove' | 'text-italic' | 'text-quote' | 'text-title' | 'text-underline' | 'text-with-image' | 'theme' | 'theme-edit' | 'theme-store' | 'theme-template' | 'three-d-environment' | 'thumbs-down' | 'thumbs-up' | 'tip-jar' | 'toggle-off' | 'toggle-on' | 'transaction' | 'transaction-fee-add' | 'transaction-fee-dollar' | 'transaction-fee-euro' | 'transaction-fee-pound' | 'transaction-fee-rupee' | 'transaction-fee-yen' | 'transfer' | 'transfer-in' | 'transfer-internal' | 'transfer-out' | 'undo' | 'unknown-device' | 'unlock' | 'viewport-narrow' | 'viewport-short' | 'viewport-tall' | 'viewport-wide' | 'wand' | 'watch' | 'wifi' | 'work' | 'work-list' | 'wrench'",
+      "value": "'product' | 'variant' | 'cart' | 'payment' | 'wallet' | 'code' | 'phone' | 'target' | 'metafields' | 'note' | 'settings' | 'paste' | 'play' | 'reset' | 'select' | 'button' | 'link' | 'map' | 'menu' | 'search' | 'table' | 'circle' | 'filter' | 'image' | 'text' | 'view' | 'alert-circle' | 'alert-triangle-filled' | 'alert-triangle' | 'arrow-down' | 'arrow-left' | 'arrow-right' | 'arrow-up-right' | 'arrow-up' | 'bag' | 'bullet' | 'calendar' | 'camera' | 'caret-down' | 'cash-dollar' | 'categories' | 'check-circle' | 'check-circle-filled' | 'check' | 'chevron-down' | 'chevron-left' | 'chevron-right' | 'chevron-up' | 'clipboard' | 'clock' | 'credit-card' | 'delete' | 'delivered' | 'delivery' | 'disabled' | 'discount' | 'edit' | 'email' | 'empty' | 'external' | 'geolocation' | 'gift-card' | 'globe' | 'grid' | 'info-filled' | 'info' | 'list-bulleted' | 'location' | 'lock' | 'menu-horizontal' | 'menu-vertical' | 'minus' | 'mobile' | 'order' | 'organization' | 'plus' | 'profile' | 'question-circle-filled' | 'question-circle' | 'reorder' | 'return' | 'savings' | 'star-filled' | 'star-half' | 'star' | 'store' | 'truck' | 'upload' | 'x-circle-filled' | 'x-circle' | 'x' | 'color' | 'adjust' | 'affiliate' | 'airplane' | 'alert-bubble' | 'alert-diamond' | 'alert-location' | 'alert-octagon' | 'alert-octagon-filled' | 'app-extension' | 'apps' | 'archive' | 'arrow-down-circle' | 'arrow-down-right' | 'arrow-left-circle' | 'arrow-right-circle' | 'arrow-up-circle' | 'arrows-in-horizontal' | 'arrows-out-horizontal' | 'attachment' | 'automation' | 'backspace' | 'bank' | 'barcode' | 'battery-low' | 'bill' | 'blank' | 'blog' | 'bolt' | 'bolt-filled' | 'book' | 'book-open' | 'bug' | 'business-entity' | 'button-press' | 'calculator' | 'calendar-check' | 'calendar-compare' | 'calendar-list' | 'calendar-time' | 'camera-flip' | 'caret-left' | 'caret-right' | 'caret-up' | 'cart-abandoned' | 'cart-discount' | 'cart-down' | 'cart-filled' | 'cart-sale' | 'cart-send' | 'cart-up' | 'cash-euro' | 'cash-pound' | 'cash-rupee' | 'cash-yen' | 'catalog-product' | 'channels' | 'chart-cohort' | 'chart-donut' | 'chart-funnel' | 'chart-histogram-first' | 'chart-histogram-first-last' | 'chart-histogram-flat' | 'chart-histogram-full' | 'chart-histogram-growth' | 'chart-histogram-last' | 'chart-histogram-second-last' | 'chart-horizontal' | 'chart-line' | 'chart-popular' | 'chart-stacked' | 'chart-vertical' | 'chat' | 'chat-new' | 'chat-referral' | 'checkbox' | 'chevron-down-circle' | 'chevron-left-circle' | 'chevron-right-circle' | 'chevron-up-circle' | 'circle-dashed' | 'clipboard-check' | 'clipboard-checklist' | 'clock-revert' | 'code-add' | 'collection' | 'collection-featured' | 'collection-list' | 'collection-reference' | 'color-none' | 'compass' | 'complete' | 'compose' | 'confetti' | 'connect' | 'content' | 'contract' | 'corner-pill' | 'corner-round' | 'corner-square' | 'credit-card-cancel' | 'credit-card-percent' | 'credit-card-reader' | 'credit-card-reader-chip' | 'credit-card-reader-tap' | 'credit-card-secure' | 'credit-card-tap-chip' | 'crop' | 'currency-convert' | 'cursor' | 'cursor-banner' | 'cursor-option' | 'data-presentation' | 'data-table' | 'database' | 'database-add' | 'database-connect' | 'desktop' | 'disabled-filled' | 'discount-add' | 'discount-automatic' | 'discount-code' | 'discount-remove' | 'dns-settings' | 'dock-floating' | 'dock-side' | 'domain' | 'domain-landing-page' | 'domain-new' | 'domain-redirect' | 'download' | 'drag-drop' | 'drag-handle' | 'drawer' | 'duplicate' | 'email-follow-up' | 'email-newsletter' | 'enabled' | 'enter' | 'envelope' | 'envelope-soft-pack' | 'eraser' | 'exchange' | 'exit' | 'export' | 'eye-check-mark' | 'eye-dropper' | 'eye-dropper-list' | 'eye-first' | 'eyeglasses' | 'fav' | 'favicon' | 'file' | 'file-list' | 'filter-active' | 'flag' | 'flip-horizontal' | 'flip-vertical' | 'flower' | 'folder' | 'folder-add' | 'folder-down' | 'folder-remove' | 'folder-up' | 'food' | 'foreground' | 'forklift' | 'forms' | 'games' | 'gauge' | 'gift' | 'git-branch' | 'git-commit' | 'git-repository' | 'globe-asia' | 'globe-europe' | 'globe-lines' | 'globe-list' | 'graduation-hat' | 'hashtag' | 'hashtag-decimal' | 'hashtag-list' | 'heart' | 'hide' | 'hide-filled' | 'home' | 'home-filled' | 'icons' | 'identity-card' | 'image-add' | 'image-alt' | 'image-explore' | 'image-magic' | 'image-none' | 'image-with-text-overlay' | 'images' | 'import' | 'in-progress' | 'incentive' | 'incoming' | 'incomplete' | 'inheritance' | 'inventory' | 'inventory-edit' | 'inventory-list' | 'inventory-transfer' | 'inventory-updated' | 'iq' | 'key' | 'keyboard' | 'keyboard-filled' | 'keyboard-hide' | 'keypad' | 'label-printer' | 'language' | 'language-translate' | 'layout-block' | 'layout-buy-button' | 'layout-buy-button-horizontal' | 'layout-buy-button-vertical' | 'layout-column-1' | 'layout-columns-2' | 'layout-columns-3' | 'layout-footer' | 'layout-header' | 'layout-logo-block' | 'layout-popup' | 'layout-rows-2' | 'layout-section' | 'layout-sidebar-left' | 'layout-sidebar-right' | 'lightbulb' | 'link-list' | 'list-bulleted-filled' | 'list-numbered' | 'live' | 'live-critical' | 'live-none' | 'location-none' | 'markets' | 'markets-euro' | 'markets-rupee' | 'markets-yen' | 'maximize' | 'measurement-size' | 'measurement-size-list' | 'measurement-volume' | 'measurement-volume-list' | 'measurement-weight' | 'measurement-weight-list' | 'media-receiver' | 'megaphone' | 'mention' | 'menu-filled' | 'merge' | 'metaobject' | 'metaobject-list' | 'metaobject-reference' | 'microphone' | 'minimize' | 'minus-circle' | 'money' | 'money-none' | 'money-split' | 'moon' | 'nature' | 'note-add' | 'notification' | 'order-batches' | 'order-draft' | 'order-filled' | 'order-first' | 'order-fulfilled' | 'order-repeat' | 'order-unfulfilled' | 'orders-status' | 'outdent' | 'outgoing' | 'package' | 'package-cancel' | 'package-fulfilled' | 'package-on-hold' | 'package-reassign' | 'package-returned' | 'page' | 'page-add' | 'page-attachment' | 'page-clock' | 'page-down' | 'page-heart' | 'page-list' | 'page-reference' | 'page-remove' | 'page-report' | 'page-up' | 'pagination-end' | 'pagination-start' | 'paint-brush-flat' | 'paint-brush-round' | 'paper-check' | 'partially-complete' | 'passkey' | 'pause-circle' | 'payment-capture' | 'payout' | 'payout-dollar' | 'payout-euro' | 'payout-pound' | 'payout-rupee' | 'payout-yen' | 'person' | 'person-add' | 'person-exit' | 'person-filled' | 'person-list' | 'person-lock' | 'person-remove' | 'person-segment' | 'personalized-text' | 'phablet' | 'phone-in' | 'phone-out' | 'pin' | 'pin-remove' | 'plan' | 'play-circle' | 'plus-circle' | 'plus-circle-down' | 'plus-circle-filled' | 'plus-circle-up' | 'point-of-sale' | 'point-of-sale-register' | 'price-list' | 'print' | 'product-add' | 'product-cost' | 'product-filled' | 'product-list' | 'product-reference' | 'product-remove' | 'product-return' | 'product-unavailable' | 'profile-filled' | 'receipt' | 'receipt-dollar' | 'receipt-euro' | 'receipt-folded' | 'receipt-paid' | 'receipt-pound' | 'receipt-refund' | 'receipt-rupee' | 'receipt-yen' | 'receivables' | 'redo' | 'referral-code' | 'refresh' | 'remove-background' | 'replace' | 'replay' | 'reward' | 'rocket' | 'rotate-left' | 'rotate-right' | 'sandbox' | 'save' | 'scan-qr-code' | 'search-add' | 'search-list' | 'search-recent' | 'search-resource' | 'send' | 'share' | 'shield-check-mark' | 'shield-none' | 'shield-pending' | 'shield-person' | 'shipping-label' | 'shipping-label-cancel' | 'shopcodes' | 'slideshow' | 'smiley-happy' | 'smiley-joy' | 'smiley-neutral' | 'smiley-sad' | 'social-ad' | 'social-post' | 'sort' | 'sort-ascending' | 'sort-descending' | 'sound' | 'sports' | 'star-circle' | 'star-list' | 'status' | 'status-active' | 'stop-circle' | 'store-import' | 'store-managed' | 'store-online' | 'sun' | 'table-masonry' | 'tablet' | 'tax' | 'team' | 'text-align-center' | 'text-align-left' | 'text-align-right' | 'text-block' | 'text-bold' | 'text-color' | 'text-font' | 'text-font-list' | 'text-grammar' | 'text-in-columns' | 'text-in-rows' | 'text-indent' | 'text-indent-remove' | 'text-italic' | 'text-quote' | 'text-title' | 'text-underline' | 'text-with-image' | 'theme' | 'theme-edit' | 'theme-store' | 'theme-template' | 'three-d-environment' | 'thumbs-down' | 'thumbs-up' | 'tip-jar' | 'toggle-off' | 'toggle-on' | 'transaction' | 'transaction-fee-add' | 'transaction-fee-dollar' | 'transaction-fee-euro' | 'transaction-fee-pound' | 'transaction-fee-rupee' | 'transaction-fee-yen' | 'transfer' | 'transfer-in' | 'transfer-internal' | 'transfer-out' | 'undo' | 'unknown-device' | 'unlock' | 'viewport-narrow' | 'viewport-short' | 'viewport-tall' | 'viewport-wide' | 'wand' | 'watch' | 'wifi' | 'work' | 'work-list' | 'wrench'",
       "description": "",
       "isPublicDocs": true
     }
@@ -167532,6 +167449,22 @@
       "value": "export function useApplyAttributeChange<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>(): (change: AttributeChange) => Promise<AttributeChangeResult> {\n  const api = useApi<Target>();\n\n  if ('applyAttributeChange' in api) {\n    return api.applyAttributeChange;\n  }\n\n  throw new ExtensionHasNoMethodError(\n    'applyAttributeChange',\n    api.extension.target,\n  );\n}"
     }
   },
+  "UseBillingAddressGeneratedType": {
+    "src/surfaces/checkout/preact/billing-address.ts": {
+      "filePath": "src/surfaces/checkout/preact/billing-address.ts",
+      "name": "UseBillingAddressGeneratedType",
+      "description": "Returns the proposed `billingAddress` applied to the checkout.",
+      "isPublicDocs": true,
+      "params": [],
+      "returns": {
+        "filePath": "src/surfaces/checkout/preact/billing-address.ts",
+        "description": "",
+        "name": "MailingAddress | undefined",
+        "value": "MailingAddress | undefined"
+      },
+      "value": "export function useBillingAddress<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>(): MailingAddress | undefined {\n  const billingAddress = useApi<Target>().billingAddress;\n\n  if (!billingAddress) {\n    throw new ScopeNotGrantedError(\n      'Using billing address requires having billing address permissions granted to your app.',\n    );\n  }\n\n  return useSubscription(billingAddress);\n}"
+    }
+  },
   "UseCustomerGeneratedType": {
     "src/surfaces/checkout/preact/buyer-identity.ts": {
       "filePath": "src/surfaces/checkout/preact/buyer-identity.ts",
@@ -168644,6 +168577,63 @@
         "value": "Partial<Settings extends ExtensionSettings>"
       },
       "value": "export function useSettings<\n  Settings extends ExtensionSettings,\n>(): Partial<Settings> {\n  const settings = useSubscription(useApi().settings);\n\n  return settings as Settings;\n}"
+    }
+  },
+  "UseShippingAddressGeneratedType": {
+    "src/surfaces/checkout/preact/shipping-address.ts": {
+      "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+      "name": "UseShippingAddressGeneratedType",
+      "description": "Returns the proposed `shippingAddress` applied to the checkout.",
+      "isPublicDocs": true,
+      "params": [],
+      "returns": {
+        "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+        "description": "",
+        "name": "ShippingAddress | undefined",
+        "value": "ShippingAddress | undefined"
+      },
+      "value": "export function useShippingAddress<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>(): ShippingAddress | undefined {\n  const shippingAddress = useApi<Target>().shippingAddress;\n\n  if (!shippingAddress) {\n    throw new ScopeNotGrantedError(\n      'Using shipping address requires having shipping address permissions granted to your app.',\n    );\n  }\n\n  return useSubscription(shippingAddress);\n}"
+    }
+  },
+  "UseApplyShippingAddressChangeGeneratedType": {
+    "src/surfaces/checkout/preact/shipping-address.ts": {
+      "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+      "name": "UseApplyShippingAddressChangeGeneratedType",
+      "description": "Returns a function to mutate the `shippingAddress` property of checkout.",
+      "isPublicDocs": true,
+      "params": [],
+      "returns": {
+        "filePath": "src/surfaces/checkout/preact/shipping-address.ts",
+        "description": "",
+        "name": "(change: ShippingAddressChange) => Promise<ShippingAddressChangeResult> | undefined",
+        "value": "(change: ShippingAddressChange) => Promise<ShippingAddressChangeResult> | undefined"
+      },
+      "value": "export function useApplyShippingAddressChange<\n  Target extends RenderExtensionTarget = RenderExtensionTarget,\n>():\n  | ((change: ShippingAddressChange) => Promise<ShippingAddressChangeResult>)\n  | undefined {\n  const api = useApi<Target>();\n\n  if ('applyShippingAddressChange' in api) {\n    return api.applyShippingAddressChange;\n  }\n\n  throw new ExtensionHasNoMethodError(\n    'applyShippingAddressChange',\n    api.extension.target,\n  );\n}"
+    }
+  },
+  "ShippingAddressChange": {
+    "src/surfaces/checkout/api/checkout/checkout.ts": {
+      "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShippingAddressChange",
+      "value": "ShippingAddressUpdateChange",
+      "description": "The input for `applyShippingAddressChange()`. Currently only supports `ShippingAddressUpdateChange` (with `type: 'updateShippingAddress'`).",
+      "members": [
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "address",
+          "value": "Partial<ShippingAddress>",
+          "description": "Fields to update in the shipping address. You only need to provide values for the fields you want to update. Any fields you don't list keep their current values."
+        },
+        {
+          "filePath": "src/surfaces/checkout/api/checkout/checkout.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "'updateShippingAddress'",
+          "description": "Identifies this as a shipping address update. This is the only supported change type for `applyShippingAddressChange()`."
+        }
+      ]
     }
   },
   "UseShippingOptionTargetGeneratedType": {

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -617,9 +617,6 @@ export interface StandardApi<Target extends ExtensionTarget = ExtensionTarget> {
 
   /**
    * Provides details on the buyer's progression through the checkout and lets you intercept navigation to validate data before the buyer continues.
-   *
-   * Refer to [buyer journey](https://shopify.dev/docs/api/checkout-ui-extensions/{API_VERSION}/apis/buyer-journey#examples)
-   * examples for more information.
    */
   buyerJourney: BuyerJourney;
 


### PR DESCRIPTION
### Background

A merchant-facing dev docs page was reported broken in [this Slack thread](https://shopify.slack.com/archives/C01FT69928K/p1781281874181299): https://shopify.dev/docs/api/checkout-ui-extensions/latest/apis/buyer-journey#examples returns a 404.

The root cause is a self-referential statement in the `buyerJourney` property's JSDoc in `packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts`:

```
Refer to [buyer journey](/docs/api/checkout-ui-extensions/{API_VERSION}/apis/buyer-journey#examples) examples for more information.
```

That link is broken two ways: the `#examples` anchor no longer exists (examples now render via `<ExampleSwitcher>` at the top of the page), and `apis/buyer-journey` is the pre-reorg path (docs were reorganized to `target-apis/checkout-apis/buyer-journey-api`), so it 404s under `/latest`.

This was already removed at HEAD in World (`checkout-web/packages/ui-extensions`) in commit `80249b` ("Remove self-referential link in buyerJourney prop JSDoc"), but that has not propagated to the published `2026-01` version snapshot, which shopify.dev syncs from this branch.

One of a set of per-version PRs (one per affected release branch: `2025-07`, `2025-10`, `2026-01`, `2026-04`, `2026-07-rc`).

### Solution

Remove the dangling statement from the `buyerJourney` JSDoc on the `2026-01` branch, mirroring World commit `80249b`.

⚠️ **Source-only PR.** The rendered shopify.dev page won't change until the committed `docs/surfaces/checkout/generated/generated_docs_data_v2.json` is regenerated via `pnpm docs:checkout` (`docs/surfaces/checkout/build-docs.sh`) and committed, then picked up by shopify.dev's once-a-day sync. That regen step is intentionally **not** included here — flagging for a maintainer to run before/at merge.

Patch authored by River; reported by Kristin Hung.

### 🎩

- Docs-comment-only change. Verified the removed text matches World commit `80249b` and that `git apply --check` is clean on this branch.

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have updated relevant documentation