### PR TITLE
Remove receipt targets from public docs

### DIFF
--- a/.changeset/pos-remove-receipt-public-docs.md
+++ b/.changeset/pos-remove-receipt-public-docs.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Mark POS receipt extension targets and their associated types as @private so they no longer appear in generated API reference documentation.

--- a/.changeset/pos-remove-receipt-public-docs.md
+++ b/.changeset/pos-remove-receipt-public-docs.md
@@ -2,19 +2,4 @@
 '@shopify/ui-extensions': patch
 ---
 
-Remove `@publicDocs` from POS receipt extension targets and their associated types so they no longer appear in generated API reference documentation.
-
-The following targets are now marked `@private` and will be excluded from the public docs:
-- `pos.receipt-footer.block.render`
-- `pos.receipt-header.block.render`
-
-The following receipt-only types are now marked `@private`:
-- `ReceiptComponents`
-- `TransactionCompleteWithReprintData`
-- `ReprintReceiptData`
-- `SaleTransactionData`
-- `ReturnTransactionData`
-- `ExchangeTransactionData`
-- `BaseTransactionComplete`
-
-The targets and types remain in the TypeScript API surface — only their public documentation visibility is removed.
+Mark POS receipt extension targets and their associated types as @private so they no longer appear in generated API reference documentation.

--- a/.changeset/pos-remove-receipt-public-docs.md
+++ b/.changeset/pos-remove-receipt-public-docs.md
@@ -1,0 +1,20 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Remove `@publicDocs` from POS receipt extension targets and their associated types so they no longer appear in generated API reference documentation.
+
+The following targets are now marked `@private` and will be excluded from the public docs:
+- `pos.receipt-footer.block.render`
+- `pos.receipt-header.block.render`
+
+The following receipt-only types are now marked `@private`:
+- `ReceiptComponents`
+- `TransactionCompleteWithReprintData`
+- `ReprintReceiptData`
+- `SaleTransactionData`
+- `ReturnTransactionData`
+- `ExchangeTransactionData`
+- `BaseTransactionComplete`
+
+The targets and types remain in the TypeScript API surface — only their public documentation visibility is removed.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/QrCode.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/QrCode.d.ts
@@ -45,7 +45,7 @@ export interface BaseElementPropsWithChildren<TClass = HTMLElement>
 export type IntrinsicElementProps<T> = T & BaseElementPropsWithChildren<T & HTMLElement>;
 
 declare const tagName = 's-qr-code';
-/** @publicDocs */
+/** @private */
 export interface QrCodeJSXProps extends Pick<QRCodeProps, 'id' | 'content'> {}
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/components-shared.d.ts
@@ -2814,7 +2814,7 @@ export interface POSBlockProps
    */
   secondaryActions?: ComponentChildren;
 }
-/** @publicDocs */
+/** @private */
 export interface QRCodeProps extends GlobalProps {
   /**
    * Set the border of the QR code.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/ReceiptComponents.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/ReceiptComponents.ts
@@ -1,4 +1,4 @@
 /**
- * @publicDocs
+ * @private
  */
 export type ReceiptComponents = 'PosBlock' | 'Text' | 'QrCode';

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
@@ -25,8 +25,6 @@ export type StandardComponents =
   | 'Page'
   | 'POSBlock'
   | 'PosBlock' // Case is important in 2025-10
-  | 'QRCode'
-  | 'QrCode' // Case is important in 2025-10
   | 'Route'
   | 'Router'
   | 'ScrollBox'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -3,7 +3,8 @@ import {LineItem} from '../../types/cart';
 
 /**
  * Defines the data structure for completed exchange transactions.
- * @publicDocs
+ *
+ * @private
  */
 export interface ExchangeTransactionData extends BaseTransactionComplete {
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
@@ -4,7 +4,8 @@ import {OrderLineItem} from '../../types/order';
 
 /**
  * Defines the data structure for receipt reprint requests.
- * @publicDocs
+ *
+ * @private
  */
 export interface ReprintReceiptData extends BaseTransactionComplete {
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -3,7 +3,8 @@ import {LineItem} from '../../types/cart';
 
 /**
  * Defines the data structure for completed return transactions.
- * @publicDocs
+ *
+ * @private
  */
 export interface ReturnTransactionData extends BaseTransactionComplete {
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
@@ -3,7 +3,8 @@ import {LineItem} from '../../types/cart';
 
 /**
  * Defines the data structure for completed sale transactions.
- * @publicDocs
+ *
+ * @private
  */
 export interface SaleTransactionData extends BaseTransactionComplete {
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
@@ -7,7 +7,8 @@ import {BaseApi} from './BaseApi';
 
 /**
  * The data object provided to receipt targets containing transaction details and reprint information.
- * @publicDocs
+ *
+ * @private
  */
 export interface TransactionCompleteWithReprintData extends BaseData, BaseApi {
   /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
@@ -310,6 +310,8 @@ export interface RenderExtensionTargets {
    * Renders a custom section in the footer of printed receipts. Use this target for adding contact details, return policies, social media links, or customer engagement elements like survey links or marketing campaigns at the bottom of receipts.
    *
    * Extensions at this target appear in the receipt footer area and support limited components optimized for print formatting, including text content for information display.
+   *
+   * @private
    */
   'pos.receipt-footer.block.render': RenderExtension<
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
@@ -319,6 +321,8 @@ export interface RenderExtensionTargets {
    * Renders a custom section in the header of printed receipts. Use this target for adding custom branding, logos, promotional messages, or store-specific information at the top of receipts.
    *
    * Extensions at this target appear in the receipt header area and support limited components optimized for print formatting, including text content for information display.
+   *
+   * @private
    */
   'pos.receipt-header.block.render': RenderExtension<
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
@@ -7,7 +7,8 @@ import type {TransactionType} from './transaction-type';
 
 /**
  * Base interface for completed transaction data shared across all transaction types.
- * @publicDocs
+ *
+ * @private
  */
 export interface BaseTransactionComplete {
   /**


### PR DESCRIPTION
## Summary

Marks the POS receipt extension targets as `@private` so they no longer appear in generated API reference documentation.

### Targets marked `@private`
- `pos.receipt-footer.block.render`
- `pos.receipt-header.block.render`

### Types marked `@private`
- `ReceiptComponents`
- `TransactionCompleteWithReprintData`
- `ReprintReceiptData`
- `SaleTransactionData`
- `ReturnTransactionData`
- `ExchangeTransactionData`
- `BaseTransactionComplete`

### Component changes
- `QrCodeJSXProps` and `QRCodeProps` marked `@private`
- `QRCode`/`QrCode` removed from `StandardComponents` (only used by receipt targets in the POS runtime)

The targets, types, and components remain in the TypeScript API surface - only their public documentation visibility is removed.

Forward-port of #4545, #4547, #4549, #4551
