### PR TITLE
Remove post-return and post-exchange targets from public docs (2026-01)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2026-01/targets.json
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2026-01/targets.json
@@ -76,232 +76,6 @@
       "ToastApi"
     ]
   },
-  "pos.return.post.action.menu-item.render": {
-    "components": [
-      "Button"
-    ],
-    "apis": [
-      "ActionApi",
-      "CameraApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PinPadApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.return.post.action.render": {
-    "components": [
-      "Badge",
-      "Banner",
-      "Box",
-      "Button",
-      "Choice",
-      "ChoiceList",
-      "Clickable",
-      "DateField",
-      "DatePicker",
-      "DateSpinner",
-      "Divider",
-      "EmailField",
-      "Embed",
-      "EmptyState",
-      "Heading",
-      "Icon",
-      "Image",
-      "Link",
-      "Modal",
-      "NumberField",
-      "POSBlock",
-      "Page",
-      "PosBlock",
-      "Route",
-      "Router",
-      "ScrollBox",
-      "SearchField",
-      "Section",
-      "Spinner",
-      "Stack",
-      "Switch",
-      "Tab",
-      "TabList",
-      "TabPanel",
-      "Tabs",
-      "Text",
-      "TextArea",
-      "TextField",
-      "TimeField",
-      "TimePicker"
-    ],
-    "apis": [
-      "CameraApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PinPadApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "ScannerApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.return.post.block.render": {
-    "components": [
-      "Badge",
-      "Box",
-      "Button",
-      "DatePicker",
-      "DateSpinner",
-      "Dialog",
-      "Heading",
-      "Icon",
-      "Image",
-      "Modal",
-      "POSBlock",
-      "POSBlockRow",
-      "PosBlock",
-      "PrintPreview",
-      "Section",
-      "Stack",
-      "Text",
-      "TimePicker"
-    ],
-    "apis": [
-      "ActionApi",
-      "CameraApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PinPadApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.exchange.post.action.menu-item.render": {
-    "components": [
-      "Button"
-    ],
-    "apis": [
-      "ActionApi",
-      "CameraApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PinPadApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.exchange.post.action.render": {
-    "components": [
-      "Badge",
-      "Banner",
-      "Box",
-      "Button",
-      "Choice",
-      "ChoiceList",
-      "Clickable",
-      "DateField",
-      "DatePicker",
-      "DateSpinner",
-      "Divider",
-      "EmailField",
-      "Embed",
-      "EmptyState",
-      "Heading",
-      "Icon",
-      "Image",
-      "Link",
-      "Modal",
-      "NumberField",
-      "POSBlock",
-      "Page",
-      "PosBlock",
-      "Route",
-      "Router",
-      "ScrollBox",
-      "SearchField",
-      "Section",
-      "Spinner",
-      "Stack",
-      "Switch",
-      "Tab",
-      "TabList",
-      "TabPanel",
-      "Tabs",
-      "Text",
-      "TextArea",
-      "TextField",
-      "TimeField",
-      "TimePicker"
-    ],
-    "apis": [
-      "CameraApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PinPadApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "ScannerApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
-  "pos.exchange.post.block.render": {
-    "components": [
-      "Badge",
-      "Box",
-      "Button",
-      "DatePicker",
-      "DateSpinner",
-      "Dialog",
-      "Heading",
-      "Icon",
-      "Image",
-      "Modal",
-      "POSBlock",
-      "POSBlockRow",
-      "PosBlock",
-      "PrintPreview",
-      "Section",
-      "Stack",
-      "Text",
-      "TimePicker"
-    ],
-    "apis": [
-      "ActionApi",
-      "CameraApi",
-      "ConnectivityApi",
-      "DeviceApi",
-      "LocaleApi",
-      "OrderApi",
-      "PinPadApi",
-      "PrintApi",
-      "ProductSearchApi",
-      "SessionApi",
-      "StorageApi",
-      "ToastApi"
-    ]
-  },
   "pos.purchase.post.action.menu-item.render": {
     "components": [
       "Button"
@@ -1080,8 +854,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.block.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
       "pos.order-details.block.render",
@@ -1090,9 +862,7 @@
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "CameraApi": {
@@ -1105,9 +875,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1121,10 +888,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "CartApi": {
@@ -1157,9 +921,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1173,10 +934,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "DeviceApi": {
@@ -1189,9 +947,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1205,10 +960,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "LocaleApi": {
@@ -1221,9 +973,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1237,10 +986,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "PinPadApi": {
@@ -1253,9 +999,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1269,10 +1012,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "PrintApi": {
@@ -1285,9 +1025,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1301,10 +1038,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "ProductSearchApi": {
@@ -1317,9 +1051,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1333,10 +1064,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "SessionApi": {
@@ -1349,9 +1077,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1365,10 +1090,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "StorageApi": {
@@ -1381,9 +1103,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1397,10 +1116,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "ToastApi": {
@@ -1413,9 +1129,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.home.tile.render",
       "pos.order-details.action.menu-item.render",
@@ -1429,10 +1142,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "ScannerApi": {
@@ -1440,29 +1150,21 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "OrderApi": {
     "targets": [
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.order-details.action.menu-item.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
       "pos.purchase.post.action.menu-item.render",
       "pos.purchase.post.action.render",
-      "pos.purchase.post.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.purchase.post.block.render"
     ]
   },
   "ProductApi": {
@@ -1511,8 +1213,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1521,9 +1221,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Banner": {
@@ -1531,13 +1229,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Box": {
@@ -1547,8 +1243,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1557,9 +1251,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Button": {
@@ -1572,9 +1264,6 @@
       "pos.draft-order-details.action.menu-item.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.menu-item.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.menu-item.render",
       "pos.order-details.action.render",
@@ -1587,10 +1276,7 @@
       "pos.purchase.post.block.render",
       "pos.register-details.action.menu-item.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.menu-item.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Choice": {
@@ -1598,13 +1284,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "ChoiceList": {
@@ -1612,13 +1296,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Clickable": {
@@ -1626,13 +1308,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "DateField": {
@@ -1640,13 +1320,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "DatePicker": {
@@ -1656,8 +1334,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1666,9 +1342,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "DateSpinner": {
@@ -1678,8 +1352,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1688,9 +1360,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Divider": {
@@ -1698,13 +1368,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "EmailField": {
@@ -1712,13 +1380,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Embed": {
@@ -1726,13 +1392,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "EmptyState": {
@@ -1740,13 +1404,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Heading": {
@@ -1756,8 +1418,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1766,9 +1426,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Icon": {
@@ -1778,8 +1436,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1788,9 +1444,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Image": {
@@ -1800,8 +1454,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1810,9 +1462,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Link": {
@@ -1820,13 +1470,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Modal": {
@@ -1836,8 +1484,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1846,9 +1492,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "NumberField": {
@@ -1856,13 +1500,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "POSBlock": {
@@ -1872,8 +1514,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1882,9 +1522,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Page": {
@@ -1892,13 +1530,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "PosBlock": {
@@ -1908,8 +1544,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1918,9 +1552,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Route": {
@@ -1928,13 +1560,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Router": {
@@ -1942,13 +1572,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "ScrollBox": {
@@ -1956,13 +1584,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "SearchField": {
@@ -1970,13 +1596,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Section": {
@@ -1986,8 +1610,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -1996,9 +1618,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Spinner": {
@@ -2006,13 +1626,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Stack": {
@@ -2022,8 +1640,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -2032,9 +1648,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Switch": {
@@ -2042,13 +1656,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Tab": {
@@ -2056,13 +1668,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "TabList": {
@@ -2070,13 +1680,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "TabPanel": {
@@ -2084,13 +1692,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Tabs": {
@@ -2098,13 +1704,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "Text": {
@@ -2114,8 +1718,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -2124,9 +1726,7 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "TextArea": {
@@ -2134,13 +1734,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "TextField": {
@@ -2148,13 +1746,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "TimeField": {
@@ -2162,13 +1758,11 @@
       "pos.cart.line-item-details.action.render",
       "pos.customer-details.action.render",
       "pos.draft-order-details.action.render",
-      "pos.exchange.post.action.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.product-details.action.render",
       "pos.purchase.post.action.render",
-      "pos.register-details.action.render",
-      "pos.return.post.action.render"
+      "pos.register-details.action.render"
     ]
   },
   "TimePicker": {
@@ -2178,8 +1772,6 @@
       "pos.customer-details.block.render",
       "pos.draft-order-details.action.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.action.render",
-      "pos.exchange.post.block.render",
       "pos.home.modal.render",
       "pos.order-details.action.render",
       "pos.order-details.block.render",
@@ -2188,45 +1780,37 @@
       "pos.purchase.post.action.render",
       "pos.purchase.post.block.render",
       "pos.register-details.action.render",
-      "pos.register-details.block.render",
-      "pos.return.post.action.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "Dialog": {
     "targets": [
       "pos.customer-details.block.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.block.render",
       "pos.order-details.block.render",
       "pos.product-details.block.render",
       "pos.purchase.post.block.render",
-      "pos.register-details.block.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "POSBlockRow": {
     "targets": [
       "pos.customer-details.block.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.block.render",
       "pos.order-details.block.render",
       "pos.product-details.block.render",
       "pos.purchase.post.block.render",
-      "pos.register-details.block.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   },
   "PrintPreview": {
     "targets": [
       "pos.customer-details.block.render",
       "pos.draft-order-details.block.render",
-      "pos.exchange.post.block.render",
       "pos.order-details.block.render",
       "pos.product-details.block.render",
       "pos.purchase.post.block.render",
-      "pos.register-details.block.render",
-      "pos.return.post.block.render"
+      "pos.register-details.block.render"
     ]
   }
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/extension-targets.ts
@@ -66,7 +66,10 @@ export interface RenderExtensionTargets {
    * Renders a single interactive button component as a menu item in the post-return action menu. Use this target for post-return operations like generating return receipts, processing restocking workflows, or collecting return feedback.
    *
    * Extensions at this target can access the order identifier through the Order API to perform return-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-return workflows.
-   */
+  
+ *
+ * @private
+ */
   'pos.return.post.action.menu-item.render': RenderExtension<
     StandardApi<'pos.return.post.action.menu-item.render'> &
       ActionApi &
@@ -77,7 +80,10 @@ export interface RenderExtensionTargets {
    * Renders a full-screen modal interface launched from post-return menu items. Use this target for complex post-return workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
    *
    * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
-   */
+  
+ *
+ * @private
+ */
   'pos.return.post.action.render': RenderExtension<
     ActionTargetApi<'pos.return.post.action.render'> & OrderApi,
     BasicComponents
@@ -86,7 +92,10 @@ export interface RenderExtensionTargets {
    * Renders a custom information section within the post-return screen. Use this target for displaying supplementary return data like completion status, refund confirmations, or follow-up workflows alongside standard return details.
    *
    * Extensions at this target appear as persistent blocks within the post-return interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-return operations.
-   */
+  
+ *
+ * @private
+ */
   'pos.return.post.block.render': RenderExtension<
     StandardApi<'pos.return.post.block.render'> & OrderApi & ActionApi,
     BlockExtensionComponents
@@ -95,7 +104,10 @@ export interface RenderExtensionTargets {
    * Renders a single interactive button component as a menu item in the post-exchange action menu. Use this target for post-exchange operations like generating exchange receipts, processing restocking workflows, or collecting exchange feedback.
    *
    * Extensions at this target can access the order identifier through the Order API to perform exchange-specific operations. Menu items typically invoke `shopify.action.presentModal()` to launch the companion modal for complete post-exchange workflows.
-   */
+  
+ *
+ * @private
+ */
   'pos.exchange.post.action.menu-item.render': RenderExtension<
     StandardApi<'pos.exchange.post.action.menu-item.render'> &
       ActionApi &
@@ -106,7 +118,10 @@ export interface RenderExtensionTargets {
    * Renders a full-screen modal interface launched from post-exchange menu items. Use this target for complex post-exchange workflows that require forms, multi-step processes, or detailed information displays beyond what a simple button can provide.
    *
    * Extensions at this target have access to order data through the Order API and support workflows with multiple screens, navigation, and interactive components.
-   */
+  
+ *
+ * @private
+ */
   'pos.exchange.post.action.render': RenderExtension<
     ActionTargetApi<'pos.exchange.post.action.render'> & OrderApi,
     BasicComponents
@@ -115,7 +130,10 @@ export interface RenderExtensionTargets {
    * Renders a custom information section within the post-exchange screen. Use this target for displaying supplementary exchange data like completion status, payment adjustments, or follow-up workflows alongside standard exchange details.
    *
    * Extensions at this target appear as persistent blocks within the post-exchange interface and support interactive elements that can launch modal workflows using `shopify.action.presentModal()` for more complex post-exchange operations.
-   */
+  
+ *
+ * @private
+ */
   'pos.exchange.post.block.render': RenderExtension<
     StandardApi<'pos.exchange.post.block.render'> & OrderApi & ActionApi,
     BlockExtensionComponents


### PR DESCRIPTION
## Summary

Marks the POS post-return and post-exchange extension targets as `@private` so they no longer appear in generated API reference documentation.

### Targets marked `@private`

**Post-return:**
- `pos.return.post.action.menu-item.render`
- `pos.return.post.action.render`
- `pos.return.post.block.render`

**Post-exchange:**
- `pos.exchange.post.action.menu-item.render`
- `pos.exchange.post.action.render`
- `pos.exchange.post.block.render`

The targets remain in the TypeScript API surface - only their public documentation visibility is removed.
