### PR TITLE
feat(pos): add options to addLineItem

### DIFF
--- a/.changeset/pos-cart-add-line-item-options.md
+++ b/.changeset/pos-cart-add-line-item-options.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Added an optional `options` argument to the POS `cart.addLineItem` method so a single call can create a line item and decorate it with line-item properties (`properties`) in one operation. This avoids the extra native call and cart sync of chaining `addLineItem` → `addLineItemProperties`. Backwards compatible—the third argument is optional. Adds the `AddLineItemOptions` type.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -17,6 +17,7 @@
     "floppy-camels-bet",
     "mean-ducks-join",
     "paragraph-text-align",
+    "pos-cart-add-line-item-options",
     "pos-data-target-readonly-cart",
     "sixty-points-doubt",
     "soft-otters-share",

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -98,6 +98,7 @@ export type {ToastApiContent, ToastApi} from './api/toast-api/toast-api';
 
 // Type exports
 export type {
+  AddLineItemOptions,
   Cart,
   CartUpdateInput,
   Customer,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/cart-api/cart-api.ts
@@ -1,5 +1,6 @@
 import type {ReadonlySignalLike} from '../../../../shared';
 import type {
+  AddLineItemOptions,
   Address,
   Cart,
   CartUpdateInput,
@@ -123,12 +124,19 @@ export interface MutableCartApiContent {
   /**
    * Add a product variant to the cart by its numeric `ID` with the specified quantity. Returns the `UUID` of the newly added line item, or an empty string if the user dismissed an oversell guard modal. Throws an error if POS fails to add the line item due to validation or system errors.
    *
+   * Pass `options` to attach line-item properties in the same operation, instead of following up with a separate `addLineItemProperties` call.
+   *
    * @param variantId the product variant's numeric ID to add to the cart
    * @param quantity the number of this variant to add to the cart
+   * @param options optional line-item properties to apply to the new line item in the same operation
    * @returns {string} the UUID of the line item added, or the empty string if the user dismissed an oversell guard modal
    * @throws {Error} if POS fails to add the line item
    */
-  addLineItem(variantId: number, quantity: number): Promise<string>;
+  addLineItem(
+    variantId: number,
+    quantity: number,
+    options?: AddLineItemOptions,
+  ): Promise<string>;
 
   /**
    * Remove a specific line item from the cart using its `UUID`. The line item will be completely removed from the cart along with any associated discounts, properties, or selling plans.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -264,6 +264,17 @@ export interface Discount {
 }
 
 /**
+ * Optional configuration for `addLineItem`. Lets a single call create a line item and decorate it with line-item properties, avoiding the extra native call and cart sync of a separate `addLineItemProperties` call.
+ * @publicDocs
+ */
+export interface AddLineItemOptions {
+  /**
+   * Custom key-value properties to attach to the newly created line item. Equivalent to calling `addLineItemProperties` with the returned `UUID`, but applied in the same operation.
+   */
+  properties?: Record<string, string>;
+}
+
+/**
  * Specifies the parameters for adding custom properties to line items. Properties are key-value pairs used for storing metadata, tracking information, or integration data.
  * @publicDocs
  */


### PR DESCRIPTION
Part of https://github.com/shop/issues-retail/issues/28967
[Dev Forum Request](https://community.shopify.dev/t/shopify-pos-ui-extension-shopify-cart-addlineitem-performance-bottleneck/33885/17?u=victor_chu)

## What

Add an optional third argument to the POS `cart.addLineItem` method so a single call can create a line item and decorate it with line-item properties:

```ts
cart.addLineItem(variantId, quantity, options?: {
  properties?: Record<string, string>; // line-item properties
});
```

Introduces the `AddLineItemOptions` type. Backwards compatible — the third argument is optional, so existing two-argument calls are unchanged.

## Why

Cafe-style POS extensions adding a "modified item" (e.g. coffee + modifiers) currently chain two extension API calls:

```ts
const uuid = await cart.addLineItem(variantId, 1);
await cart.addLineItemProperties(uuid, {modifiers: 'oat milk,extra shot'});
```

Each call awaits its own native SDK call and `syncDraftCheckout` round-trip — measured at ~3s p50 for the sequential pattern.
