### PR TITLE
docs(point-of-sale): pin paymentvalidations to tender-confirm semantics

### DIFF
--- a/.changeset/pos-payment-validations-tender-confirm-docs.md
+++ b/.changeset/pos-payment-validations-tender-confirm-docs.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Document `paymentvalidations` dispatch timing: fires when a tender is confirmed but not yet committed, once per tender attempt (split payments dispatch per tender).

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -96,7 +96,10 @@ export interface InterceptedPaymentMethod {
 }
 
 /**
- * Dispatched when staff selects a payment method on the payments screen.
+ * Dispatched when a tender is confirmed but not yet committed — after the
+ * amount is entered, before the payment is recorded. One event per tender
+ * attempt; split payments dispatch one event per tender, each carrying its
+ * own amount.
  *
  * @private
  */


### PR DESCRIPTION
## What

Docs-only follow-up to #4611: pins `PaymentValidationsEvent`'s dispatch timing, which was settled after that PR merged.

- Fires when a tender is **confirmed but not committed** — after the amount is entered, before the payment is recorded (previously read "when staff selects a payment method", which was the pre-settlement wording).
- **One event per tender attempt**; split payments dispatch one event per tender, each carrying its own `amount`.
- Replaces the rejected two-event proposal (method-selected + post-tender).

Confirm-time is also why `amount` is per-tender meaningful: at selection time only the outstanding total exists; at confirm time the event carries the amount this tender actually charges.

## References

- Types: #4611 (merged) · Release: #4622 (`2027.0.0-rc.5`)
- API contract: Shopify/ui-api-design#1557
- POS host implementation (gates at `useCashPaymentSubmission`, before `addPayment`): shop/world#997831 → shop/world#1000498 → execution PR to follow
