### PR TITLE
feat(pos): add Cart.currency

### DIFF
--- a/.changeset/pos-cart-money-v2.md
+++ b/.changeset/pos-cart-money-v2.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-tester': patch
+---
+
+Add `currency` to the POS Cart API so extensions can read the cart presentment currency.

--- a/packages/ui-extensions-tester/src/point-of-sale/factories.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/factories.ts
@@ -76,6 +76,7 @@ function createPosCart(): Cart {
     subtotal: '0.00',
     taxTotal: '0.00',
     grandTotal: '0.00',
+    currency: 'USD',
     cartDiscounts: [],
     lineItems: [],
     properties: {},

--- a/packages/ui-extensions-tester/src/point-of-sale/index.ts
+++ b/packages/ui-extensions-tester/src/point-of-sale/index.ts
@@ -112,6 +112,7 @@ const posMutationDefaults: {
     subtotal: '0.00',
     taxTotal: '0.00',
     grandTotal: '0.00',
+    currency: 'USD',
     cartDiscounts: [],
     lineItems: [],
     properties: {},

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -24,6 +24,10 @@ export interface Cart {
    */
   grandTotal: string;
   /**
+   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for this cart.
+   */
+  currency: string;
+  /**
    * The cart note to set during bulk update. Replaces existing note or sets new note if none exists. Set to `undefined` to remove current note.
    */
   note?: string;

--- a/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/types/cart.ts
@@ -24,7 +24,7 @@ export interface Cart {
    */
   grandTotal: string;
   /**
-   * The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code for this cart.
+   * The ISO 4217 currency code for this cart.
    */
   currency: string;
   /**


### PR DESCRIPTION
## Summary

Add `currency` to the POS `Cart` type.

POS already includes this value on the cart object it passes to the host (`DraftCheckout.currency`). This change only types that existing field so extensions can read `shopify.cart.current.value.currency`.

The field is present on the cart payload for every API version. Types are published from this package version.

## Test plan

- [x] Confirm POS sends `currency` on the cart payload
- [x] Confirm `shopify.cart.current.value.currency` is populated in an extension