### PR TITLE
Add missing children to checkbox type (2026-01)

### DIFF
--- a/.changeset/checkbox-label-slot-children.md
+++ b/.changeset/checkbox-label-slot-children.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Fix the `s-checkbox` JSX type so the documented `label` slot can be provided as slotted children. `Checkbox` now uses `BaseElementPropsWithChildren` (matching `Chip` and other slot-bearing components) instead of the childless `BaseElementProps`, which previously left `CheckboxElementSlots` unusable via JSX.

--- a/packages/ui-extensions/src/surfaces/checkout/components/Checkbox.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Checkbox.d.ts
@@ -28,6 +28,16 @@ export interface BaseElementProps<TClass = HTMLElement> {
     slot?: Lowercase<string>;
 }
 /**
+ * The base properties for elements that have children, extending `BaseElementProps` with children support.
+ * @publicDocs
+ */
+export interface BaseElementPropsWithChildren<TClass = HTMLElement> extends BaseElementProps<TClass> {
+    /**
+     * The child elements to render within this component.
+     */
+    children?: preact.ComponentChildren;
+}
+/**
  * An event type that narrows the `currentTarget` to the specific HTML element associated with the custom element tag. This provides type-safe event handling in callback listeners.
  * @publicDocs
  */
@@ -38,9 +48,7 @@ export type CallbackEvent<TTagName extends keyof HTMLElementTagNameMap, TEvent e
  * A typed event listener for custom element events. The listener receives a `CallbackEvent` with the correct `currentTarget` type for the associated custom element tag.
  * @publicDocs
  */
-export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, TData = object> = (EventListener & {
-    (event: CallbackEvent<TTagName, Event> & TData): void;
-}) | null;
+export type CallbackEventListener<TTagName extends keyof HTMLElementTagNameMap, TData = object> = (EventListener & ((event: CallbackEvent<TTagName, Event> & TData) => void)) | null;
 
 declare const tagName = "s-checkbox";
 /** @publicDocs */
@@ -89,7 +97,7 @@ declare global {
 declare module 'preact' {
     namespace createElement.JSX {
         interface IntrinsicElements {
-            [tagName]: CheckboxProps & BaseElementProps<CheckboxElement>;
+            [tagName]: CheckboxProps & BaseElementPropsWithChildren<CheckboxElement>;
         }
     }
 }


### PR DESCRIPTION
### Background

The documented `label` slot on `s-checkbox` could not be provided as JSX children because the generated Preact intrinsic element type used `BaseElementProps`, which does not define `children`.

Depends on: https://github.com/shop/world/pull/930614

### Solution

Regenerate `Checkbox.d.ts` so `s-checkbox` uses `BaseElementPropsWithChildren<CheckboxElement>`, exposing `preact.ComponentChildren` for slot content.

### 🎩

TypeScript consumers can now provide the documented `label` slot as children without a type error.

### Checklist

- [x] Generated component types from checkout-web
- [ ] I have :tophat:'d these changes
