### PR TITLE
Deprecate `useLocalizationMarket` and `localization.market` across surfaces

### DIFF
--- a/.changeset/deprecate-localization-market.md
+++ b/.changeset/deprecate-localization-market.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Deprecate `useLocalizationMarket` and `localization.market` on both checkout and customer-account surfaces. These will be removed in a future version of the API.

--- a/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/api/standard/standard.ts
@@ -436,12 +436,15 @@ export interface Localization {
   /**
    * The [market](/docs/apps/build/markets) context of the checkout,
    * carried over from the cart context. Markets group countries and
-   * regions with shared pricing, languages, and domains. The market
-   * context updates when the buyer changes the country of their
-   * shipping address. The value is `undefined` if the market is unknown.
+   * regions with shared pricing, languages, and domains. In cases where
+   * multiple markets match, this returns the most narrowly scoped
+   * country region market. The market context updates when the buyer
+   * changes the country of their shipping address. The value is
+   * `undefined` if the market is unknown.
    *
-   * @deprecated Merchants now manage which extensions load for each
-   * market, so extensions no longer need to check this value.
+   * > Caution: This `market` field is deprecated and will be removed in a future version of the API.
+   *
+   * @deprecated This `market` field will be removed in a future version of the API.
    */
   market: SubscribableSignalLike<Market | undefined>;
 }

--- a/packages/ui-extensions/src/surfaces/checkout/preact/market.ts
+++ b/packages/ui-extensions/src/surfaces/checkout/preact/market.ts
@@ -5,8 +5,14 @@ import {useApi} from './api';
 import {useSubscription} from './subscription';
 
 /**
- * Returns the market of the checkout, and automatically re-renders
- * your component if it changes.
+ * Returns the market of the checkout, carried over from the cart context.
+ * In cases where multiple markets match, this returns the most narrowly
+ * scoped country region market. Automatically re-renders your component
+ * if it changes.
+ *
+ * > Caution: This hook is deprecated and will be removed in a future version of the API.
+ *
+ * @deprecated This hook will be removed in a future version of the API.
  * @publicDocs
  */
 export function useLocalizationMarket<

--- a/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/api/order-status/order-status.ts
@@ -201,7 +201,12 @@ export interface OrderStatusLocalization {
   /**
    * The [market](/docs/apps/build/markets) associated with the order, carried
    * over from the cart context. Markets group countries and regions with shared pricing,
-   * languages, and domains. The value is `undefined` if the market is unknown.
+   * languages, and domains. In cases where multiple markets match, this returns the most
+   * narrowly scoped country region market. The value is `undefined` if the market is unknown.
+   *
+   * > Caution: This `market` field is deprecated and will be removed in a future version of the API.
+   *
+   * @deprecated This `market` field will be removed in a future version of the API.
    */
   market: SubscribableSignalLike<Market | undefined>;
 }

--- a/packages/ui-extensions/src/surfaces/customer-account/preact/market.ts
+++ b/packages/ui-extensions/src/surfaces/customer-account/preact/market.ts
@@ -6,8 +6,14 @@ import {useSubscription} from './subscription';
 import {ExtensionHasNoFieldError} from './errors';
 
 /**
- * Returns the market of the checkout, and automatically re-renders
- * your component if it changes.
+ * Returns the market associated with the order, carried over from the cart
+ * context. In cases where multiple markets match, this returns the most
+ * narrowly scoped country region market. Automatically re-renders your
+ * component if it changes.
+ *
+ * > Caution: This hook is deprecated and will be removed in a future version of the API.
+ *
+ * @deprecated This hook will be removed in a future version of the API.
  */
 export function useLocalizationMarket<
   Target extends RenderOrderStatusExtensionTarget = RenderOrderStatusExtensionTarget,


### PR DESCRIPTION
Issue: https://github.com/shop/issues-markets/issues/4068

## Summary

Adds `@deprecated` JSDoc tags and `> Caution:` doc blocks to `useLocalizationMarket` hook and `localization.market` property on both checkout and customer-account surfaces. Updates the property descriptions to clarify that in cases where multiple markets match, this returns the most narrowly scoped country region market.

**Why:** `useLocalizationMarket` is a one-line wrapper whose body is `useSubscription(localization.market)`. TypeScript does not propagate `@deprecated` through a wrapper, so someone using the hook gets no warning today while someone using the property does.

The `> Caution:` block mirrors the pattern used by `useTarget`, `useExtensionApi`, `useExtensionData`, and `useDeliveryGroupTarget`, since the docs pipeline does not serialize `@deprecated` for top-level exported hooks.

Companion PR in World: https://github.com/shop/world/pull/988628

## Changes

- `checkout/api/standard/standard.ts` — updates `@deprecated` on `localization.market` and adds `> Caution:` block; clarifies market scoping description
- `checkout/preact/market.ts` — adds `@deprecated` and `> Caution:` to `useLocalizationMarket`; updates description
- `customer-account/api/order-status/order-status.ts` — adds `@deprecated` and `> Caution:` to `localization.market`; clarifies market scoping description
- `customer-account/preact/market.ts` — adds `@deprecated` and `> Caution:` to `useLocalizationMarket`; updates description
- Changeset for patch bump of `@shopify/ui-extensions`

## Test plan
- [ ] Verify `@deprecated` shows strikethrough/warning in IDE when using `useLocalizationMarket` or `localization.market`
- [ ] Confirm docs build renders the `> Caution:` block correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)