### PR TITLE
Add POS Resolution API types

### DIFF
--- a/.changeset/pos-resolution-api.md
+++ b/.changeset/pos-resolution-api.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': minor
+---
+
+Add the POS Resolution API types.

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api.ts
@@ -20,6 +20,10 @@ export type {
   ExtensionApiContent,
 } from './api/extension-api/extension-api';
 export type {ActionTargetApi} from './api/action-target-api/action-target-api';
+export type {
+  ResolutionApi,
+  ResolutionApiContent,
+} from './api/resolution-api/resolution-api';
 export type {DataTargetApi} from './api/data-target-api/data-target-api';
 export type {
   TransactionCompleteEvent,

--- a/packages/ui-extensions/src/surfaces/point-of-sale/api/resolution-api/resolution-api.ts
+++ b/packages/ui-extensions/src/surfaces/point-of-sale/api/resolution-api/resolution-api.ts
@@ -1,0 +1,21 @@
+import type {ReadonlySignalLike} from '../../../../shared';
+import type {ShopifyInterceptMap} from '../../events';
+
+/**
+ * Provides access to the intercepted workflow that initiated a resolution flow.
+ *
+ * @private
+ */
+export interface ResolutionApiContent {
+  /** The intercepted workflow event being resolved. */
+  event: ReadonlySignalLike<ShopifyInterceptMap[keyof ShopifyInterceptMap]>;
+}
+
+/**
+ * Provides access to the current resolution context.
+ *
+ * @private
+ */
+export interface ResolutionApi {
+  resolution: ResolutionApiContent;
+}


### PR DESCRIPTION
## Summary

- add private POS `ResolutionApi` and `ResolutionApiContent` types
- expose the intercepted workflow as `shopify.resolution.event`
- type `event` as a read-only signal whose value is the union of `ShopifyInterceptMap` events
- add a minor changeset for `@shopify/ui-extensions`

Part of https://github.com/shop/issues-retail/issues/33117

This intentionally does not register or modify any extension target.

## Dependency

- Shopify/extensibility#1631 depends on this PR.

## Validation

- `yarn build`
- `yarn type-check`
- `yarn lint`
- `yarn test -- packages/ui-extensions/` is currently blocked by the repository's missing `react-test-renderer` dependency (2 suites pass; 36 unrelated checkout suites fail during loading).
