### PR TITLE
Fix broken web components links in Admin API descriptions (2025-10)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data_v2.json
@@ -1790,7 +1790,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -1798,7 +1798,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1806,7 +1806,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1814,7 +1814,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1822,7 +1822,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1830,7 +1830,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1838,7 +1838,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3012,7 +3012,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -3020,7 +3020,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3028,7 +3028,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3036,7 +3036,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3044,7 +3044,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3052,7 +3052,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3060,7 +3060,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4619,7 +4619,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4627,7 +4627,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4683,7 +4683,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4691,7 +4691,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4699,7 +4699,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4779,7 +4779,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -4787,7 +4787,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4795,7 +4795,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4803,7 +4803,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4811,7 +4811,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4819,7 +4819,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4827,7 +4827,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5146,7 +5146,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -5154,7 +5154,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5162,7 +5162,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5170,7 +5170,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5178,7 +5178,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5186,7 +5186,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5194,7 +5194,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7748,7 +7748,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -7780,7 +7780,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -7788,7 +7788,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7796,7 +7796,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7876,7 +7876,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -7884,7 +7884,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7892,7 +7892,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7900,7 +7900,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7908,7 +7908,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7916,7 +7916,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7924,7 +7924,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16249,7 +16249,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -16257,7 +16257,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16265,7 +16265,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16273,7 +16273,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16281,7 +16281,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16289,7 +16289,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16297,11 +16297,11 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface BoxProps\n  extends Pick<\n    RequiredBoxProps,\n    | 'accessibilityLabel'\n    | 'accessibilityRole'\n    | 'accessibilityVisibility'\n    | 'background'\n    | 'blockSize'\n    | 'border'\n    | 'borderColor'\n    | 'borderRadius'\n    | 'borderStyle'\n    | 'borderWidth'\n    | 'inlineSize'\n    | 'maxBlockSize'\n    | 'maxInlineSize'\n    | 'minBlockSize'\n    | 'minInlineSize'\n    | 'overflow'\n  > {\n  /**\n   * The background color of the component.\n   *\n   * @default 'transparent'\n   */\n  background: Extract<\n    RequiredBoxProps['background'],\n    'transparent' | 'base' | 'subdued' | 'strong'\n  >;\n  /**\n   * The thickness of the border on all sides.\n   *\n   * When set, this overrides the width value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderWidth:\n    | MaybeAllValuesShorthandProperty<\n        Extract<\n          RequiredBoxProps['borderWidth'],\n          'small-100' | 'small' | 'base' | 'large' | 'large-100' | 'none'\n        >\n      >\n    | Extract<RequiredBoxProps['borderWidth'], ''>;\n  /**\n   * The visual style of the border on all sides, such as solid, dashed, or dotted.\n   *\n   * When set, this overrides the style value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderStyle:\n    | MaybeAllValuesShorthandProperty<BoxBorderStyles>\n    | Extract<RequiredBoxProps['borderStyle'], ''>;\n  /**\n   * The color of the border using the design system's color scale.\n   *\n   * When set, this overrides the color value specified in the `border` property.\n   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.\n   *\n   * @default '' - meaning no override\n   */\n  borderColor: Extract<\n    RequiredBoxProps['borderColor'],\n    'subdued' | 'base' | 'strong' | ''\n  >;\n  /**\n   * The roundedness of the element's corners using the design system's radius scale.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.\n   *\n   * @default 'none'\n   */\n  borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;\n  /**\n   * The padding applied to all edges of the component.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n   * - 1 value applies to all sides\n   * - 2 values apply to block (top/bottom) and inline (left/right)\n   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n   *\n   * **Examples:** `base`, `large none`, `base large-100 base small`\n   *\n   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default 'none'\n   */\n  padding: ResponsiveBoxProps['padding'];\n  /**\n   * The block-direction padding (top and bottom in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for block-start and block-end.\n   *\n   * **Example:** `large none` applies `large` to the top and `none` to the bottom.\n   *\n   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlock: ResponsiveBoxProps['paddingBlock'];\n  /**\n   * The block-start padding (top in horizontal writing modes).\n   *\n   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];\n  /**\n   * The block-end padding (bottom in horizontal writing modes).\n   *\n   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];\n  /**\n   * The inline-direction padding (left and right in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.\n   *\n   * **Example:** `large none` applies `large` to the left and `none` to the right.\n   *\n   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInline: ResponsiveBoxProps['paddingInline'];\n  /**\n   * The inline-start padding (left in LTR writing modes, right in RTL).\n   *\n   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];\n  /**\n   * The inline-end padding (right in LTR writing modes, left in RTL).\n   *\n   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];\n  /**\n   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n   *\n   * - `auto` the component's initial value. The actual value depends on the component and context.\n   * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.\n   *\n   * @default 'auto'\n   */\n  display: ResponsiveBoxProps['display'];\n  /**\n   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n   *\n   * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;\n   * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n   *\n   * Learn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n   *\n   * @default 'auto'\n   */\n  blockSize: SizeUnitsOrAuto;\n  /**\n   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).\n   *\n   * @default '0'\n   */\n  minBlockSize: SizeUnits;\n  /**\n   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).\n   *\n   * @default 'none'\n   */\n  maxBlockSize: SizeUnitsOrNone;\n  /**\n   * The width in horizontal writing modes, or height in vertical writing modes.\n   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n   *\n   * @default 'auto'\n   */\n  inlineSize: SizeUnitsOrAuto;\n  /**\n   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).\n   *\n   * @default '0'\n   */\n  minInlineSize: SizeUnits;\n  /**\n   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).\n   *\n   * @default 'none'\n   */\n  maxInlineSize: SizeUnitsOrNone;\n}"
+      "value": "export interface BoxProps\n  extends Pick<\n    RequiredBoxProps,\n    | 'accessibilityLabel'\n    | 'accessibilityRole'\n    | 'accessibilityVisibility'\n    | 'background'\n    | 'blockSize'\n    | 'border'\n    | 'borderColor'\n    | 'borderRadius'\n    | 'borderStyle'\n    | 'borderWidth'\n    | 'inlineSize'\n    | 'maxBlockSize'\n    | 'maxInlineSize'\n    | 'minBlockSize'\n    | 'minInlineSize'\n    | 'overflow'\n  > {\n  /**\n   * The background color of the component.\n   *\n   * @default 'transparent'\n   */\n  background: Extract<\n    RequiredBoxProps['background'],\n    'transparent' | 'base' | 'subdued' | 'strong'\n  >;\n  /**\n   * The thickness of the border on all sides.\n   *\n   * When set, this overrides the width value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderWidth:\n    | MaybeAllValuesShorthandProperty<\n        Extract<\n          RequiredBoxProps['borderWidth'],\n          'small-100' | 'small' | 'base' | 'large' | 'large-100' | 'none'\n        >\n      >\n    | Extract<RequiredBoxProps['borderWidth'], ''>;\n  /**\n   * The visual style of the border on all sides, such as solid, dashed, or dotted.\n   *\n   * When set, this overrides the style value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderStyle:\n    | MaybeAllValuesShorthandProperty<BoxBorderStyles>\n    | Extract<RequiredBoxProps['borderStyle'], ''>;\n  /**\n   * The color of the border using the design system's color scale.\n   *\n   * When set, this overrides the color value specified in the `border` property.\n   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.\n   *\n   * @default '' - meaning no override\n   */\n  borderColor: Extract<\n    RequiredBoxProps['borderColor'],\n    'subdued' | 'base' | 'strong' | ''\n  >;\n  /**\n   * The roundedness of the element's corners using the design system's radius scale.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.\n   *\n   * @default 'none'\n   */\n  borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;\n  /**\n   * The padding applied to all edges of the component.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n   * - 1 value applies to all sides\n   * - 2 values apply to block (top/bottom) and inline (left/right)\n   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n   *\n   * **Examples:** `base`, `large none`, `base large-100 base small`\n   *\n   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default 'none'\n   */\n  padding: ResponsiveBoxProps['padding'];\n  /**\n   * The block-direction padding (top and bottom in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for block-start and block-end.\n   *\n   * **Example:** `large none` applies `large` to the top and `none` to the bottom.\n   *\n   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlock: ResponsiveBoxProps['paddingBlock'];\n  /**\n   * The block-start padding (top in horizontal writing modes).\n   *\n   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];\n  /**\n   * The block-end padding (bottom in horizontal writing modes).\n   *\n   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];\n  /**\n   * The inline-direction padding (left and right in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.\n   *\n   * **Example:** `large none` applies `large` to the left and `none` to the right.\n   *\n   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInline: ResponsiveBoxProps['paddingInline'];\n  /**\n   * The inline-start padding (left in LTR writing modes, right in RTL).\n   *\n   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];\n  /**\n   * The inline-end padding (right in LTR writing modes, left in RTL).\n   *\n   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];\n  /**\n   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n   *\n   * - `auto` the component's initial value. The actual value depends on the component and context.\n   * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.\n   *\n   * @default 'auto'\n   */\n  display: ResponsiveBoxProps['display'];\n  /**\n   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n   *\n   * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;\n   * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n   *\n   * Learn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n   *\n   * @default 'auto'\n   */\n  blockSize: SizeUnitsOrAuto;\n  /**\n   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).\n   *\n   * @default '0'\n   */\n  minBlockSize: SizeUnits;\n  /**\n   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).\n   *\n   * @default 'none'\n   */\n  maxBlockSize: SizeUnitsOrNone;\n  /**\n   * The width in horizontal writing modes, or height in vertical writing modes.\n   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n   *\n   * @default 'auto'\n   */\n  inlineSize: SizeUnitsOrAuto;\n  /**\n   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).\n   *\n   * @default '0'\n   */\n  minInlineSize: SizeUnits;\n  /**\n   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).\n   *\n   * @default 'none'\n   */\n  maxInlineSize: SizeUnitsOrNone;\n}"
     }
   },
   "BoxJSXProps": {
@@ -16484,7 +16484,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -16492,7 +16492,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16500,7 +16500,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16508,7 +16508,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16516,7 +16516,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16524,7 +16524,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16532,7 +16532,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -17925,7 +17925,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -17933,7 +17933,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17941,7 +17941,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17949,7 +17949,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17957,7 +17957,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17965,7 +17965,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17973,7 +17973,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18270,7 +18270,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -18278,7 +18278,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18286,7 +18286,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18294,7 +18294,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18302,7 +18302,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18310,7 +18310,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18318,7 +18318,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20089,7 +20089,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20105,7 +20105,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20113,7 +20113,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20121,7 +20121,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20194,7 +20194,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20202,7 +20202,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20210,7 +20210,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20218,7 +20218,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20226,7 +20226,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20234,7 +20234,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20242,7 +20242,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20266,11 +20266,11 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface GridProps\n  extends BoxProps,\n    Required<\n      Pick<\n        GridProps$1,\n        | 'alignItems'\n        | 'justifyItems'\n        | 'placeItems'\n        | 'alignContent'\n        | 'justifyContent'\n        | 'placeContent'\n      >\n    > {\n  /**\n   * Aligns the grid items along the block axis.\n   *\n   * @default '' - meaning no override\n   */\n  alignItems: AlignItemsKeyword | '';\n  /**\n   * Aligns the grid items along the inline axis.\n   *\n   * @default '' - meaning no override\n   */\n  justifyItems: JustifyItemsKeyword | '';\n  /**\n   * A shorthand property for `justify-items` and `align-items`.\n   *\n   * @default 'normal normal'\n   */\n  placeItems: `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword;\n  /**\n   * Aligns the grid along the block axis. This overrides the block value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  alignContent: AlignContentKeyword | '';\n  /**\n   * Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  justifyContent: JustifyContentKeyword | '';\n  /**\n   * A shorthand property for `justify-content` and `align-content`.\n   *\n   * @default 'normal normal'\n   */\n  placeContent:\n    | `${AlignContentKeyword} ${JustifyContentKeyword}`\n    | AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveGridProps['gap'];\n  /**\n   * s spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveGridProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveGridProps['columnGap'];\n  /**\n   * The columns in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];\n  /**\n   * The rows in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateRows: ResponsiveGridProps['gridTemplateRows'];\n}"
+      "value": "export interface GridProps\n  extends BoxProps,\n    Required<\n      Pick<\n        GridProps$1,\n        | 'alignItems'\n        | 'justifyItems'\n        | 'placeItems'\n        | 'alignContent'\n        | 'justifyContent'\n        | 'placeContent'\n      >\n    > {\n  /**\n   * Aligns the grid items along the block axis.\n   *\n   * @default '' - meaning no override\n   */\n  alignItems: AlignItemsKeyword | '';\n  /**\n   * Aligns the grid items along the inline axis.\n   *\n   * @default '' - meaning no override\n   */\n  justifyItems: JustifyItemsKeyword | '';\n  /**\n   * A shorthand property for `justify-items` and `align-items`.\n   *\n   * @default 'normal normal'\n   */\n  placeItems: `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword;\n  /**\n   * Aligns the grid along the block axis. This overrides the block value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  alignContent: AlignContentKeyword | '';\n  /**\n   * Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  justifyContent: JustifyContentKeyword | '';\n  /**\n   * A shorthand property for `justify-content` and `align-content`.\n   *\n   * @default 'normal normal'\n   */\n  placeContent:\n    | `${AlignContentKeyword} ${JustifyContentKeyword}`\n    | AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveGridProps['gap'];\n  /**\n   * s spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveGridProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveGridProps['columnGap'];\n  /**\n   * The columns in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];\n  /**\n   * The rows in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateRows: ResponsiveGridProps['gridTemplateRows'];\n}"
     }
   },
   "GridJSXProps": {
@@ -20404,7 +20404,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20420,7 +20420,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20428,7 +20428,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20436,7 +20436,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20517,7 +20517,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20525,7 +20525,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20533,7 +20533,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20541,7 +20541,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20549,7 +20549,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20557,7 +20557,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20565,7 +20565,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20589,7 +20589,7 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -20776,7 +20776,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20784,7 +20784,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20792,7 +20792,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20800,7 +20800,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20808,7 +20808,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20816,7 +20816,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20824,7 +20824,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -21027,7 +21027,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -21035,7 +21035,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21043,7 +21043,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21051,7 +21051,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21059,7 +21059,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21067,7 +21067,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21075,7 +21075,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -24782,7 +24782,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24790,7 +24790,7 @@
           "syntaxKind": "PropertySignature",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -24806,7 +24806,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -24871,7 +24871,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -24879,7 +24879,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24887,7 +24887,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24895,7 +24895,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24903,7 +24903,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24911,7 +24911,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24919,7 +24919,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24927,11 +24927,11 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface StackProps\n  extends BoxProps,\n    Pick<\n      Required<AlignedStackProps>,\n      'justifyContent' | 'alignItems' | 'alignContent'\n    > {\n  /**\n   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n   *\n   * Use this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.\n   *\n   * @default 'normal'\n   */\n  justifyContent: JustifyContentKeyword;\n  /**\n   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n   *\n   * Use this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.\n   *\n   * @default 'normal'\n   */\n  alignItems: AlignItemsKeyword;\n  /**\n   * Controls the distribution of lines along the block axis when content wraps into multiple lines.\n   *\n   * This property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.\n   *\n   * @default 'normal'\n   */\n  alignContent: AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveStackProps['gap'];\n  /**\n   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveStackProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveStackProps['columnGap'];\n  /**\n   * The direction in which the stack's children are placed within the stack.\n   *\n   * Accepts:\n   * - A single value, either `inline` or `block`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value\n   *\n   * @default 'block'\n   *\n   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'\n   */\n  direction: ResponsiveStackProps['direction'];\n}"
+      "value": "export interface StackProps\n  extends BoxProps,\n    Pick<\n      Required<AlignedStackProps>,\n      'justifyContent' | 'alignItems' | 'alignContent'\n    > {\n  /**\n   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n   *\n   * Use this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.\n   *\n   * @default 'normal'\n   */\n  justifyContent: JustifyContentKeyword;\n  /**\n   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n   *\n   * Use this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.\n   *\n   * @default 'normal'\n   */\n  alignItems: AlignItemsKeyword;\n  /**\n   * Controls the distribution of lines along the block axis when content wraps into multiple lines.\n   *\n   * This property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.\n   *\n   * @default 'normal'\n   */\n  alignContent: AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveStackProps['gap'];\n  /**\n   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveStackProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveStackProps['columnGap'];\n  /**\n   * The direction in which the stack's children are placed within the stack.\n   *\n   * Accepts:\n   * - A single value, either `inline` or `block`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value\n   *\n   * @default 'block'\n   *\n   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'\n   */\n  direction: ResponsiveStackProps['direction'];\n}"
     }
   },
   "StackJSXProps": {
@@ -25065,7 +25065,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25073,7 +25073,7 @@
           "syntaxKind": "PropertySignature",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -25089,7 +25089,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -25162,7 +25162,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -25170,7 +25170,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25178,7 +25178,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25186,7 +25186,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25194,7 +25194,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25202,7 +25202,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25210,7 +25210,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25218,7 +25218,7 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -1790,7 +1790,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -1798,7 +1798,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1806,7 +1806,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1814,7 +1814,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1822,7 +1822,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1830,7 +1830,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1838,7 +1838,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3012,7 +3012,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -3020,7 +3020,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3028,7 +3028,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3036,7 +3036,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3044,7 +3044,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3052,7 +3052,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3060,7 +3060,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4619,7 +4619,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4627,7 +4627,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4683,7 +4683,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4691,7 +4691,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4699,7 +4699,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4779,7 +4779,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -4787,7 +4787,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4795,7 +4795,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4803,7 +4803,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4811,7 +4811,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4819,7 +4819,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4827,7 +4827,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5146,7 +5146,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -5154,7 +5154,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5162,7 +5162,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5170,7 +5170,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5178,7 +5178,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5186,7 +5186,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5194,7 +5194,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7748,7 +7748,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -7780,7 +7780,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -7788,7 +7788,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7796,7 +7796,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7876,7 +7876,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -7884,7 +7884,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7892,7 +7892,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7900,7 +7900,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7908,7 +7908,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7916,7 +7916,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7924,7 +7924,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16249,7 +16249,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -16257,7 +16257,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16265,7 +16265,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16273,7 +16273,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16281,7 +16281,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16289,7 +16289,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16297,11 +16297,11 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface BoxProps\n  extends Pick<\n    RequiredBoxProps,\n    | 'accessibilityLabel'\n    | 'accessibilityRole'\n    | 'accessibilityVisibility'\n    | 'background'\n    | 'blockSize'\n    | 'border'\n    | 'borderColor'\n    | 'borderRadius'\n    | 'borderStyle'\n    | 'borderWidth'\n    | 'inlineSize'\n    | 'maxBlockSize'\n    | 'maxInlineSize'\n    | 'minBlockSize'\n    | 'minInlineSize'\n    | 'overflow'\n  > {\n  /**\n   * The background color of the component.\n   *\n   * @default 'transparent'\n   */\n  background: Extract<\n    RequiredBoxProps['background'],\n    'transparent' | 'base' | 'subdued' | 'strong'\n  >;\n  /**\n   * The thickness of the border on all sides.\n   *\n   * When set, this overrides the width value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderWidth:\n    | MaybeAllValuesShorthandProperty<\n        Extract<\n          RequiredBoxProps['borderWidth'],\n          'small-100' | 'small' | 'base' | 'large' | 'large-100' | 'none'\n        >\n      >\n    | Extract<RequiredBoxProps['borderWidth'], ''>;\n  /**\n   * The visual style of the border on all sides, such as solid, dashed, or dotted.\n   *\n   * When set, this overrides the style value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderStyle:\n    | MaybeAllValuesShorthandProperty<BoxBorderStyles>\n    | Extract<RequiredBoxProps['borderStyle'], ''>;\n  /**\n   * The color of the border using the design system's color scale.\n   *\n   * When set, this overrides the color value specified in the `border` property.\n   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.\n   *\n   * @default '' - meaning no override\n   */\n  borderColor: Extract<\n    RequiredBoxProps['borderColor'],\n    'subdued' | 'base' | 'strong' | ''\n  >;\n  /**\n   * The roundedness of the element's corners using the design system's radius scale.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.\n   *\n   * @default 'none'\n   */\n  borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;\n  /**\n   * The padding applied to all edges of the component.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n   * - 1 value applies to all sides\n   * - 2 values apply to block (top/bottom) and inline (left/right)\n   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n   *\n   * **Examples:** `base`, `large none`, `base large-100 base small`\n   *\n   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default 'none'\n   */\n  padding: ResponsiveBoxProps['padding'];\n  /**\n   * The block-direction padding (top and bottom in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for block-start and block-end.\n   *\n   * **Example:** `large none` applies `large` to the top and `none` to the bottom.\n   *\n   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlock: ResponsiveBoxProps['paddingBlock'];\n  /**\n   * The block-start padding (top in horizontal writing modes).\n   *\n   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];\n  /**\n   * The block-end padding (bottom in horizontal writing modes).\n   *\n   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];\n  /**\n   * The inline-direction padding (left and right in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.\n   *\n   * **Example:** `large none` applies `large` to the left and `none` to the right.\n   *\n   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInline: ResponsiveBoxProps['paddingInline'];\n  /**\n   * The inline-start padding (left in LTR writing modes, right in RTL).\n   *\n   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];\n  /**\n   * The inline-end padding (right in LTR writing modes, left in RTL).\n   *\n   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];\n  /**\n   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n   *\n   * - `auto` the component's initial value. The actual value depends on the component and context.\n   * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.\n   *\n   * @default 'auto'\n   */\n  display: ResponsiveBoxProps['display'];\n  /**\n   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n   *\n   * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;\n   * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n   *\n   * Learn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n   *\n   * @default 'auto'\n   */\n  blockSize: SizeUnitsOrAuto;\n  /**\n   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).\n   *\n   * @default '0'\n   */\n  minBlockSize: SizeUnits;\n  /**\n   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).\n   *\n   * @default 'none'\n   */\n  maxBlockSize: SizeUnitsOrNone;\n  /**\n   * The width in horizontal writing modes, or height in vertical writing modes.\n   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n   *\n   * @default 'auto'\n   */\n  inlineSize: SizeUnitsOrAuto;\n  /**\n   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).\n   *\n   * @default '0'\n   */\n  minInlineSize: SizeUnits;\n  /**\n   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).\n   *\n   * @default 'none'\n   */\n  maxInlineSize: SizeUnitsOrNone;\n}"
+      "value": "export interface BoxProps\n  extends Pick<\n    RequiredBoxProps,\n    | 'accessibilityLabel'\n    | 'accessibilityRole'\n    | 'accessibilityVisibility'\n    | 'background'\n    | 'blockSize'\n    | 'border'\n    | 'borderColor'\n    | 'borderRadius'\n    | 'borderStyle'\n    | 'borderWidth'\n    | 'inlineSize'\n    | 'maxBlockSize'\n    | 'maxInlineSize'\n    | 'minBlockSize'\n    | 'minInlineSize'\n    | 'overflow'\n  > {\n  /**\n   * The background color of the component.\n   *\n   * @default 'transparent'\n   */\n  background: Extract<\n    RequiredBoxProps['background'],\n    'transparent' | 'base' | 'subdued' | 'strong'\n  >;\n  /**\n   * The thickness of the border on all sides.\n   *\n   * When set, this overrides the width value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderWidth:\n    | MaybeAllValuesShorthandProperty<\n        Extract<\n          RequiredBoxProps['borderWidth'],\n          'small-100' | 'small' | 'base' | 'large' | 'large-100' | 'none'\n        >\n      >\n    | Extract<RequiredBoxProps['borderWidth'], ''>;\n  /**\n   * The visual style of the border on all sides, such as solid, dashed, or dotted.\n   *\n   * When set, this overrides the style value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderStyle:\n    | MaybeAllValuesShorthandProperty<BoxBorderStyles>\n    | Extract<RequiredBoxProps['borderStyle'], ''>;\n  /**\n   * The color of the border using the design system's color scale.\n   *\n   * When set, this overrides the color value specified in the `border` property.\n   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.\n   *\n   * @default '' - meaning no override\n   */\n  borderColor: Extract<\n    RequiredBoxProps['borderColor'],\n    'subdued' | 'base' | 'strong' | ''\n  >;\n  /**\n   * The roundedness of the element's corners using the design system's radius scale.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.\n   *\n   * @default 'none'\n   */\n  borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;\n  /**\n   * The padding applied to all edges of the component.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n   * - 1 value applies to all sides\n   * - 2 values apply to block (top/bottom) and inline (left/right)\n   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n   *\n   * **Examples:** `base`, `large none`, `base large-100 base small`\n   *\n   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default 'none'\n   */\n  padding: ResponsiveBoxProps['padding'];\n  /**\n   * The block-direction padding (top and bottom in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for block-start and block-end.\n   *\n   * **Example:** `large none` applies `large` to the top and `none` to the bottom.\n   *\n   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlock: ResponsiveBoxProps['paddingBlock'];\n  /**\n   * The block-start padding (top in horizontal writing modes).\n   *\n   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];\n  /**\n   * The block-end padding (bottom in horizontal writing modes).\n   *\n   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];\n  /**\n   * The inline-direction padding (left and right in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.\n   *\n   * **Example:** `large none` applies `large` to the left and `none` to the right.\n   *\n   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInline: ResponsiveBoxProps['paddingInline'];\n  /**\n   * The inline-start padding (left in LTR writing modes, right in RTL).\n   *\n   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];\n  /**\n   * The inline-end padding (right in LTR writing modes, left in RTL).\n   *\n   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];\n  /**\n   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n   *\n   * - `auto` the component's initial value. The actual value depends on the component and context.\n   * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.\n   *\n   * @default 'auto'\n   */\n  display: ResponsiveBoxProps['display'];\n  /**\n   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n   *\n   * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;\n   * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n   *\n   * Learn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n   *\n   * @default 'auto'\n   */\n  blockSize: SizeUnitsOrAuto;\n  /**\n   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).\n   *\n   * @default '0'\n   */\n  minBlockSize: SizeUnits;\n  /**\n   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).\n   *\n   * @default 'none'\n   */\n  maxBlockSize: SizeUnitsOrNone;\n  /**\n   * The width in horizontal writing modes, or height in vertical writing modes.\n   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n   *\n   * @default 'auto'\n   */\n  inlineSize: SizeUnitsOrAuto;\n  /**\n   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).\n   *\n   * @default '0'\n   */\n  minInlineSize: SizeUnits;\n  /**\n   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).\n   *\n   * @default 'none'\n   */\n  maxInlineSize: SizeUnitsOrNone;\n}"
     }
   },
   "BoxJSXProps": {
@@ -16484,7 +16484,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -16492,7 +16492,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16500,7 +16500,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16508,7 +16508,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16516,7 +16516,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16524,7 +16524,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16532,7 +16532,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -17925,7 +17925,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -17933,7 +17933,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17941,7 +17941,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17949,7 +17949,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17957,7 +17957,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17965,7 +17965,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17973,7 +17973,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18270,7 +18270,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -18278,7 +18278,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18286,7 +18286,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18294,7 +18294,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18302,7 +18302,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18310,7 +18310,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18318,7 +18318,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20089,7 +20089,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20105,7 +20105,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20113,7 +20113,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20121,7 +20121,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20194,7 +20194,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20202,7 +20202,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20210,7 +20210,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20218,7 +20218,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20226,7 +20226,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20234,7 +20234,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20242,7 +20242,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20266,11 +20266,11 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface GridProps\n  extends BoxProps,\n    Required<\n      Pick<\n        GridProps$1,\n        | 'alignItems'\n        | 'justifyItems'\n        | 'placeItems'\n        | 'alignContent'\n        | 'justifyContent'\n        | 'placeContent'\n      >\n    > {\n  /**\n   * Aligns the grid items along the block axis.\n   *\n   * @default '' - meaning no override\n   */\n  alignItems: AlignItemsKeyword | '';\n  /**\n   * Aligns the grid items along the inline axis.\n   *\n   * @default '' - meaning no override\n   */\n  justifyItems: JustifyItemsKeyword | '';\n  /**\n   * A shorthand property for `justify-items` and `align-items`.\n   *\n   * @default 'normal normal'\n   */\n  placeItems: `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword;\n  /**\n   * Aligns the grid along the block axis. This overrides the block value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  alignContent: AlignContentKeyword | '';\n  /**\n   * Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  justifyContent: JustifyContentKeyword | '';\n  /**\n   * A shorthand property for `justify-content` and `align-content`.\n   *\n   * @default 'normal normal'\n   */\n  placeContent:\n    | `${AlignContentKeyword} ${JustifyContentKeyword}`\n    | AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveGridProps['gap'];\n  /**\n   * s spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveGridProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveGridProps['columnGap'];\n  /**\n   * The columns in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];\n  /**\n   * The rows in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateRows: ResponsiveGridProps['gridTemplateRows'];\n}"
+      "value": "export interface GridProps\n  extends BoxProps,\n    Required<\n      Pick<\n        GridProps$1,\n        | 'alignItems'\n        | 'justifyItems'\n        | 'placeItems'\n        | 'alignContent'\n        | 'justifyContent'\n        | 'placeContent'\n      >\n    > {\n  /**\n   * Aligns the grid items along the block axis.\n   *\n   * @default '' - meaning no override\n   */\n  alignItems: AlignItemsKeyword | '';\n  /**\n   * Aligns the grid items along the inline axis.\n   *\n   * @default '' - meaning no override\n   */\n  justifyItems: JustifyItemsKeyword | '';\n  /**\n   * A shorthand property for `justify-items` and `align-items`.\n   *\n   * @default 'normal normal'\n   */\n  placeItems: `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword;\n  /**\n   * Aligns the grid along the block axis. This overrides the block value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  alignContent: AlignContentKeyword | '';\n  /**\n   * Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  justifyContent: JustifyContentKeyword | '';\n  /**\n   * A shorthand property for `justify-content` and `align-content`.\n   *\n   * @default 'normal normal'\n   */\n  placeContent:\n    | `${AlignContentKeyword} ${JustifyContentKeyword}`\n    | AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveGridProps['gap'];\n  /**\n   * s spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveGridProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveGridProps['columnGap'];\n  /**\n   * The columns in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];\n  /**\n   * The rows in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateRows: ResponsiveGridProps['gridTemplateRows'];\n}"
     }
   },
   "GridJSXProps": {
@@ -20404,7 +20404,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20420,7 +20420,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20428,7 +20428,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20436,7 +20436,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20517,7 +20517,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20525,7 +20525,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20533,7 +20533,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20541,7 +20541,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20549,7 +20549,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20557,7 +20557,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20565,7 +20565,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20589,7 +20589,7 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -20776,7 +20776,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20784,7 +20784,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20792,7 +20792,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20800,7 +20800,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20808,7 +20808,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20816,7 +20816,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20824,7 +20824,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -21027,7 +21027,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -21035,7 +21035,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21043,7 +21043,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21051,7 +21051,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21059,7 +21059,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21067,7 +21067,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21075,7 +21075,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -24782,7 +24782,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24790,7 +24790,7 @@
           "syntaxKind": "PropertySignature",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -24806,7 +24806,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -24871,7 +24871,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -24879,7 +24879,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24887,7 +24887,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24895,7 +24895,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24903,7 +24903,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24911,7 +24911,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24919,7 +24919,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24927,11 +24927,11 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface StackProps\n  extends BoxProps,\n    Pick<\n      Required<AlignedStackProps>,\n      'justifyContent' | 'alignItems' | 'alignContent'\n    > {\n  /**\n   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n   *\n   * Use this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.\n   *\n   * @default 'normal'\n   */\n  justifyContent: JustifyContentKeyword;\n  /**\n   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n   *\n   * Use this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.\n   *\n   * @default 'normal'\n   */\n  alignItems: AlignItemsKeyword;\n  /**\n   * Controls the distribution of lines along the block axis when content wraps into multiple lines.\n   *\n   * This property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.\n   *\n   * @default 'normal'\n   */\n  alignContent: AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveStackProps['gap'];\n  /**\n   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveStackProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveStackProps['columnGap'];\n  /**\n   * The direction in which the stack's children are placed within the stack.\n   *\n   * Accepts:\n   * - A single value, either `inline` or `block`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value\n   *\n   * @default 'block'\n   *\n   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'\n   */\n  direction: ResponsiveStackProps['direction'];\n}"
+      "value": "export interface StackProps\n  extends BoxProps,\n    Pick<\n      Required<AlignedStackProps>,\n      'justifyContent' | 'alignItems' | 'alignContent'\n    > {\n  /**\n   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n   *\n   * Use this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.\n   *\n   * @default 'normal'\n   */\n  justifyContent: JustifyContentKeyword;\n  /**\n   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n   *\n   * Use this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.\n   *\n   * @default 'normal'\n   */\n  alignItems: AlignItemsKeyword;\n  /**\n   * Controls the distribution of lines along the block axis when content wraps into multiple lines.\n   *\n   * This property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.\n   *\n   * @default 'normal'\n   */\n  alignContent: AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveStackProps['gap'];\n  /**\n   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveStackProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveStackProps['columnGap'];\n  /**\n   * The direction in which the stack's children are placed within the stack.\n   *\n   * Accepts:\n   * - A single value, either `inline` or `block`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value\n   *\n   * @default 'block'\n   *\n   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'\n   */\n  direction: ResponsiveStackProps['direction'];\n}"
     }
   },
   "StackJSXProps": {
@@ -25065,7 +25065,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25073,7 +25073,7 @@
           "syntaxKind": "PropertySignature",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -25089,7 +25089,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -25162,7 +25162,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -25170,7 +25170,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25178,7 +25178,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25186,7 +25186,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25194,7 +25194,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25202,7 +25202,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25210,7 +25210,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25218,7 +25218,7 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2025-10/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2025-10/generated_docs_data_v2.json
@@ -1790,7 +1790,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -1798,7 +1798,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1806,7 +1806,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1814,7 +1814,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1822,7 +1822,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1830,7 +1830,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -1838,7 +1838,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3012,7 +3012,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -3020,7 +3020,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3028,7 +3028,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3036,7 +3036,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3044,7 +3044,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3052,7 +3052,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -3060,7 +3060,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4619,7 +4619,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4627,7 +4627,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4683,7 +4683,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -4691,7 +4691,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4699,7 +4699,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4779,7 +4779,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -4787,7 +4787,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4795,7 +4795,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4803,7 +4803,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4811,7 +4811,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4819,7 +4819,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -4827,7 +4827,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5146,7 +5146,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -5154,7 +5154,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5162,7 +5162,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5170,7 +5170,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5178,7 +5178,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5186,7 +5186,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -5194,7 +5194,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7748,7 +7748,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -7780,7 +7780,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -7788,7 +7788,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7796,7 +7796,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7876,7 +7876,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -7884,7 +7884,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7892,7 +7892,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7900,7 +7900,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7908,7 +7908,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7916,7 +7916,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -7924,7 +7924,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16249,7 +16249,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -16257,7 +16257,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16265,7 +16265,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16273,7 +16273,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16281,7 +16281,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16289,7 +16289,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16297,11 +16297,11 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface BoxProps\n  extends Pick<\n    RequiredBoxProps,\n    | 'accessibilityLabel'\n    | 'accessibilityRole'\n    | 'accessibilityVisibility'\n    | 'background'\n    | 'blockSize'\n    | 'border'\n    | 'borderColor'\n    | 'borderRadius'\n    | 'borderStyle'\n    | 'borderWidth'\n    | 'inlineSize'\n    | 'maxBlockSize'\n    | 'maxInlineSize'\n    | 'minBlockSize'\n    | 'minInlineSize'\n    | 'overflow'\n  > {\n  /**\n   * The background color of the component.\n   *\n   * @default 'transparent'\n   */\n  background: Extract<\n    RequiredBoxProps['background'],\n    'transparent' | 'base' | 'subdued' | 'strong'\n  >;\n  /**\n   * The thickness of the border on all sides.\n   *\n   * When set, this overrides the width value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderWidth:\n    | MaybeAllValuesShorthandProperty<\n        Extract<\n          RequiredBoxProps['borderWidth'],\n          'small-100' | 'small' | 'base' | 'large' | 'large-100' | 'none'\n        >\n      >\n    | Extract<RequiredBoxProps['borderWidth'], ''>;\n  /**\n   * The visual style of the border on all sides, such as solid, dashed, or dotted.\n   *\n   * When set, this overrides the style value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderStyle:\n    | MaybeAllValuesShorthandProperty<BoxBorderStyles>\n    | Extract<RequiredBoxProps['borderStyle'], ''>;\n  /**\n   * The color of the border using the design system's color scale.\n   *\n   * When set, this overrides the color value specified in the `border` property.\n   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.\n   *\n   * @default '' - meaning no override\n   */\n  borderColor: Extract<\n    RequiredBoxProps['borderColor'],\n    'subdued' | 'base' | 'strong' | ''\n  >;\n  /**\n   * The roundedness of the element's corners using the design system's radius scale.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.\n   *\n   * @default 'none'\n   */\n  borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;\n  /**\n   * The padding applied to all edges of the component.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n   * - 1 value applies to all sides\n   * - 2 values apply to block (top/bottom) and inline (left/right)\n   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n   *\n   * **Examples:** `base`, `large none`, `base large-100 base small`\n   *\n   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default 'none'\n   */\n  padding: ResponsiveBoxProps['padding'];\n  /**\n   * The block-direction padding (top and bottom in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for block-start and block-end.\n   *\n   * **Example:** `large none` applies `large` to the top and `none` to the bottom.\n   *\n   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlock: ResponsiveBoxProps['paddingBlock'];\n  /**\n   * The block-start padding (top in horizontal writing modes).\n   *\n   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];\n  /**\n   * The block-end padding (bottom in horizontal writing modes).\n   *\n   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];\n  /**\n   * The inline-direction padding (left and right in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.\n   *\n   * **Example:** `large none` applies `large` to the left and `none` to the right.\n   *\n   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInline: ResponsiveBoxProps['paddingInline'];\n  /**\n   * The inline-start padding (left in LTR writing modes, right in RTL).\n   *\n   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];\n  /**\n   * The inline-end padding (right in LTR writing modes, left in RTL).\n   *\n   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];\n  /**\n   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n   *\n   * - `auto` the component's initial value. The actual value depends on the component and context.\n   * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.\n   *\n   * @default 'auto'\n   */\n  display: ResponsiveBoxProps['display'];\n  /**\n   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n   *\n   * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;\n   * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n   *\n   * Learn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n   *\n   * @default 'auto'\n   */\n  blockSize: SizeUnitsOrAuto;\n  /**\n   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).\n   *\n   * @default '0'\n   */\n  minBlockSize: SizeUnits;\n  /**\n   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).\n   *\n   * @default 'none'\n   */\n  maxBlockSize: SizeUnitsOrNone;\n  /**\n   * The width in horizontal writing modes, or height in vertical writing modes.\n   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n   *\n   * @default 'auto'\n   */\n  inlineSize: SizeUnitsOrAuto;\n  /**\n   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).\n   *\n   * @default '0'\n   */\n  minInlineSize: SizeUnits;\n  /**\n   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).\n   *\n   * @default 'none'\n   */\n  maxInlineSize: SizeUnitsOrNone;\n}"
+      "value": "export interface BoxProps\n  extends Pick<\n    RequiredBoxProps,\n    | 'accessibilityLabel'\n    | 'accessibilityRole'\n    | 'accessibilityVisibility'\n    | 'background'\n    | 'blockSize'\n    | 'border'\n    | 'borderColor'\n    | 'borderRadius'\n    | 'borderStyle'\n    | 'borderWidth'\n    | 'inlineSize'\n    | 'maxBlockSize'\n    | 'maxInlineSize'\n    | 'minBlockSize'\n    | 'minInlineSize'\n    | 'overflow'\n  > {\n  /**\n   * The background color of the component.\n   *\n   * @default 'transparent'\n   */\n  background: Extract<\n    RequiredBoxProps['background'],\n    'transparent' | 'base' | 'subdued' | 'strong'\n  >;\n  /**\n   * The thickness of the border on all sides.\n   *\n   * When set, this overrides the width value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different widths per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderWidth:\n    | MaybeAllValuesShorthandProperty<\n        Extract<\n          RequiredBoxProps['borderWidth'],\n          'small-100' | 'small' | 'base' | 'large' | 'large-100' | 'none'\n        >\n      >\n    | Extract<RequiredBoxProps['borderWidth'], ''>;\n  /**\n   * The visual style of the border on all sides, such as solid, dashed, or dotted.\n   *\n   * When set, this overrides the style value specified in the `border` property.\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different styles per side.\n   *\n   * @default '' - meaning no override\n   */\n  borderStyle:\n    | MaybeAllValuesShorthandProperty<BoxBorderStyles>\n    | Extract<RequiredBoxProps['borderStyle'], ''>;\n  /**\n   * The color of the border using the design system's color scale.\n   *\n   * When set, this overrides the color value specified in the `border` property.\n   * Choose from `subdued`, `base`, or `strong` to match the visual emphasis needed.\n   *\n   * @default '' - meaning no override\n   */\n  borderColor: Extract<\n    RequiredBoxProps['borderColor'],\n    'subdued' | 'base' | 'strong' | ''\n  >;\n  /**\n   * The roundedness of the element's corners using the design system's radius scale.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) for specifying different radii per corner. Use this to create rounded corners or fully rounded elements.\n   *\n   * @default 'none'\n   */\n  borderRadius: MaybeAllValuesShorthandProperty<BoxBorderRadii>;\n  /**\n   * The padding applied to all edges of the component.\n   *\n   * Supports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n   * - 1 value applies to all sides\n   * - 2 values apply to block (top/bottom) and inline (left/right)\n   * - 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n   * - 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n   *\n   * **Examples:** `base`, `large none`, `base large-100 base small`\n   *\n   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default 'none'\n   */\n  padding: ResponsiveBoxProps['padding'];\n  /**\n   * The block-direction padding (top and bottom in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for block-start and block-end.\n   *\n   * **Example:** `large none` applies `large` to the top and `none` to the bottom.\n   *\n   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlock: ResponsiveBoxProps['paddingBlock'];\n  /**\n   * The block-start padding (top in horizontal writing modes).\n   *\n   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockStart: ResponsiveBoxProps['paddingBlockStart'];\n  /**\n   * The block-end padding (bottom in horizontal writing modes).\n   *\n   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingBlockEnd: ResponsiveBoxProps['paddingBlockEnd'];\n  /**\n   * The inline-direction padding (left and right in horizontal writing modes).\n   *\n   * Accepts a single value for both sides or two space-separated values for inline-start and inline-end.\n   *\n   * **Example:** `large none` applies `large` to the left and `none` to the right.\n   *\n   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInline: ResponsiveBoxProps['paddingInline'];\n  /**\n   * The inline-start padding (left in LTR writing modes, right in RTL).\n   *\n   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineStart: ResponsiveBoxProps['paddingInlineStart'];\n  /**\n   * The inline-end padding (right in LTR writing modes, left in RTL).\n   *\n   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.\n   *\n   * @default '' - meaning no override\n   */\n  paddingInlineEnd: ResponsiveBoxProps['paddingInlineEnd'];\n  /**\n   * The outer [display](https://developer.mozilla.org/en-US/docs/Web/CSS/display) type of the component. The outer type sets a component's participation in [flow layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout).\n   *\n   * - `auto` the component's initial value. The actual value depends on the component and context.\n   * - `none` hides the component from display and removes it from the accessibility tree, making it invisible to screen readers.\n   *\n   * @default 'auto'\n   */\n  display: ResponsiveBoxProps['display'];\n  /**\n   * The vertical size of the element in standard layouts (height in left-to-right or right-to-left writing modes).\n   *\n   * Block size adjusts based on the writing direction: in horizontal layouts, it controls the height;\n   * in vertical layouts, it controls the width. This ensures consistent behavior across different text directions.\n   *\n   * Learn more about [block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size).\n   *\n   * @default 'auto'\n   */\n  blockSize: SizeUnitsOrAuto;\n  /**\n   * The minimum height in horizontal writing modes, or minimum width in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size).\n   *\n   * @default '0'\n   */\n  minBlockSize: SizeUnits;\n  /**\n   * The maximum height in horizontal writing modes, or maximum width in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size).\n   *\n   * @default 'none'\n   */\n  maxBlockSize: SizeUnitsOrNone;\n  /**\n   * The width in horizontal writing modes, or height in vertical writing modes.\n   * Use this for flow-relative sizing that adapts to text direction. Learn more about [inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/inline-size).\n   *\n   * @default 'auto'\n   */\n  inlineSize: SizeUnitsOrAuto;\n  /**\n   * The minimum width in horizontal writing modes, or minimum height in vertical writing modes.\n   * Prevents the element from shrinking below this size.\n   *\n   * Learn more about [min-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size).\n   *\n   * @default '0'\n   */\n  minInlineSize: SizeUnits;\n  /**\n   * The maximum width in horizontal writing modes, or maximum height in vertical writing modes.\n   * Prevents the element from growing beyond this size.\n   *\n   * Learn more about [max-inline-size](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size).\n   *\n   * @default 'none'\n   */\n  maxInlineSize: SizeUnitsOrNone;\n}"
     }
   },
   "BoxJSXProps": {
@@ -16484,7 +16484,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -16492,7 +16492,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16500,7 +16500,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16508,7 +16508,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16516,7 +16516,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16524,7 +16524,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -16532,7 +16532,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -17925,7 +17925,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -17933,7 +17933,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17941,7 +17941,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17949,7 +17949,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17957,7 +17957,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17965,7 +17965,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -17973,7 +17973,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18270,7 +18270,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -18278,7 +18278,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18286,7 +18286,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18294,7 +18294,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18302,7 +18302,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18310,7 +18310,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -18318,7 +18318,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20089,7 +20089,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20105,7 +20105,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20113,7 +20113,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20121,7 +20121,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20194,7 +20194,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20202,7 +20202,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20210,7 +20210,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20218,7 +20218,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20226,7 +20226,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20234,7 +20234,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20242,7 +20242,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20266,11 +20266,11 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface GridProps\n  extends BoxProps,\n    Required<\n      Pick<\n        GridProps$1,\n        | 'alignItems'\n        | 'justifyItems'\n        | 'placeItems'\n        | 'alignContent'\n        | 'justifyContent'\n        | 'placeContent'\n      >\n    > {\n  /**\n   * Aligns the grid items along the block axis.\n   *\n   * @default '' - meaning no override\n   */\n  alignItems: AlignItemsKeyword | '';\n  /**\n   * Aligns the grid items along the inline axis.\n   *\n   * @default '' - meaning no override\n   */\n  justifyItems: JustifyItemsKeyword | '';\n  /**\n   * A shorthand property for `justify-items` and `align-items`.\n   *\n   * @default 'normal normal'\n   */\n  placeItems: `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword;\n  /**\n   * Aligns the grid along the block axis. This overrides the block value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  alignContent: AlignContentKeyword | '';\n  /**\n   * Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  justifyContent: JustifyContentKeyword | '';\n  /**\n   * A shorthand property for `justify-content` and `align-content`.\n   *\n   * @default 'normal normal'\n   */\n  placeContent:\n    | `${AlignContentKeyword} ${JustifyContentKeyword}`\n    | AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveGridProps['gap'];\n  /**\n   * s spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveGridProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveGridProps['columnGap'];\n  /**\n   * The columns in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];\n  /**\n   * The rows in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateRows: ResponsiveGridProps['gridTemplateRows'];\n}"
+      "value": "export interface GridProps\n  extends BoxProps,\n    Required<\n      Pick<\n        GridProps$1,\n        | 'alignItems'\n        | 'justifyItems'\n        | 'placeItems'\n        | 'alignContent'\n        | 'justifyContent'\n        | 'placeContent'\n      >\n    > {\n  /**\n   * Aligns the grid items along the block axis.\n   *\n   * @default '' - meaning no override\n   */\n  alignItems: AlignItemsKeyword | '';\n  /**\n   * Aligns the grid items along the inline axis.\n   *\n   * @default '' - meaning no override\n   */\n  justifyItems: JustifyItemsKeyword | '';\n  /**\n   * A shorthand property for `justify-items` and `align-items`.\n   *\n   * @default 'normal normal'\n   */\n  placeItems: `${AlignItemsKeyword} ${JustifyItemsKeyword}` | AlignItemsKeyword;\n  /**\n   * Aligns the grid along the block axis. This overrides the block value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  alignContent: AlignContentKeyword | '';\n  /**\n   * Aligns the grid along the inline axis. This overrides the inline value of `placeContent`.\n   *\n   * @default '' - meaning no override\n   */\n  justifyContent: JustifyContentKeyword | '';\n  /**\n   * A shorthand property for `justify-content` and `align-content`.\n   *\n   * @default 'normal normal'\n   */\n  placeContent:\n    | `${AlignContentKeyword} ${JustifyContentKeyword}`\n    | AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveGridProps['gap'];\n  /**\n   * s spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveGridProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveGridProps['columnGap'];\n  /**\n   * The columns in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];\n  /**\n   * The rows in the grid and their sizes.\n   *\n   * Accepts:\n   * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value\n   *\n   * @default 'none'\n   */\n  gridTemplateRows: ResponsiveGridProps['gridTemplateRows'];\n}"
     }
   },
   "GridJSXProps": {
@@ -20404,7 +20404,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20420,7 +20420,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20428,7 +20428,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateColumns",
           "value": "string",
-          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The columns in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20436,7 +20436,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gridTemplateRows",
           "value": "string",
-          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value",
+          "description": "The rows in the grid and their sizes.\n\nAccepts:\n- [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -20517,7 +20517,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20525,7 +20525,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20533,7 +20533,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20541,7 +20541,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20549,7 +20549,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20557,7 +20557,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20565,7 +20565,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20589,7 +20589,7 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "s spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -20776,7 +20776,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -20784,7 +20784,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20792,7 +20792,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20800,7 +20800,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20808,7 +20808,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20816,7 +20816,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -20824,7 +20824,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -21027,7 +21027,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -21035,7 +21035,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21043,7 +21043,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21051,7 +21051,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21059,7 +21059,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21067,7 +21067,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -21075,7 +21075,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         }
       ],
@@ -24782,7 +24782,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24790,7 +24790,7 @@
           "syntaxKind": "PropertySignature",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -24806,7 +24806,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -24871,7 +24871,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -24879,7 +24879,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24887,7 +24887,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24895,7 +24895,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24903,7 +24903,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24911,7 +24911,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24919,7 +24919,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -24927,11 +24927,11 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],
-      "value": "export interface StackProps\n  extends BoxProps,\n    Pick<\n      Required<AlignedStackProps>,\n      'justifyContent' | 'alignItems' | 'alignContent'\n    > {\n  /**\n   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n   *\n   * Use this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.\n   *\n   * @default 'normal'\n   */\n  justifyContent: JustifyContentKeyword;\n  /**\n   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n   *\n   * Use this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.\n   *\n   * @default 'normal'\n   */\n  alignItems: AlignItemsKeyword;\n  /**\n   * Controls the distribution of lines along the block axis when content wraps into multiple lines.\n   *\n   * This property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.\n   *\n   * @default 'normal'\n   */\n  alignContent: AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveStackProps['gap'];\n  /**\n   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveStackProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveStackProps['columnGap'];\n  /**\n   * The direction in which the stack's children are placed within the stack.\n   *\n   * Accepts:\n   * - A single value, either `inline` or `block`\n   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value\n   *\n   * @default 'block'\n   *\n   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'\n   */\n  direction: ResponsiveStackProps['direction'];\n}"
+      "value": "export interface StackProps\n  extends BoxProps,\n    Pick<\n      Required<AlignedStackProps>,\n      'justifyContent' | 'alignItems' | 'alignContent'\n    > {\n  /**\n   * Controls the distribution of children along the inline axis (horizontally in horizontal writing modes).\n   *\n   * Use this to position items along the primary axis of the stack - horizontally for inline stacks or vertically for block stacks when wrapped into multiple lines.\n   *\n   * @default 'normal'\n   */\n  justifyContent: JustifyContentKeyword;\n  /**\n   * Controls the alignment of children along the block axis (vertically in horizontal writing modes).\n   *\n   * Use this to align items perpendicular to the stack direction - vertically for inline stacks or horizontally for block stacks.\n   *\n   * @default 'normal'\n   */\n  alignItems: AlignItemsKeyword;\n  /**\n   * Controls the distribution of lines along the block axis when content wraps into multiple lines.\n   *\n   * This property only affects stacks with wrapping content. For single-line stacks, use `alignItems` instead.\n   *\n   * @default 'normal'\n   */\n  alignContent: AlignContentKeyword;\n  /**\n   * Adjusts spacing between elements.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n   * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default 'none'\n   */\n  gap: ResponsiveStackProps['gap'];\n  /**\n   * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  rowGap: ResponsiveStackProps['rowGap'];\n  /**\n   * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n   *\n   * Accepts:\n   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value\n   *\n   * @default '' - meaning no override\n   */\n  columnGap: ResponsiveStackProps['columnGap'];\n  /**\n   * The direction in which the stack's children are placed within the stack.\n   *\n   * Accepts:\n   * - A single value, either `inline` or `block`\n   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value\n   *\n   * @default 'block'\n   *\n   * @implementation the content will wrap if the direction is 'inline', and not wrap if the direction is 'block'\n   */\n  direction: ResponsiveStackProps['direction'];\n}"
     }
   },
   "StackJSXProps": {
@@ -25065,7 +25065,7 @@
           "syntaxKind": "PropertySignature",
           "name": "columnGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25073,7 +25073,7 @@
           "syntaxKind": "PropertySignature",
           "name": "direction",
           "value": "MaybeResponsive<\"inline\" | \"block\">",
-          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value",
+          "description": "The direction in which the stack's children are placed within the stack.\n\nAccepts:\n- A single value, either `inline` or `block`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value",
           "defaultValue": "'block'"
         },
         {
@@ -25089,7 +25089,7 @@
           "syntaxKind": "PropertySignature",
           "name": "gap",
           "value": "MaybeResponsive<MaybeTwoValuesShorthandProperty<SpacingKeyword>>",
-          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`\n- A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'none'"
         },
         {
@@ -25162,7 +25162,7 @@
           "syntaxKind": "PropertySignature",
           "name": "padding",
           "value": "MaybeResponsive<MaybeAllValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The padding applied to all edges of the component.\n\nSupports [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) using flow-relative values:\n- 1 value applies to all sides\n- 2 values apply to block (top/bottom) and inline (left/right)\n- 3 values apply to block-start (top), inline (left/right), and block-end (bottom)\n- 4 values apply to block-start (top), inline-end (right), block-end (bottom), and inline-start (left)\n\n**Examples:** `base`, `large none`, `base large-100 base small`\n\nUse `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'none'"
         },
         {
@@ -25170,7 +25170,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlock",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-direction padding (top and bottom in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for block-start and block-end.\n\n**Example:** `large none` applies `large` to the top and `none` to the bottom.\n\nOverrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25178,7 +25178,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-end padding (bottom in horizontal writing modes).\n\nOverrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25186,7 +25186,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingBlockStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The block-start padding (top in horizontal writing modes).\n\nOverrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25194,7 +25194,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInline",
           "value": "MaybeResponsive<\"\" | MaybeTwoValuesShorthandProperty<PaddingKeyword>>",
-          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-direction padding (left and right in horizontal writing modes).\n\nAccepts a single value for both sides or two space-separated values for inline-start and inline-end.\n\n**Example:** `large none` applies `large` to the left and `none` to the right.\n\nOverrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25202,7 +25202,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineEnd",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-end padding (right in LTR writing modes, left in RTL).\n\nOverrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25210,7 +25210,7 @@
           "syntaxKind": "PropertySignature",
           "name": "paddingInlineStart",
           "value": "MaybeResponsive<\"\" | PaddingKeyword>",
-          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
+          "description": "The inline-start padding (left in LTR writing modes, right in RTL).\n\nOverrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.",
           "defaultValue": "'' - meaning no override"
         },
         {
@@ -25218,7 +25218,7 @@
           "syntaxKind": "PropertySignature",
           "name": "rowGap",
           "value": "MaybeResponsive<\"\" | SpacingKeyword>",
-          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
+          "description": "Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.\n\nAccepts:\n- A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`\n- A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value",
           "defaultValue": "'' - meaning no override"
         }
       ],

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -5510,7 +5510,7 @@ export interface BoxProps
    *
    * **Examples:** `base`, `large none`, `base large-100 base small`
    *
-   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Use `auto` to inherit padding from the nearest container with removed padding. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -5522,7 +5522,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the top and `none` to the bottom.
    *
-   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5530,7 +5530,7 @@ export interface BoxProps
   /**
    * The block-start padding (top in horizontal writing modes).
    *
-   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-start value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5538,7 +5538,7 @@ export interface BoxProps
   /**
    * The block-end padding (bottom in horizontal writing modes).
    *
-   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the block-end value from `paddingBlock`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5550,7 +5550,7 @@ export interface BoxProps
    *
    * **Example:** `large none` applies `large` to the left and `none` to the right.
    *
-   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline value from `padding`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5558,7 +5558,7 @@ export interface BoxProps
   /**
    * The inline-start padding (left in LTR writing modes, right in RTL).
    *
-   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-start value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -5566,7 +5566,7 @@ export interface BoxProps
   /**
    * The inline-end padding (right in LTR writing modes, left in RTL).
    *
-   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * Overrides the inline-end value from `paddingInline`. Also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -7052,9 +7052,9 @@ export interface GridProps
    * Adjusts spacing between elements.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
    * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
@@ -7063,8 +7063,8 @@ export interface GridProps
    * s spacing between elements in the block axis. This overrides the row value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -7073,8 +7073,8 @@ export interface GridProps
    * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -7084,7 +7084,7 @@ export interface GridProps
    *
    * Accepts:
    * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
@@ -7094,7 +7094,7 @@ export interface GridProps
    *
    * Accepts:
    * - [Track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes), such as `1fr auto`
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported track sizing values as a query value
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported track sizing values as a query value
    *
    * @default 'none'
    */
@@ -8686,9 +8686,9 @@ export interface StackProps
    * Adjusts spacing between elements.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value applied to both axes, such as `large-100`
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value applied to both axes, such as `large-100`
    * - A pair of values, such as `large-100 large-500`, to set the inline and block axes respectively
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default 'none'
    */
@@ -8697,8 +8697,8 @@ export interface StackProps
    * Adjusts spacing between elements in the block axis. This overrides the row value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -8707,8 +8707,8 @@ export interface StackProps
    * Adjusts spacing between elements in the inline axis. This overrides the column value of `gap`.
    *
    * Accepts:
-   * - A single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value, such as `large-100`
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported SpacingKeyword as a query value
+   * - A single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value, such as `large-100`
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported SpacingKeyword as a query value
    *
    * @default '' - meaning no override
    */
@@ -8718,7 +8718,7 @@ export interface StackProps
    *
    * Accepts:
    * - A single value, either `inline` or `block`
-   * - A [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported direction values as a query value
+   * - A [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported direction values as a query value
    *
    * @default 'block'
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Badge.d.ts
@@ -232,7 +232,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Button.d.ts
@@ -44,7 +44,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
    */
   slot?: Lowercase<string>;
 }

--- a/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Clickable.d.ts
@@ -197,7 +197,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -209,7 +209,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -219,7 +219,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -229,7 +229,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -241,7 +241,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -251,7 +251,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -261,7 +261,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Grid.d.ts
@@ -175,7 +175,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -187,7 +187,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -197,7 +197,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -207,7 +207,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -219,7 +219,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -229,7 +229,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -239,7 +239,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -362,31 +362,31 @@ export interface GridProps
     | `${AlignContentKeyword} ${JustifyContentKeyword}`
     | AlignContentKeyword;
   /**
-   * The spacing between grid rows and columns. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for rows and columns. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The spacing between grid rows and columns. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for rows and columns. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gap: ResponsiveGridProps['gap'];
   /**
-   * The spacing between grid rows. This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The spacing between grid rows. This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveGridProps['rowGap'];
   /**
-   * The spacing between grid columns. This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The spacing between grid columns. This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveGridProps['columnGap'];
   /**
-   * The number of columns and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 1fr)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The number of columns and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 1fr)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gridTemplateColumns: ResponsiveGridProps['gridTemplateColumns'];
   /**
-   * The number of rows and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 100px)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The number of rows and their sizes. You can use [track sizing values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Basic_concepts_of_grid_layout#fixed_and_flexible_track_sizes) (for example, `'1fr auto'` or `'repeat(3, 100px)'`) to define the grid structure. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/GridItem.d.ts
@@ -170,7 +170,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -182,7 +182,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -192,7 +192,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -202,7 +202,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -214,7 +214,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -224,7 +224,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -234,7 +234,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Image.d.ts
@@ -205,7 +205,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -217,7 +217,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -227,7 +227,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -237,7 +237,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -249,7 +249,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -259,7 +259,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -269,7 +269,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](https://shopify.dev/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */

--- a/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/Stack.d.ts
@@ -174,7 +174,7 @@ export interface BoxProps
    *
    * A padding value of `auto` will use the default padding for the closest container that has had its usual padding removed.
    *
-   * `padding` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `padding` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default 'none'
    */
@@ -186,7 +186,7 @@ export interface BoxProps
    *
    * This overrides the block value of `padding`.
    *
-   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlock` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -196,7 +196,7 @@ export interface BoxProps
    *
    * This overrides the block-start value of `paddingBlock`.
    *
-   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -206,7 +206,7 @@ export interface BoxProps
    *
    * This overrides the block-end value of `paddingBlock`.
    *
-   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingBlockEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -218,7 +218,7 @@ export interface BoxProps
    *
    * This overrides the inline value of `padding`.
    *
-   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInline` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -228,7 +228,7 @@ export interface BoxProps
    *
    * This overrides the inline-start value of `paddingInline`.
    *
-   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineStart` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -238,7 +238,7 @@ export interface BoxProps
    *
    * This overrides the inline-end value of `paddingInline`.
    *
-   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
+   * `paddingInlineEnd` also accepts a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) string with the supported `PaddingKeyword` as a query value.
    *
    * @default '' - meaning no override
    */
@@ -340,25 +340,25 @@ export interface StackProps
    */
   alignContent: AlignContentKeyword;
   /**
-   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the stack. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value to apply the same spacing to both axes (for example, `'large-100'`), or a pair of values (for example, `'large-100 large-500'`) to set different spacing for the block and inline axes. This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default 'none'
    */
   gap: ResponsiveStackProps['gap'];
   /**
-   * The spacing between children in the block axis (vertical in horizontal writing modes). This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the block axis (vertical in horizontal writing modes). This property overrides the row spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   rowGap: ResponsiveStackProps['rowGap'];
   /**
-   * The spacing between children in the inline axis (horizontal in left-to-right languages). This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The spacing between children in the inline axis (horizontal in left-to-right languages). This property overrides the column spacing set by the `gap` property. You can provide a single [`SpacingKeyword`](/docs/api/polaris/using-polaris-web-components#scale) value (for example, `'large-100'`), or a [responsive value](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default '' - meaning no override
    */
   columnGap: ResponsiveStackProps['columnGap'];
   /**
-   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-web-components#responsive-values) using container query syntax.
+   * The direction in which the stack's children are laid out. Use `'inline'` to arrange children horizontally (with wrapping enabled), or `'block'` to arrange them vertically (without wrapping). This property also accepts [responsive values](/docs/api/polaris/using-polaris-web-components#responsive-values) using container query syntax.
    *
    * @default 'block'
    *

--- a/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components/TextField.d.ts
@@ -59,7 +59,7 @@ export interface PreactBaseElementProps<TClass extends HTMLElement> {
    */
   ref?: preact.Ref<TClass>;
   /**
-   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/app-ui/using-web-components#slots).
+   * The named slot this element should be placed in when used within a web component. Learn more about [using slots](/docs/api/polaris/using-polaris-web-components#slots).
    */
   slot?: Lowercase<string>;
 }


### PR DESCRIPTION
## Problem
**These links were broken.** Admin component JSDoc linked to the old `using-web-components` slug, which no longer resolves correctly. There were two failure modes, both live on production:

| Link in source | HTTP | Result |
|---|---|---|
| `/docs/api/polaris/using-web-components#…` (most links) | **404** | Page not found — hard broken |
| `/docs/api/app-ui/using-web-components#…` | **301** | Redirects to the canonical page but **drops the `#fragment`**, landing at the top instead of the section |
| `/docs/api/polaris/using-polaris-web-components#…` | **200** | Correct — anchors resolve ✓ |

So links such as `SpacingKeyword` (`#scale`) and responsive value (`#responsive-values`) either 404’d outright or dumped the reader at the top of the page instead of the intended section.

## Fix
Restore the canonical slug everywhere in the admin surface:

```
(polaris|app-ui)/using-web-components  ->  polaris/using-polaris-web-components
```

Links-only diff (no content/symbol changes). Touches the source `.d.ts` files and the checked-in v2 docs data.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Part of a set fixing this across all affected versions: #4538 (2025-10), #4539 (2026-01), #4537 (2026-04), #4536 (2026-07-rc)._