### PR TITLE
Remove post-return and post-exchange targets from public docs (2025-07)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/generated/targets.json
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/generated/targets.json
@@ -66,194 +66,6 @@
       "ToastApi"
     ]
   },
-  "pos.return.post.action.menu-item.render": {
-    "components": [
-      "Button"
-    ],
-    "apis": [
-      "ActionApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.return.post.action.render": {
-    "components": [
-      "Badge",
-      "Banner",
-      "Box",
-      "Button",
-      "CameraScanner",
-      "DateField",
-      "DatePicker",
-      "Dialog",
-      "EmailField",
-      "Icon",
-      "Image",
-      "List",
-      "Navigator",
-      "NumberField",
-      "POSBlock",
-      "POSBlockRow",
-      "PinPad",
-      "PrintPreview",
-      "RadioButtonList",
-      "Screen",
-      "ScrollView",
-      "SearchBar",
-      "Section",
-      "SectionHeader",
-      "SegmentedControl",
-      "Selectable",
-      "Stack",
-      "Stepper",
-      "Text",
-      "TextArea",
-      "TextField",
-      "TimeField",
-      "TimePicker"
-    ],
-    "apis": [
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "NavigationApi",
-      "OrderApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "ScannerApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.return.post.block.render": {
-    "components": [
-      "Badge",
-      "Button",
-      "DatePicker",
-      "Dialog",
-      "Icon",
-      "Image",
-      "POSBlock",
-      "POSBlockRow",
-      "Stack",
-      "Text",
-      "TimePicker"
-    ],
-    "apis": [
-      "ActionApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.exchange.post.action.menu-item.render": {
-    "components": [
-      "Button"
-    ],
-    "apis": [
-      "ActionApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.exchange.post.action.render": {
-    "components": [
-      "Badge",
-      "Banner",
-      "Box",
-      "Button",
-      "CameraScanner",
-      "DateField",
-      "DatePicker",
-      "Dialog",
-      "EmailField",
-      "Icon",
-      "Image",
-      "List",
-      "Navigator",
-      "NumberField",
-      "POSBlock",
-      "POSBlockRow",
-      "PinPad",
-      "PrintPreview",
-      "RadioButtonList",
-      "Screen",
-      "ScrollView",
-      "SearchBar",
-      "Section",
-      "SectionHeader",
-      "SegmentedControl",
-      "Selectable",
-      "Stack",
-      "Stepper",
-      "Text",
-      "TextArea",
-      "TextField",
-      "TimeField",
-      "TimePicker"
-    ],
-    "apis": [
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "NavigationApi",
-      "OrderApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "ScannerApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.exchange.post.block.render": {
-    "components": [
-      "Badge",
-      "Button",
-      "DatePicker",
-      "Dialog",
-      "Icon",
-      "Image",
-      "POSBlock",
-      "POSBlockRow",
-      "Stack",
-      "Text",
-      "TimePicker"
-    ],
-    "apis": [
-      "ActionApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
   "pos.purchase.post.action.menu-item.render": {
     "components": [
       "Button"
@@ -814,17 +626,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.block.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
       "pos.order-details.block.render",
       "pos.product-details.action.menu-item.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "CartApi": {
@@ -857,9 +665,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -870,10 +675,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "DeviceApi": {
@@ -886,9 +688,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -899,10 +698,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "LocaleApi": {
@@ -915,9 +711,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -928,10 +721,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "PrintApi": {
@@ -944,9 +734,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -957,10 +744,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "ProductSearchApi": {
@@ -973,9 +757,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -986,10 +767,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "SessionApi": {
@@ -1002,9 +780,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1015,10 +790,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "StorageApi": {
@@ -1031,9 +803,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1044,10 +813,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "ToastApi": {
@@ -1060,9 +826,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1073,10 +836,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "NavigationApi": {
@@ -1084,12 +844,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "ScannerApi": {
@@ -1097,28 +855,20 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "OrderApi": {
     "targets": [
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.order-details.action.menu-item.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "ProductApi": {
@@ -1160,17 +910,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "Banner": {
@@ -1178,12 +924,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Box": {
@@ -1191,12 +935,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Button": {
@@ -1209,9 +951,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.menu-item.render",
       "pos.order-details.action.render",
@@ -1221,10 +960,7 @@
       "pos.product-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "CameraScanner": {
@@ -1232,12 +968,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "DateField": {
@@ -1245,12 +979,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "DatePicker": {
@@ -1260,17 +992,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "Dialog": {
@@ -1280,17 +1008,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "EmailField": {
@@ -1298,12 +1022,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Icon": {
@@ -1313,17 +1035,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "Image": {
@@ -1333,17 +1051,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "List": {
@@ -1351,12 +1065,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Navigator": {
@@ -1364,12 +1076,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "NumberField": {
@@ -1377,12 +1087,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "POSBlock": {
@@ -1392,17 +1100,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "POSBlockRow": {
@@ -1412,17 +1116,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "PinPad": {
@@ -1430,12 +1130,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "PrintPreview": {
@@ -1443,12 +1141,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "RadioButtonList": {
@@ -1456,12 +1152,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Screen": {
@@ -1469,12 +1163,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "ScrollView": {
@@ -1482,12 +1174,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "SearchBar": {
@@ -1495,12 +1185,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Section": {
@@ -1508,12 +1196,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "SectionHeader": {
@@ -1521,12 +1207,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "SegmentedControl": {
@@ -1534,12 +1218,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Selectable": {
@@ -1547,12 +1229,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Stack": {
@@ -1562,17 +1242,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "Stepper": {
@@ -1580,12 +1256,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "Text": {
@@ -1595,17 +1269,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "TextArea": {
@@ -1613,12 +1283,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "TextField": {
@@ -1626,12 +1294,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "TimeField": {
@@ -1639,12 +1305,10 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
-      "pos.purchase.post.action.render",
-      "pos.return.post.action.render"
+      "pos.purchase.post.action.render"
     ]
   },
   "TimePicker": {
@@ -1654,17 +1318,13 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.product-details.action.render",
       "pos.product-details.block.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   }
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/targets.ts
@@ -61,7 +61,10 @@ export interface ExtensionTargets {
    * Renders a single interactive button component as a menu item in the post-return action menu. Use this target for post-return operations like generating return receipts, processing restocking workflows, or collecting return feedback.
    *
    * Extensions at this target can access the order identifier through the Order API to perform return-specific operations. Menu items typically invoke `api.action.presentModal()` to launch the companion modal for complete post-return workflows.
-   */
+  
+ *
+ * @private
+ */
   'pos.return.post.action.menu-item.render': RenderExtension<
     StandardApi<'pos.return.post.action.menu-item.render'> &
       ActionApi &
@@ -72,7 +75,10 @@ export interface ExtensionTargets {
    * Renders a full-screen modal interface launched from post-return menu items. Use this target for complex post-return workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
    *
    * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
-   */
+  
+ *
+ * @private
+ */
   'pos.return.post.action.render': RenderExtension<
     ActionTargetApi<'pos.return.post.action.render'> & OrderApi,
     BasicComponents
@@ -81,7 +87,10 @@ export interface ExtensionTargets {
    * Renders a custom information section within the post-return screen. Use this target for displaying supplementary return data like completion status, refund confirmations, or follow-up workflows alongside standard return details.
    *
    * Extensions at this target appear as persistent blocks within the post-return interface and support interactive elements that can launch modal workflows using `api.action.presentModal()` for more complex post-return operations.
-   */
+  
+ *
+ * @private
+ */
   'pos.return.post.block.render': RenderExtension<
     StandardApi<'pos.return.post.block.render'> & OrderApi & ActionApi,
     BlockComponents
@@ -90,7 +99,10 @@ export interface ExtensionTargets {
    * Renders a single interactive button component as a menu item in the post-exchange action menu. Use this target for post-exchange operations like generating exchange receipts, processing restocking workflows, or collecting exchange feedback.
    *
    * Extensions at this target can access the order identifier through the Order API to perform exchange-specific operations. Menu items typically invoke `api.action.presentModal()` to launch the companion modal for complete post-exchange workflows.
-   */
+  
+ *
+ * @private
+ */
   'pos.exchange.post.action.menu-item.render': RenderExtension<
     StandardApi<'pos.exchange.post.action.menu-item.render'> &
       ActionApi &
@@ -101,7 +113,10 @@ export interface ExtensionTargets {
    * Renders a full-screen modal interface launched from post-exchange menu items. Use this target for complex post-exchange workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
    *
    * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
-   */
+  
+ *
+ * @private
+ */
   'pos.exchange.post.action.render': RenderExtension<
     ActionTargetApi<'pos.exchange.post.action.render'> & OrderApi,
     BasicComponents
@@ -110,7 +125,10 @@ export interface ExtensionTargets {
    * Renders a custom information section within the post-exchange screen. Use this target for displaying supplementary exchange data like completion status, payment adjustments, or follow-up workflows alongside standard exchange details.
    *
    * Extensions at this target appear as persistent blocks within the post-exchange interface and support interactive elements that can launch modal workflows using `api.action.presentModal()` for more complex post-exchange operations.
-   */
+  
+ *
+ * @private
+ */
   'pos.exchange.post.block.render': RenderExtension<
     StandardApi<'pos.exchange.post.block.render'> & OrderApi & ActionApi,
     BlockComponents


### PR DESCRIPTION
## Summary

Marks the POS post-return and post-exchange extension targets as `@private` so they no longer appear in generated API reference documentation.

### Targets marked `@private`

**Post-return:**
- `pos.return.post.action.menu-item.render`
- `pos.return.post.action.render`
- `pos.return.post.block.render`

**Post-exchange:**
- `pos.exchange.post.action.menu-item.render`
- `pos.exchange.post.action.render`
- `pos.exchange.post.block.render`

The targets remain in the TypeScript API surface - only their public documentation visibility is removed.
