### PR TITLE
Hide tertiary button variant from s-button docs

### DIFF
--- a/.changeset/hide-tertiary-button-docs.md
+++ b/.changeset/hide-tertiary-button-docs.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Hide the `tertiary` button variant from the generated `s-button` documentation while preserving the existing public type.

--- a/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/checkout/generated/generated_docs_data_v2.json
@@ -21977,12 +21977,12 @@
           "syntaxKind": "PropertySignature",
           "name": "variant",
           "value": "'auto' | 'primary' | 'secondary'",
-          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.\n- `'tertiary'`: Low-emphasis style for less prominent actions.",
+          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.",
           "isOptional": true,
           "defaultValue": "'auto'"
         }
       ],
-      "value": "export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'disabled' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'loading' | 'target' | 'tone' | 'type' | 'variant'> {\n    target?: Extract<ButtonProps$1['target'], 'auto' | '_blank'>;\n    tone?: Extract<ButtonProps$1['tone'], 'auto' | 'neutral' | 'critical'>;\n    /**\n     * The behavioral type of the button component, which determines what action it performs when activated.\n     *\n     * - `submit`: Submits the nearest containing form.\n     * - `button`: Performs no default action, relying on the `click` event handler for behavior.\n     *\n     * This property is ignored if `href` or `commandFor`/`command` is set.\n     *\n     * @default 'button'\n     */\n    type?: Extract<ButtonProps$1['type'], 'submit' | 'button'>;\n    variant?: Extract<ButtonProps$1['variant'], 'auto' | 'primary' | 'secondary'>;\n}"
+      "value": "export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'disabled' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'loading' | 'target' | 'tone' | 'type' | 'variant'> {\n    target?: Extract<ButtonProps$1['target'], 'auto' | '_blank'>;\n    tone?: Extract<ButtonProps$1['tone'], 'auto' | 'neutral' | 'critical'>;\n    /**\n     * The behavioral type of the button component, which determines what action it performs when activated.\n     *\n     * - `submit`: Submits the nearest containing form.\n     * - `button`: Performs no default action, relying on the `click` event handler for behavior.\n     *\n     * This property is ignored if `href` or `commandFor`/`command` is set.\n     *\n     * @default 'button'\n     */\n    type?: Extract<ButtonProps$1['type'], 'submit' | 'button'>;\n    /**\n     * The visual style variant of the button component, which controls its prominence and emphasis.\n     *\n     * - `'auto'`: Automatically determined by the button's context.\n     * - `'primary'`: High-emphasis style for the main action.\n     * - `'secondary'`: Medium-emphasis style for supporting actions.\n     *\n     * @default 'auto'\n     */\n    variant?: Extract<ButtonProps$1['variant'], 'auto' | 'primary' | 'secondary'>;\n}"
     }
   },
   "ButtonEvents": {
@@ -24389,7 +24389,7 @@
           "syntaxKind": "PropertySignature",
           "name": "variant",
           "value": "'auto' | 'primary' | 'secondary'",
-          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.\n- `'tertiary'`: Low-emphasis style for less prominent actions.",
+          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.",
           "isOptional": true,
           "defaultValue": "'auto'"
         },
@@ -24534,7 +24534,7 @@
           "syntaxKind": "PropertySignature",
           "name": "variant",
           "value": "'auto' | 'primary' | 'secondary'",
-          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.\n- `'tertiary'`: Low-emphasis style for less prominent actions.",
+          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.",
           "isOptional": true,
           "defaultValue": "'auto'"
         }

--- a/packages/ui-extensions/docs/surfaces/customer-account/generated/customer_account_ui_extensions/2026-07/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/customer-account/generated/customer_account_ui_extensions/2026-07/generated_docs_data_v2.json
@@ -40153,12 +40153,12 @@
           "syntaxKind": "PropertySignature",
           "name": "variant",
           "value": "'auto' | 'primary' | 'secondary'",
-          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.\n- `'tertiary'`: Low-emphasis style for less prominent actions.",
+          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.",
           "isOptional": true,
           "defaultValue": "'auto'"
         }
       ],
-      "value": "export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'disabled' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'loading' | 'target' | 'tone' | 'type' | 'variant'> {\n    target?: Extract<ButtonProps$1['target'], 'auto' | '_blank'>;\n    tone?: Extract<ButtonProps$1['tone'], 'auto' | 'neutral' | 'critical'>;\n    /**\n     * The behavioral type of the button component, which determines what action it performs when activated.\n     *\n     * - `submit`: Submits the nearest containing form.\n     * - `button`: Performs no default action, relying on the `click` event handler for behavior.\n     *\n     * This property is ignored if `href` or `commandFor`/`command` is set.\n     *\n     * @default 'button'\n     */\n    type?: Extract<ButtonProps$1['type'], 'submit' | 'button'>;\n    variant?: Extract<ButtonProps$1['variant'], 'auto' | 'primary' | 'secondary'>;\n}"
+      "value": "export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLabel' | 'command' | 'commandFor' | 'disabled' | 'href' | 'id' | 'inlineSize' | 'interestFor' | 'loading' | 'target' | 'tone' | 'type' | 'variant'> {\n    target?: Extract<ButtonProps$1['target'], 'auto' | '_blank'>;\n    tone?: Extract<ButtonProps$1['tone'], 'auto' | 'neutral' | 'critical'>;\n    /**\n     * The behavioral type of the button component, which determines what action it performs when activated.\n     *\n     * - `submit`: Submits the nearest containing form.\n     * - `button`: Performs no default action, relying on the `click` event handler for behavior.\n     *\n     * This property is ignored if `href` or `commandFor`/`command` is set.\n     *\n     * @default 'button'\n     */\n    type?: Extract<ButtonProps$1['type'], 'submit' | 'button'>;\n    /**\n     * The visual style variant of the button component, which controls its prominence and emphasis.\n     *\n     * - `'auto'`: Automatically determined by the button's context.\n     * - `'primary'`: High-emphasis style for the main action.\n     * - `'secondary'`: Medium-emphasis style for supporting actions.\n     *\n     * @default 'auto'\n     */\n    variant?: Extract<ButtonProps$1['variant'], 'auto' | 'primary' | 'secondary'>;\n}"
     }
   },
   "ButtonEvents": {
@@ -42565,7 +42565,7 @@
           "syntaxKind": "PropertySignature",
           "name": "variant",
           "value": "'auto' | 'primary' | 'secondary'",
-          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.\n- `'tertiary'`: Low-emphasis style for less prominent actions.",
+          "description": "The visual style variant of the button component, which controls its prominence and emphasis.\n\n- `'auto'`: Automatically determined by the button's context.\n- `'primary'`: High-emphasis style for the main action.\n- `'secondary'`: Medium-emphasis style for supporting actions.",
           "isOptional": true,
           "defaultValue": "'auto'"
         },

--- a/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/components/Button.d.ts
@@ -53,6 +53,15 @@ export interface ButtonElementProps extends Pick<ButtonProps$1, 'accessibilityLa
      * @default 'button'
      */
     type?: Extract<ButtonProps$1['type'], 'submit' | 'button'>;
+    /**
+     * The visual style variant of the button component, which controls its prominence and emphasis.
+     *
+     * - `'auto'`: Automatically determined by the button's context.
+     * - `'primary'`: High-emphasis style for the main action.
+     * - `'secondary'`: Medium-emphasis style for supporting actions.
+     *
+     * @default 'auto'
+     */
     variant?: Extract<ButtonProps$1['variant'], 'auto' | 'primary' | 'secondary'>;
 }
 export interface ButtonEvents extends Pick<ButtonProps$1, 'onClick'> {


### PR DESCRIPTION
### Background

The generated `s-button` reference inherited the shared `ButtonProps.variant` description and advertised the `tertiary` variant, even though the public `ButtonElementProps.variant` type is narrowed to `auto`, `primary`, and `secondary`.

This is a docs-only JSDoc description change. The `tertiary` variant remains in the base `ButtonProps` type and in `@shopify/checkout-web-ui`; we just do not want to advertise it yet.

### Solution

Add a local JSDoc description to the narrowed `variant` property without changing its `Extract` type, then regenerate the 2026-07 customer-account and checkout docs data. Include the required patch changeset for `@shopify/ui-extensions`.

### Next steps

- After review, merge this PR into `2026-07`.
- The generated docs will sync automatically to Shopify Dev on the daily cadence; no manual deployment is required. For an urgent sync, contact `#help-shopify-dev-eng`.
- Forward-port this change to `2026-07-rc`, regenerate both docs surfaces for that version, and include `Forward-port of #4583` in the follow-up PR body.

### 🎩

- Ran `yarn docs:customer-account 2026-07`.
- Ran `yarn docs:checkout 2026-07`.
- Confirmed the generated button descriptions no longer include the `tertiary` bullet and the published value remains `'auto' | 'primary' | 'secondary'`.
- Ran `yarn build`, `yarn test`, `yarn type-check`, and `yarn lint`.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have updated relevant documentation
