### PR TITLE
Remove unnecessary changeset (2025-10)

### DIFF
--- a/.changeset/pos-remove-receipt-public-docs-2025-10.md
+++ b/.changeset/pos-remove-receipt-public-docs-2025-10.md
@@ -1,5 +1,0 @@
----
-'@shopify/ui-extensions': patch
----
-
-Mark POS receipt extension targets and their associated types as @private so they no longer appear in generated API reference documentation.


### PR DESCRIPTION
The @private annotation changes in the merged receipt targets PR were docs-only and don't require a package release. Removing the changeset that was added with those changes.