### PR TITLE
Remove shopUser from documented AppMetafieldEntryTarget types

### DIFF
--- a/.changeset/remove-shopuser-metafield-docs.md
+++ b/.changeset/remove-shopuser-metafield-docs.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Remove `shopUser` from the documented `AppMetafieldEntryTarget` resource types for checkout UI extensions. Shop User metafields were never released publicly and are not a supported metafield target for partner extensions; keeping the value in the public API reference caused partners to attempt using an unsupported capability.

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -247,7 +247,6 @@ export interface AppMetafieldEntryTarget {
    * - `'customer'`: The customer who placed the order.
    * - `'product'`: A product in the merchant's catalog.
    * - `'shop'`: The merchant's shop.
-   * - `'shopUser'`: A staff member or collaborator account on the shop.
    * - `'variant'`: A specific variant of a product.
    * - `'company'`: A [B2B](https://shopify.dev/docs/apps/build/b2b) company associated with the order.
    * - `'companyLocation'`: A location belonging to a [B2B](https://shopify.dev/docs/apps/build/b2b) company.
@@ -259,7 +258,6 @@ export interface AppMetafieldEntryTarget {
     | 'customer'
     | 'product'
     | 'shop'
-    | 'shopUser'
     | 'variant'
     | 'company'
     | 'companyLocation'


### PR DESCRIPTION
Resolves https://github.com/shop/issues-checkout/issues/145

## Summary

- Removes `'shopUser'` from the `AppMetafieldEntryTarget.type` union in the checkout surface `standard.ts`, and drops its JSDoc bullet.
- Shop User metafields were never released publicly and there is no intention to release them (privacy concerns). Access has already been revoked, and the merchant-facing handling code was previously removed from checkout-web in shop/world.
- Because the generated API reference renders the type union itself, the value is currently published on shopify.dev (e.g. `/docs/api/checkout-ui-extensions/2025-07/apis/metafields`), which led partners to attempt using an unsupported capability and caused repeat incidents (see issue).
- The static configuration page (`configuration#metafields`) was already cleaned up separately; this PR covers the remaining generated API reference.
- Runtime behavior is unchanged — this only narrows the published/documented type.

## Tophat

1. Confirm no remaining `shopUser` references in the checkout surface: `grep -rn \"shopUser\" packages/ui-extensions/src` → no results.
2. Regenerate the checkout API reference docs and verify `shopUser` no longer appears in the `AppMetafieldEntryTarget` type values.