### PR TITLE
docs(pos): correct Discount.amount read behavior for 2026-07

### DIFF
--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -246,7 +246,9 @@ export interface SellingPlan {
  */
 export interface Discount {
   /**
-   * The discount value to apply. For `'Percentage'` type, this represents the percentage value (For example, "10" for 10% off). For `'FixedAmount'` type, this represents the fixed monetary amount to deduct from the line item price. Commonly used for discount calculations and displaying the discount value to merchants.
+   * The discount value to apply. For `'Percentage'` type, this represents the percentage value (For example, "10" for 10% off). For `'FixedAmount'` type, this represents the fixed monetary amount to deduct from the line item price.
+   *
+   * Note: in this API version, reading a discount from the cart returns the calculated monetary total of the discount in this field, not the value that was applied. Because writes interpret the field as the applied value, passing a cart discount read from the cart back to `bulkCartUpdate` unchanged will not preserve the discount. From API version 2026-10, reads return the applied value, matching writes.
    */
   amount: number;
   /**


### PR DESCRIPTION
## What

Corrects the `Discount.amount` TSDoc on the POS cart types for the released 2026-07 API version: reading a discount from the cart returns the calculated monetary total in this field, not the value that was applied. The previous doc claimed reads return the percentage value, which is not what this version does (shop/issues-retail#33093, reported in https://community.shopify.dev/t/36265 and https://community.shopify.dev/t/36171).

Also warns that echoing a read discount back through `bulkCartUpdate` does not preserve it in this version, and points to 2026-10 where reads match writes (Shopify/extensibility#1657, shop/world#997169).

Older released branches have the same behavior; happy to cherry-pick this doc note to them if that's the convention.
