### PR TITLE
Remove receipt targets from public docs (2026-01)

### DIFF
--- a/.changeset/pos-remove-receipt-public-docs-2026-01.md
+++ b/.changeset/pos-remove-receipt-public-docs-2026-01.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Mark POS receipt extension targets and their associated types as @private so they no longer appear in generated API reference documentation.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -7213,7 +7213,7 @@ interface PosBlock {
 /**
  * The POS block component renders a QR code when the block is used within a receipt target.
  *
- * @publicDocs
+ * @private
  */
 interface QrCode {
   /** A unique identifier for the element. */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/targets/StandardComponents.ts
@@ -22,8 +22,6 @@ export type StandardComponents =
   | 'Page'
   | 'POSBlock'
   | 'PosBlock' // Case is important in 2025-10
-  | 'QRCode'
-  | 'QrCode' // Case is important in 2025-10
   | 'Route'
   | 'Router'
   | 'ScrollBox'

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ExchangeTransactionData.ts
@@ -2,6 +2,8 @@ import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
 /**
+ *
+ * @private
  * Defines the data structure for completed exchange transactions.
  */
 export interface ExchangeTransactionData extends BaseTransactionComplete {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReprintReceiptData.ts
@@ -3,6 +3,8 @@ import {LineItem} from '../../types/cart';
 import {OrderLineItem} from '../../types/order';
 
 /**
+ *
+ * @private
  * Defines the data structure for receipt reprint requests.
  */
 export interface ReprintReceiptData extends BaseTransactionComplete {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/ReturnTransactionData.ts
@@ -2,6 +2,8 @@ import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
 /**
+ *
+ * @private
  * Defines the data structure for completed return transactions.
  */
 export interface ReturnTransactionData extends BaseTransactionComplete {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/SaleTransactionData.ts
@@ -2,6 +2,8 @@ import {BaseTransactionComplete} from '../../types/base-transaction-complete';
 import {LineItem} from '../../types/cart';
 
 /**
+ *
+ * @private
  * Defines the data structure for completed sale transactions.
  */
 export interface SaleTransactionData extends BaseTransactionComplete {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/event/data/TransactionCompleteData.ts
@@ -26,7 +26,7 @@ export interface TransactionCompleteData extends BaseData, BaseApi {
 }
 
 /**
- * @publicDocs
+ * @private
  * The data object provided to receipt targets containing transaction details and reprint information.
  */
 export interface TransactionCompleteWithReprintData extends BaseData, BaseApi {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
@@ -313,7 +313,10 @@ export interface RenderExtensionTargets {
    * Renders a custom section in the footer of printed receipts. Use this target for adding contact details, return policies, social media links, or customer engagement elements like survey links or marketing campaigns at the bottom of receipts.
    *
    * Extensions at this target appear in the receipt footer area and support limited components optimized for print formatting, including text content for information display.
-   */
+  
+ *
+ * @private
+ */
   'pos.receipt-footer.block.render': RenderExtension<
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
     ReceiptComponents
@@ -322,7 +325,10 @@ export interface RenderExtensionTargets {
    * Renders a custom section in the header of printed receipts. Use this target for adding custom branding, logos, promotional messages, or store-specific information at the top of receipts.
    *
    * Extensions at this target appear in the receipt header area and support limited components optimized for print formatting, including text content for information display.
-   */
+  
+ *
+ * @private
+ */
   'pos.receipt-header.block.render': RenderExtension<
     {[key: string]: any} & StorageApi & TransactionCompleteWithReprintData,
     ReceiptComponents

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/base-transaction-complete.ts
@@ -6,6 +6,8 @@ import type {TaxLine} from './tax-line';
 import type {TransactionType} from './transaction-type';
 
 /**
+ *
+ * @private
  * Base interface for completed transaction data shared across all transaction types.
  */
 export interface BaseTransactionComplete {


### PR DESCRIPTION
## Summary

Marks the POS receipt extension targets as `@private` so they no longer appear in generated API reference documentation.

### Targets marked `@private`
- `pos.receipt-footer.block.render`
- `pos.receipt-header.block.render`

### Types marked `@private`
Receipt-only types are also marked `@private` (where they exist on this branch):
- `ReceiptComponents`
- `TransactionCompleteWithReprintData` / `TransactionCompleteData`
- `ReprintReceiptData`
- `SaleTransactionData`
- `ReturnTransactionData`
- `ExchangeTransactionData`
- `BaseTransactionComplete`

### Component changes
- `QrCode`/`QRCode` removed from `StandardComponents` where present (only used by receipt targets in the POS runtime)

The targets, types, and components remain in the TypeScript API surface - only their public documentation visibility is removed.
