### PR TITLE
docs(pos): expose app background event methods

### DIFF
--- a/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/point-of-sale/generated/pos_ui_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -9257,5 +9257,30 @@
       ],
       "value": "export interface BackgroundShopifyGlobal extends ShopifyGlobal {\n  /**\n   * Register a listener for a POS host event. Listeners are fire-and-forget:\n   * their return values are ignored, and their errors are caught without\n   * affecting the host or other listeners.\n   */\n  addEventListener<K extends keyof ShopifyEventMap>(\n    type: K,\n    listener: (event: ShopifyEventMap[K]) => void,\n  ): void;\n\n  /**\n   * Remove a listener previously registered with `addEventListener`. The\n   * `listener` reference must match the one used to register.\n   */\n  removeEventListener<K extends keyof ShopifyEventMap>(\n    type: K,\n    listener: (event: ShopifyEventMap[K]) => void,\n  ): void;\n}"
     }
+  },
+  "Docs_AppBackgroundEventMethods": {
+    "src/surfaces/point-of-sale/api/docs.ts": {
+      "filePath": "src/surfaces/point-of-sale/api/docs.ts",
+      "name": "Docs_AppBackgroundEventMethods",
+      "description": "Methods available on the `shopify` global for app background extensions.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/surfaces/point-of-sale/api/docs.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "addEventListener",
+          "value": "<K extends keyof ShopifyEventMap>(type: K, listener: (event: ShopifyEventMap[K]) => void) => void",
+          "description": "Register a listener for a POS host event. Listeners are fire-and-forget: their return values are ignored, and their errors are caught without affecting the host or other listeners."
+        },
+        {
+          "filePath": "src/surfaces/point-of-sale/api/docs.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "removeEventListener",
+          "value": "<K extends keyof ShopifyEventMap>(type: K, listener: (event: ShopifyEventMap[K]) => void) => void",
+          "description": "Remove a listener previously registered with `addEventListener`. The `listener` reference must match the one used to register."
+        }
+      ],
+      "value": "export interface Docs_AppBackgroundEventMethods\n  extends Pick<\n    BackgroundShopifyGlobal,\n    'addEventListener' | 'removeEventListener'\n  > {}"
+    }
   }
 }

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/docs.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/docs.ts
@@ -1,0 +1,11 @@
+import type {BackgroundShopifyGlobal} from '../globals';
+
+/**
+ * Methods available on the `shopify` global for app background extensions.
+ * @publicDocs
+ */
+export interface Docs_AppBackgroundEventMethods
+  extends Pick<
+    BackgroundShopifyGlobal,
+    'addEventListener' | 'removeEventListener'
+  > {}


### PR DESCRIPTION
## What

Adds a docs-only `Docs_AppBackgroundEventMethods` interface that picks `addEventListener` and `removeEventListener` from `BackgroundShopifyGlobal`, then regenerates the POS docs data.

## Why

These methods live on the `shopify` global for app background extensions. They aren't a named target API, so the docs need a named type to render the methods without changing `DataTargetApi` or the target support mapping.

## Testing

- `yarn type-check`
- `yarn lint`
- `git diff --check`