### PR TITLE
[2026-04] Pin npm 11.7 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,8 +68,8 @@ jobs:
 
       - uses: ./.github/workflows/actions/prepare
 
-      - name: Update npm to latest
-        run: npm install -g npm@latest
+      - name: Update npm to 11.7
+        run: npm install -g npm@11.7
 
       - id: changesets
         name: Create release Pull Request or publish to NPM


### PR DESCRIPTION
### Background

[npm 12.0.1](https://github.com/npm/cli/releases/tag/v12.0.1) became the `latest` release and requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. Our deploy workflow uses Node 20.20.0, causing `npm install -g npm@latest` to fail before Changesets can update or create the release PR.

### Solution

Pin the deploy workflow to [npm 11.7.0](https://github.com/npm/cli/releases/tag/v11.7.0), which supports Node 20 and restores release automation.

We are not bumping Node yet because `.nvmrc` controls the runtime for all CI workflows, making that a broader change requiring full compatibility testing across our build and test tooling. A Node upgrade should be handled separately; this PR provides the smallest low-risk fix for the blocked releases.
