### PR TITLE
Add types for POS intercept ValidationAdd target values

### DIFF
--- a/.changeset/pos-validation-target-grammar.md
+++ b/.changeset/pos-validation-target-grammar.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add types for POS intercept `ValidationAdd.target` values (`$.cart`, `$.cart.lineItems['<uuid>']`, `$.payment`), narrowed per intercepted event.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -110,10 +110,60 @@ export interface PaymentValidationsEvent extends Event {
   readonly amount: MoneyV2;
 }
 
+/**
+ * Targets the whole cart. Validations with this target render at the cart
+ * scope (for example the cart banner).
+ *
+ * @private
+ */
+export type CartTarget = '$.cart';
+
+/**
+ * Targets one cart line item by its `uuid` from this event's `cart` snapshot,
+ * for example `$.cart.lineItems['adfd6b06-4a24-4f5f-9f4b-ea21f4432dd4']`.
+ *
+ * @private
+ */
+export type CartLineItemTarget = `$.cart.lineItems['${string}']`;
+
+/** @private */
+export type CartValidationTarget = CartTarget | CartLineItemTarget;
+
+/**
+ * Targets the payment attempt being intercepted.
+ *
+ * @private
+ */
+export type PaymentTarget = '$.payment';
+
+/** @private */
+export type PaymentValidationTarget = PaymentTarget;
+
+/**
+ * Where a validation applies, as an enumerated token following the
+ * [Functions validation target model](https://shopify.dev/docs/api/functions/latest/cart-and-checkout-validation#supported-checkout-field-targets).
+ * Targets are matched as exact strings, never evaluated as JSON paths.
+ *
+ * @private
+ */
+export type ValidationTarget = CartValidationTarget | PaymentValidationTarget;
+
+/**
+ * The validation targets valid for a given intercepted event.
+ *
+ * @private
+ */
+export type ValidationTargetFor<TEvent extends Event> =
+  TEvent extends CartValidationsEvent
+    ? CartValidationTarget
+    : TEvent extends PaymentValidationsEvent
+    ? PaymentValidationTarget
+    : ValidationTarget;
+
 /** @private */
 export type ShopifyInterceptor<TEvent extends Event> = (
   event: TEvent,
-) => InterceptResult;
+) => InterceptResult<ValidationTargetFor<TEvent>>;
 
 /**
  * The result an interceptor returns. An empty `operations` list allows the
@@ -121,8 +171,10 @@ export type ShopifyInterceptor<TEvent extends Event> = (
  *
  * @private
  */
-export interface InterceptResult {
-  operations: Operation[];
+export interface InterceptResult<
+  TTarget extends ValidationTarget = ValidationTarget,
+> {
+  operations: Operation<TTarget>[];
 }
 
 /**
@@ -130,8 +182,10 @@ export interface InterceptResult {
  *
  * @private
  */
-export interface Operation {
-  validationAdd?: ValidationAdd;
+export interface Operation<
+  TTarget extends ValidationTarget = ValidationTarget,
+> {
+  validationAdd?: ValidationAdd<TTarget>;
 }
 
 /** @private */
@@ -142,15 +196,31 @@ export type ValidationLevel = 'WARNING' | 'ERROR';
  *
  * @private
  */
-export interface ValidationAdd {
+export interface ValidationAdd<
+  TTarget extends ValidationTarget = ValidationTarget,
+> {
   /** `ERROR` blocks the workflow. `WARNING` does not. */
   level: ValidationLevel;
 
-  /** Stable identifier for this validation. */
+  /**
+   * Stable identifier for this validation. Handles are namespaced per
+   * extension and may repeat across targets: the same handle on two line
+   * items is two validations.
+   */
   handle: string;
 
-  /** JSON-path locator for where the validation applies. */
-  target?: string;
+  /**
+   * Locates the data the validation applies to; the host decides where it
+   * renders, falling back to the event's root scope. Defaults to the root
+   * scope (`$.cart` / `$.payment`).
+   *
+   * Line item uuids are only valid within the event that delivered them:
+   * echo `lineItems[n].uuid` from this event's cart snapshot, don't cache
+   * uuids across events. Bundle components are not addressable; target their
+   * parent line. Unrecognized targets degrade to the root scope — the
+   * validation still applies, rendered less specifically.
+   */
+  target?: TTarget;
 }
 
 export type {

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -111,8 +111,8 @@ export interface PaymentValidationsEvent extends Event {
 }
 
 /**
- * Targets the whole cart. Validations with this target render at the cart
- * scope (for example the cart banner).
+ * Targets the whole cart. Validations with this target apply at the cart
+ * scope rather than to a specific line item.
  *
  * @private
  */
@@ -149,15 +149,23 @@ export type PaymentValidationTarget = PaymentTarget;
 export type ValidationTarget = CartValidationTarget | PaymentValidationTarget;
 
 /**
+ * Maps POS interceptable workflow names to their valid validation targets.
+ *
+ * @private
+ */
+interface ValidationTargetMap {
+  [POS_INTERCEPT_NAMES.CART_VALIDATIONS]: CartValidationTarget;
+  [POS_INTERCEPT_NAMES.PAYMENT_VALIDATIONS]: PaymentValidationTarget;
+}
+
+/**
  * The validation targets valid for a given intercepted event.
  *
  * @private
  */
 export type ValidationTargetFor<TEvent extends Event> =
-  TEvent extends CartValidationsEvent
-    ? CartValidationTarget
-    : TEvent extends PaymentValidationsEvent
-    ? PaymentValidationTarget
+  TEvent['type'] extends keyof ValidationTargetMap
+    ? ValidationTargetMap[TEvent['type']]
     : ValidationTarget;
 
 /** @private */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -139,9 +139,8 @@ export type PaymentTarget = '$.payment';
 export type PaymentValidationTarget = PaymentTarget;
 
 /**
- * Where a validation applies, as an enumerated token following the
- * [Functions validation target model](https://shopify.dev/docs/api/functions/latest/cart-and-checkout-validation#supported-checkout-field-targets).
- * Targets are matched as exact strings, never evaluated as JSON paths.
+ * Where a validation applies, as an enumerated token. Targets are matched
+ * as exact strings, never evaluated as JSON paths.
  *
  * @private
  */

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -223,7 +223,7 @@ export interface ValidationAdd<
    * scope (`$.cart` / `$.payment`).
    *
    * Line item uuids are only valid within the event that delivered them:
-   * echo `lineItems[n].uuid` from this event's cart snapshot, don't cache
+   * use `lineItems[n].uuid` from this event's cart snapshot, don't cache
    * uuids across events. Bundle components are not addressable; target their
    * parent line. Unrecognized targets degrade to the root scope — the
    * validation still applies, rendered less specifically.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/events.ts
@@ -111,8 +111,7 @@ export interface PaymentValidationsEvent extends Event {
 }
 
 /**
- * Targets the whole cart. Validations with this target apply at the cart
- * scope rather than to a specific line item.
+ * Targets the whole cart rather than a specific line item.
  *
  * @private
  */
@@ -219,14 +218,14 @@ export interface ValidationAdd<
 
   /**
    * Locates the data the validation applies to; the host decides where it
-   * renders, falling back to the event's root scope. Defaults to the root
-   * scope (`$.cart` / `$.payment`).
+   * renders. Omitted or unrecognized targets fall back to the event's root
+   * scope (`$.cart` / `$.payment`) — the validation still applies, rendered
+   * less specifically.
    *
    * Line item uuids are only valid within the event that delivered them:
    * use `lineItems[n].uuid` from this event's cart snapshot, don't cache
-   * uuids across events. Bundle components are not addressable; target their
-   * parent line. Unrecognized targets degrade to the root scope — the
-   * validation still applies, rendered less specifically.
+   * uuids across events. Bundle components are not addressable; target
+   * their parent line.
    */
   target?: TTarget;
 }


### PR DESCRIPTION
### Background

https://github.com/shop/issues-retail/issues/33533

The POS intercept API (#4520) shipped `ValidationAdd.target` as a bare `string` documented as a "JSON-path locator". The target contract we're keeping is the [Functions validation target model](https://shopify.dev/docs/api/functions/latest/cart-and-checkout-validation#supported-checkout-field-targets): an enumerated token table, string-matched, never evaluated as JSON paths. Bare `string` can never be narrowed later without a breaking change, and it silently accepts targets no host honors.

### Solution

Pin the grammar as template literal types while the intercept API is still `@private`, narrowed per intercepted event:

| Event | Field | Target value |
| --- | --- | --- |
| `cartvalidations` | cart | `$.cart` |
| `cartvalidations` | line item | `$.cart.lineItems['<uuid>']` |
| `paymentvalidations` | payment attempt | `$.payment` |

- `ValidationTarget` union of `CartValidationTarget` / `PaymentValidationTarget`; wire format stays a plain string, and unions can widen later (never narrow).
- `ValidationTargetFor<TEvent>` narrows interceptor returns per event: a `cartvalidations` interceptor cannot return `$.payment` (compile error), and vice versa. `InterceptResult` / `Operation` / `ValidationAdd` gain a defaulted type parameter, so existing structural consumers compile unchanged.
- Devs write the line target inline — TS contextually checks template expressions against template literal types:

  ```ts
  target: `$.cart.lineItems['${lineItem.uuid}']`  // checked char-for-char
  target: `$.cart.lineItems[${idx}]`              // compile error
  ```

- JSDoc pins the semantics: targets are data locators (host decides rendering, falls back to the event's root scope); line item uuids must be echoed from the same event's cart snapshot, not cached across events; bundle components target their parent line; unrecognized targets degrade to root scope rather than dropping the validation; handles are namespaced per extension and may repeat across targets.

### Alternatives Considered

1. **Keep `target?: string`** — ❌ can never be narrowed without a breaking change; typos and unsupported targets compile silently.
2. **JSONPath filter `$.cart.lineItems[?(@.uuid=='<uuid>')]`** — ❌ buys spec-valid JSONPath semantics the Functions token model doesn't have (its own table hardcodes `deliveryGroups[0]` against multi-group carts), at the cost of syntax hostile to extension developers.
3. **Positional `$.cart.lineItems[2]`** — ❌ cannot carry stable identity; `.filter().map((li, i))` silently targets the wrong line.
4. **Structured object / sibling uuid field** — ❌ breaks the single-string target contract shared with Functions.

### :tophat:

- Type-level only (`@private` API, no runtime change beyond the type declarations). `yarn type-check` passes.
- Verified narrowing with a scratch file: valid tokens assignable per event; cross-event tokens and positional indexes fail compilation with `@ts-expect-error` consumed.
- Host-side runtime sanitation of these tokens is tracked in https://github.com/shop/issues-retail/issues/33534 (extensibility repo); POS line-item rendering in https://github.com/shop/issues-retail/issues/32377.

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have updated relevant documentation
