### PR TITLE
docs(pos): document Discount.amount read behavior from 2026-10

### DIFF
--- a/packages/ui-extensions/checkout/preact.esnext
+++ b/packages/ui-extensions/checkout/preact.esnext
@@ -1,0 +1,1 @@
+export * from "./build/esnext/surfaces/checkout/preact/index.esnext";

--- a/packages/ui-extensions/checkout/preact.js
+++ b/packages/ui-extensions/checkout/preact.js
@@ -1,0 +1,1 @@
+module.exports = require("./build/cjs/surfaces/checkout/preact/index.js");

--- a/packages/ui-extensions/checkout/preact.mjs
+++ b/packages/ui-extensions/checkout/preact.mjs
@@ -1,0 +1,1 @@
+export * from "./build/esm/surfaces/checkout/preact/index.mjs";

--- a/packages/ui-extensions/customer-account/preact.esnext
+++ b/packages/ui-extensions/customer-account/preact.esnext
@@ -1,0 +1,1 @@
+export * from "./build/esnext/surfaces/customer-account/preact/index.esnext";

--- a/packages/ui-extensions/customer-account/preact.js
+++ b/packages/ui-extensions/customer-account/preact.js
@@ -1,0 +1,1 @@
+module.exports = require("./build/cjs/surfaces/customer-account/preact/index.js");

--- a/packages/ui-extensions/customer-account/preact.mjs
+++ b/packages/ui-extensions/customer-account/preact.mjs
@@ -1,0 +1,1 @@
+export * from "./build/esm/surfaces/customer-account/preact/index.mjs";

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -50,6 +50,11 @@ export interface LineItem {
 }
 
 export interface Discount {
+  /**
+   * The discount value to apply. For `'Percentage'` type, this is the percentage value (for example, `10` for 10% off). For `'FixedAmount'` type, this is the fixed monetary amount to deduct.
+   *
+   * From API version 2026-10, reading a manual discount from the cart returns the same value that was applied, so discounts can be passed back to `bulkCartUpdate` unchanged. This also requires a POS app version with the corresponding fix; on older POS app versions, reads return the calculated monetary total of the discount instead (the behavior of all API versions before 2026-10).
+   */
   amount: number;
   currency?: string;
   discountDescription?: string;


### PR DESCRIPTION
## What

Adds TSDoc to `Discount.amount` on the POS cart types documenting the read behavior that ships with API version 2026-10: reading a manual discount from the cart returns the value that was applied (e.g. `10` for 10%), matching writes, so discounts can be echoed through `bulkCartUpdate` losslessly. Includes the POS app version caveat for older clients.

## Why

Part of the fix for shop/issues-retail#33093: before 2026-10, reads return the calculated monetary total while writes take the applied value, so read-modify-write cycles silently corrupt percentage discounts. The behavior change is implemented in Shopify/extensibility#1657 (host, version-gated) and shop/world#997169 (POS emits the raw value).

Reported in https://community.shopify.dev/t/36265 and https://community.shopify.dev/t/36171.

Companion doc correction for the released 2026-07 branch: see the `2026-07_pos_discount_amount_doc_fix` PR.
