### PR TITLE
Port over missing types from 2026-04 to 2026-07-rc

### DIFF
--- a/.changeset/add-purchase-type-and-recurring-cycle-limit.md
+++ b/.changeset/add-purchase-type-and-recurring-cycle-limit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add purchaseType and recurringCycleLimit subscribable fields to the DiscountsApi for discount function settings extensions.

--- a/packages/ui-extensions-tester/src/admin/README.md
+++ b/packages/ui-extensions-tester/src/admin/README.md
@@ -64,6 +64,20 @@ extension.shopify.discounts.updateDiscountClasses =
     .mockReturnValue(
       createResult('updateDiscountClasses'),
     );
+
+extension.shopify.discounts.updatePurchaseType =
+  vi
+    .fn()
+    .mockReturnValue(
+      createResult('updatePurchaseType'),
+    );
+
+extension.shopify.discounts.updateRecurringCycleLimit =
+  vi
+    .fn()
+    .mockReturnValue(
+      createResult('updateRecurringCycleLimit'),
+    );
 ```
 
 ## 📂 Example
@@ -82,7 +96,9 @@ Creates a typed mock result for an admin mutation API.
 
 Supported mutations:
 
-| Mutation                  | Default                      |
-| ------------------------- | ---------------------------- |
-| `'applyMetafieldChange'`  | `{type: 'success'}`          |
-| `'updateDiscountClasses'` | `{success: true, value: []}` |
+| Mutation                      | Default                                       |
+| ----------------------------- | --------------------------------------------- |
+| `'applyMetafieldChange'`      | `{type: 'success'}`                           |
+| `'updateDiscountClasses'`     | `{success: true, value: []}`                  |
+| `'updatePurchaseType'`        | `{success: true, value: 'one_time_purchase'}` |
+| `'updateRecurringCycleLimit'` | `{success: true, value: null}`                |

--- a/packages/ui-extensions-tester/src/admin/factories.ts
+++ b/packages/ui-extensions-tester/src/admin/factories.ts
@@ -260,6 +260,11 @@ function createDiscountFunctionSettingsMock<T extends ExtensionTarget>(
       discountClasses: createReadonlySignalLike([]),
       updateDiscountClasses: () => createResult('updateDiscountClasses'),
       discountMethod: createReadonlySignalLike('automatic' as const),
+      purchaseType: createReadonlySignalLike('one_time_purchase' as const),
+      updatePurchaseType: () => createResult('updatePurchaseType'),
+      recurringCycleLimit: createReadonlySignalLike(null),
+      updateRecurringCycleLimit: () =>
+        createResult('updateRecurringCycleLimit'),
     },
   };
 }

--- a/packages/ui-extensions-tester/src/admin/index.ts
+++ b/packages/ui-extensions-tester/src/admin/index.ts
@@ -58,6 +58,10 @@ export interface AdminMutationResults {
     | Awaited<ReturnType<ValidationApplyMetafieldChange>>
     | Awaited<ReturnType<DiscountApplyMetafieldChange>>;
   updateDiscountClasses: ReturnType<DiscountsApi['updateDiscountClasses']>;
+  updatePurchaseType: ReturnType<DiscountsApi['updatePurchaseType']>;
+  updateRecurringCycleLimit: ReturnType<
+    DiscountsApi['updateRecurringCycleLimit']
+  >;
 }
 
 const adminMutationDefaults: {
@@ -65,6 +69,11 @@ const adminMutationDefaults: {
 } = {
   applyMetafieldChange: () => ({type: 'success'}),
   updateDiscountClasses: () => ({success: true as const, value: []}),
+  updatePurchaseType: () => ({
+    success: true as const,
+    value: 'one_time_purchase' as const,
+  }),
+  updateRecurringCycleLimit: () => ({success: true as const, value: null}),
 };
 
 /**

--- a/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
+++ b/packages/ui-extensions/src/surfaces/admin/api/discount-function-settings/launch-options.ts
@@ -35,6 +35,12 @@ export type DiscountClass = 'product' | 'order' | 'shipping';
 export type DiscountMethod = 'automatic' | 'code';
 
 /**
+ * The purchase type that determines which purchases the discount applies to. Use `'one_time_purchase'` for one-time purchases only, `'subscription'` for subscription purchases only, or `'both'` for both.
+ * @publicDocs
+ */
+export type PurchaseType = 'one_time_purchase' | 'subscription' | 'both';
+
+/**
  * The `data` object exposed to discount function settings extensions in the `admin.discount-details.function-settings.render` target. Use this to access the current discount configuration and populate your settings interface with existing values.
  * @publicDocs
  */
@@ -62,4 +68,20 @@ export interface DiscountsApi {
    * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.
    */
   discountMethod: ReadonlySignalLike<DiscountMethod>;
+  /**
+   * A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both.
+   */
+  purchaseType: ReadonlySignalLike<PurchaseType>;
+  /**
+   * A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`).
+   */
+  updatePurchaseType: UpdateSignalFunction<PurchaseType>;
+  /**
+   * A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set.
+   */
+  recurringCycleLimit: ReadonlySignalLike<number | null>;
+  /**
+   * A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit.
+   */
+  updateRecurringCycleLimit: UpdateSignalFunction<number | null>;
 }


### PR DESCRIPTION
Ports the subscription fields from #4275 into `2026-07-rc`, adding `purchaseType`, `updatePurchaseType`, `recurringCycleLimit`, and `updateRecurringCycleLimit` to the discount function settings `DiscountsApi`.

### Why
These fields were added on `2026-04` stable but never made it into the `2026-07-rc` branch. This restores parity before we release the stable version of 2026-07.

### Changes
- Should be an exact copy of https://github.com/Shopify/ui-extensions/pull/4275 with some changes to support ui-extensions-tester

### Notes
- Did **not** recreate `discount-function-settings.doc.ts`,  the RC generates reference docs from `@publicDocs` JSDoc annotations, so `PurchaseType` is annotated accordingly instead.