### PR TITLE
Restore calver package versions on 2026-10-rc

### DIFF
--- a/.changeset/pos-remove-action-api-from-action-render.md
+++ b/.changeset/pos-remove-action-api-from-action-render.md
@@ -1,6 +1,6 @@
 ---
-'@shopify/ui-extensions': major
-'@shopify/ui-extensions-tester': major
+'@shopify/ui-extensions': minor
+'@shopify/ui-extensions-tester': minor
 ---
 
 Remove the POS Action API (`shopify.action.presentModal()`) from action render targets (`*.action.render`).

--- a/packages/ui-extensions-tester/CHANGELOG.md
+++ b/packages/ui-extensions-tester/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @shopify/ui-extensions-tester
 
-## 2027.0.0-rc.5
+## 2026.10.0-rc.5
 
 ### Major Changes
 
@@ -13,7 +13,7 @@
 ### Patch Changes
 
 - Updated dependencies [[`d8b03c9`](https://github.com/Shopify/ui-extensions/commit/d8b03c99ac71e227d55743a5da657b94575e31b7), [`8e59844`](https://github.com/Shopify/ui-extensions/commit/8e59844f885f3df4e409964b5df370e5a58c7f21)]:
-  - @shopify/ui-extensions@2027.0.0-rc.5
+  - @shopify/ui-extensions@2026.10.0-rc.5
 
 ## 2026.10.0-rc.4
 

--- a/packages/ui-extensions-tester/package.json
+++ b/packages/ui-extensions-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/ui-extensions-tester",
-  "version": "2027.0.0-rc.5",
+  "version": "2026.10.0-rc.5",
   "main": "index.js",
   "module": "index.mjs",
   "esnext": "index.esnext",
@@ -55,7 +55,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@shopify/ui-extensions": "2027.0.0-rc.5"
+    "@shopify/ui-extensions": "2026.10.0-rc.5"
   },
   "peerDependencies": {
     "preact": "^10.0.0"

--- a/packages/ui-extensions-tester/src/tests/api-version.test.ts
+++ b/packages/ui-extensions-tester/src/tests/api-version.test.ts
@@ -1,0 +1,12 @@
+import {API_VERSION} from '../api-version';
+
+describe('API_VERSION', () => {
+  // API_VERSION derives from the npm package version (2026.10.x -> "2026-10"),
+  // so a semver-major changeset on this calver-keyed package rolls the year and
+  // produces a nonexistent API version ("2027-00"), breaking every consumer
+  // pinned to the branch's real version. Breaking changes here must be
+  // released as minor bumps within the branch's calendar version.
+  it('is a quarterly Shopify API version', () => {
+    expect(API_VERSION).toMatch(/^\d{4}-(01|04|07|10)$/);
+  });
+});

--- a/packages/ui-extensions/CHANGELOG.md
+++ b/packages/ui-extensions/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @shopify/ui-extensions
 
-## 2027.0.0-rc.5
+## 2026.10.0-rc.5
 
 ### Major Changes
 

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/ui-extensions",
-  "version": "2027.0.0-rc.5",
+  "version": "2026.10.0-rc.5",
   "scripts": {
     "docs:admin": "node ./docs/surfaces/admin/build-docs.mjs",
     "docs:checkout": "bash ./docs/surfaces/checkout/build-docs.sh",


### PR DESCRIPTION
### Background

Every commit on `2026-10-rc` since #4622 fails the `test` job:

```
api_version "2026-10" does not match the version supported by @shopify/ui-extensions-tester ("2027-00")
```

Trace: #4612 shipped its (version-gated) breaking change with a **`major`** changeset. The release PR #4622 then bumped `@shopify/ui-extensions` and `@shopify/ui-extensions-tester` from `2026.10.0-rc.4` to `2027.0.0-rc.5`. These packages are calver-keyed — the tester derives its supported API version from its own npm version (`api-version.ts`), so the major bump produced the nonexistent API version `2027-00`, and `validateApiVersion` rejects every example pinned to `api_version = "2026-10"`.

On an RC branch the `major.minor` of the package version *is* the API version; breaking changes must release as `minor` bumps within the branch's calendar version (#4612's change was already version-gated in its own docs: "removed for API versions 2026-10 and later").

### Solution

- **Downgrade the retained changeset to `minor`** (`pos-remove-action-api-from-action-render.md`). Changesets pre-mode retains consumed changeset files and recomputes each release from `initialVersions` + the highest bump across all of them — with the file still `major`, the next `Version Packages (rc)` would recompute `2027.0.0-rc.6` and revert any version correction. Verified via `changeset version` dry-run: with `minor`, the next computed version is `2026.10.0-rc.5`. The breaking-change warning stays in the changeset text and PR #4612; only the "Major Changes" changelog heading is lost.
- Restore both packages to `2026.10.0-rc.5` (next unpublished version; `2027.0.0-rc.5` is already on npm and can stay as a dead tag — consider `npm deprecate` after merge). Note this was unsustainable regardless of intent: the branch's final release `2026.10.0` is semver-*lower* than the published `2027.0.0-rc.5`, so the rc stream could never converge to its own stable release.
- Fix the cross-dep (`ui-extensions-tester` → `ui-extensions@2026.10.0-rc.5`) and retitle the CHANGELOG entries.
- Add a guard test asserting `API_VERSION` matches `^\d{4}-(01|04|07|10)$`. Scope honestly stated: #4622's `test` job **already failed on the existing example test and was merged and published anyway**, so no test closes that override path. What this guard adds: it checks *validity* (real quarter) rather than *consistency* (toml == version), so the tempting wrong fix — bumping the example's `api_version` to `2027-00` — stays red instead of going green, it also catches minor-overflow versions (`2026-11`), and its comment states the calver rule so the failure isn't misread as a stale example.

- Document the rule in `AGENTS.md` (calver semantics, never-`major`, pre-mode changeset retention) so future contributors and coding agents don't repeat this.

### Follow-ups this PR doesn't do (process, not code)

- Gate Deploy/publish on the `test` job — red CI published to npm this time.
- Optional: a changeset lint rejecting `major` bumps while `.changeset/pre.json` exists — that fires at the feature PR (earliest point), before the bad version exists in-tree.

No changeset: this PR *is* the version correction; the next `Version Packages (rc)` continues from `2026.10.0-rc.5`.

### :tophat:

- `yarn test --ci ui-extensions-tester`: 98 passed (includes the new guard test)
- Ran the CI-failing scenario (`examples/testing/checkout-basic-testing-example`: install + test) locally on this branch: 3 passed. The pre-fix failure is from CI logs, not reproduced locally.
- type-check / lint / test: green on this PR's CI (first green `test` job on the branch since #4622)

**Note for after merge:** the npm `rc` dist-tag currently points at the broken `2027.0.0-rc.5`, so `npm install @shopify/ui-extensions-tester@rc` serves the bad version until the next `Version Packages (rc)` publishes `2026.10.0-rc.5` and moves the tag. If that gap matters, retag manually (`npm dist-tag add @shopify/ui-extensions-tester@2026.10.0-rc.4 rc`) or deprecate `2027.0.0-rc.5`.
