### PR TITLE
Forward-port POS s-image borderRadius to 2026-10

### DIFF
--- a/.changeset/document-pos-image-border-radius.md
+++ b/.changeset/document-pos-image-border-radius.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Document the `borderRadius` prop on the POS `s-image` component.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -4195,6 +4195,29 @@ interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit' | 'alt'> {
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#src
    */
   src?: ImageProps['src'];
+  /**
+   * Border radius for the image corners.
+   *
+   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
+   * supported. Note that, contrary to CSS, it uses flow-relative values and the order is:
+   *
+   * - 4 values: `start-start inline-end end-end inline-start`
+   * - 3 values: `start-start inline end-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   * - `base` means all corners have `base` radius
+   * - `base none` means start-start and end-end corners are `base`, inline-end and inline-start corners are `none`
+   * - `base none large` means start-start is `base`, inline-end and inline-start are `none`, end-end is `large`
+   * - `base none large small` means start-start is `base`, inline-end is `none`, end-end is `large`, inline-start is `small`
+   *
+   * Supports size keywords from the design system scale:
+   * - Size scale: `small-500`, `small-400`, `small-300`, `small-200`, `small-100`, `small`, `base`, `large`, `large-100`, `large-200`, `large-300`, `large-400`, `large-500`
+   * - Special values: `max`, `none`
+   *
+   * @default 'none'
+   */
+  borderRadius?: MaybeAllValuesShorthandProperty<BorderRadiusKeyword>;
 }
 declare global {
   interface HTMLElementTagNameMap {
@@ -7116,6 +7139,29 @@ interface Image {
    * @see ://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt
    */
   alt?: string;
+  /**
+   * Border radius for the image corners.
+   *
+   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
+   * supported. Note that, contrary to CSS, it uses flow-relative values and the order is:
+   *
+   * - 4 values: `start-start inline-end end-end inline-start`
+   * - 3 values: `start-start inline end-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   * - `base` means all corners have `base` radius
+   * - `base none` means start-start and end-end corners are `base`, inline-end and inline-start corners are `none`
+   * - `base none large` means start-start is `base`, inline-end and inline-start are `none`, end-end is `large`
+   * - `base none large small` means start-start is `base`, inline-end is `none`, end-end is `large`, inline-start is `small`
+   *
+   * Supports size keywords from the design system scale:
+   * - Size scale: `small-500`, `small-400`, `small-300`, `small-200`, `small-100`, `small`, `base`, `large`, `large-100`, `large-200`, `large-300`, `large-400`, `large-500`
+   * - Special values: `max`, `none`
+   *
+   * @default 'none'
+   */
+  borderRadius?: MaybeAllValuesShorthandProperty<BorderRadiusKeyword>;
 }
 
 /**

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components.d.ts
@@ -4201,15 +4201,15 @@ interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit' | 'alt'> {
    * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
    * supported. Note that, contrary to CSS, it uses flow-relative values and the order is:
    *
-   * - 4 values: `start-start inline-end end-end inline-start`
-   * - 3 values: `start-start inline end-end`
-   * - 2 values: `block inline`
+   * - 4 values: `start-start start-end end-end end-start`
+   * - 3 values: `start-start (start-end & end-start) end-end`
+   * - 2 values: `(start-start & end-end) (start-end & end-start)`
    *
    * For example:
    * - `base` means all corners have `base` radius
-   * - `base none` means start-start and end-end corners are `base`, inline-end and inline-start corners are `none`
-   * - `base none large` means start-start is `base`, inline-end and inline-start are `none`, end-end is `large`
-   * - `base none large small` means start-start is `base`, inline-end is `none`, end-end is `large`, inline-start is `small`
+   * - `base none` means start-start and end-end corners are `base`, start-end and end-start corners are `none`
+   * - `base none large` means start-start is `base`, start-end and end-start are `none`, end-end is `large`
+   * - `base none large small` means start-start is `base`, start-end is `none`, end-end is `large`, end-start is `small`
    *
    * Supports size keywords from the design system scale:
    * - Size scale: `small-500`, `small-400`, `small-300`, `small-200`, `small-100`, `small`, `base`, `large`, `large-100`, `large-200`, `large-300`, `large-400`, `large-500`
@@ -7145,15 +7145,15 @@ interface Image {
    * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
    * supported. Note that, contrary to CSS, it uses flow-relative values and the order is:
    *
-   * - 4 values: `start-start inline-end end-end inline-start`
-   * - 3 values: `start-start inline end-end`
-   * - 2 values: `block inline`
+   * - 4 values: `start-start start-end end-end end-start`
+   * - 3 values: `start-start (start-end & end-start) end-end`
+   * - 2 values: `(start-start & end-end) (start-end & end-start)`
    *
    * For example:
    * - `base` means all corners have `base` radius
-   * - `base none` means start-start and end-end corners are `base`, inline-end and inline-start corners are `none`
-   * - `base none large` means start-start is `base`, inline-end and inline-start are `none`, end-end is `large`
-   * - `base none large small` means start-start is `base`, inline-end is `none`, end-end is `large`, inline-start is `small`
+   * - `base none` means start-start and end-end corners are `base`, start-end and end-start corners are `none`
+   * - `base none large` means start-start is `base`, start-end and end-start are `none`, end-end is `large`
+   * - `base none large small` means start-start is `base`, start-end is `none`, end-end is `large`, end-start is `small`
    *
    * Supports size keywords from the design system scale:
    * - Size scale: `small-500`, `small-400`, `small-300`, `small-200`, `small-100`, `small`, `base`, `large`, `large-100`, `large-200`, `large-300`, `large-400`, `large-500`

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
@@ -8,7 +8,13 @@
 /* eslint-disable import-x/namespace */
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference, spaced-comment
 /// <reference lib="DOM" />
-import type {ImageProps, Key, Ref} from './components-shared.d.ts';
+import type {
+  BorderRadiusKeyword,
+  ImageProps,
+  Key,
+  MaybeAllValuesShorthandProperty,
+  Ref,
+} from './components-shared.d.ts';
 
 /** @publicDocs */
 export type ComponentChildren = any;
@@ -60,6 +66,29 @@ export interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
    * The image source URL (remote URL or local file resource). When loading or no src is provided, a placeholder is rendered. Ensure URLs are properly formatted and properly formatted.
    */
   src?: ImageProps['src'];
+  /**
+   * Border radius for the image corners.
+   *
+   * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
+   * supported. Note that, contrary to CSS, it uses flow-relative values and the order is:
+   *
+   * - 4 values: `start-start inline-end end-end inline-start`
+   * - 3 values: `start-start inline end-end`
+   * - 2 values: `block inline`
+   *
+   * For example:
+   * - `base` means all corners have `base` radius
+   * - `base none` means start-start and end-end corners are `base`, inline-end and inline-start corners are `none`
+   * - `base none large` means start-start is `base`, inline-end and inline-start are `none`, end-end is `large`
+   * - `base none large small` means start-start is `base`, inline-end is `none`, end-end is `large`, inline-start is `small`
+   *
+   * Supports size keywords from the design system scale:
+   * - Size scale: `small-500`, `small-400`, `small-300`, `small-200`, `small-100`, `small`, `base`, `large`, `large-100`, `large-200`, `large-300`, `large-400`, `large-500`
+   * - Special values: `max`, `none`
+   *
+   * @default 'none'
+   */
+  borderRadius?: MaybeAllValuesShorthandProperty<BorderRadiusKeyword>;
 }
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/components/Image.d.ts
@@ -72,15 +72,15 @@ export interface ImageJSXProps extends Pick<ImageProps, 'id' | 'objectFit'> {
    * [1-to-4-value syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Shorthand_properties#edges_of_a_box) is
    * supported. Note that, contrary to CSS, it uses flow-relative values and the order is:
    *
-   * - 4 values: `start-start inline-end end-end inline-start`
-   * - 3 values: `start-start inline end-end`
-   * - 2 values: `block inline`
+   * - 4 values: `start-start start-end end-end end-start`
+   * - 3 values: `start-start (start-end & end-start) end-end`
+   * - 2 values: `(start-start & end-end) (start-end & end-start)`
    *
    * For example:
    * - `base` means all corners have `base` radius
-   * - `base none` means start-start and end-end corners are `base`, inline-end and inline-start corners are `none`
-   * - `base none large` means start-start is `base`, inline-end and inline-start are `none`, end-end is `large`
-   * - `base none large small` means start-start is `base`, inline-end is `none`, end-end is `large`, inline-start is `small`
+   * - `base none` means start-start and end-end corners are `base`, start-end and end-start corners are `none`
+   * - `base none large` means start-start is `base`, start-end and end-start are `none`, end-end is `large`
+   * - `base none large small` means start-start is `base`, start-end is `none`, end-end is `large`, end-start is `small`
    *
    * Supports size keywords from the design system scale:
    * - Size scale: `small-500`, `small-400`, `small-300`, `small-200`, `small-100`, `small`, `base`, `large`, `large-100`, `large-200`, `large-300`, `large-400`, `large-500`


### PR DESCRIPTION
## Problem

The POS `s-image` component supports `borderRadius` at runtime from API version `2026-07`, but the upcoming `2026-10` public TypeScript contract omits the property.

## Solution

Forward-port the public Image type and documentation source so `borderRadius` remains supported in `2026-10`. The full `2026-10-rc` generated POS reference baseline will need to land separately.
