### PR TITLE
Remove unsupported print action shouldRender targets

### DIFF
--- a/.changeset/print-action-should-render-detail-targets.md
+++ b/.changeset/print-action-should-render-detail-targets.md
@@ -1,0 +1,5 @@
+---
+'@shopify/ui-extensions': patch
+---
+
+Remove unsupported bulk print action `shouldRender` targets from Admin UI extension types and generated docs.

--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data_v2.json
@@ -482,13 +482,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.order-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-details.action.render",
           "value": "RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems."
@@ -573,13 +566,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.product-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-purchase-option.action.render",
           "value": "RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations."
@@ -642,7 +628,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2490,7 +2476,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -2835,7 +2821,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2279",
+          "name": "__@internals$3@2270",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3517,7 +3503,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3620,7 +3606,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2380",
+          "name": "__@internals$2@2371",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3879,7 +3865,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4040,7 +4026,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2424",
+          "name": "__@dirtyStateSymbol@2415",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -4048,7 +4034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2423",
+          "name": "__@internals$1@2414",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4215,7 +4201,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2459",
+          "name": "__@setFiles@2450",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true
@@ -4223,7 +4209,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2461",
+          "name": "__@getFileInput@2452",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true
@@ -4231,7 +4217,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2460",
+          "name": "__@internals@2451",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4541,7 +4527,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -5949,7 +5935,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -5957,7 +5943,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -5965,7 +5951,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -6176,7 +6162,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6427,7 +6413,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7017,7 +7003,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7320,7 +7306,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7567,7 +7553,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@2874",
+          "name": "__@usedFirstOptionSymbol@2865",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true
@@ -7575,7 +7561,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@2875",
+          "name": "__@hasInitialValueSymbol@2866",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -7605,7 +7591,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8169,7 +8155,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8284,7 +8270,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@2950",
+          "name": "__@actualTableVariantSymbol@2941",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true
@@ -8292,7 +8278,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@2951",
+          "name": "__@tableHeadersSharedDataSymbol@2942",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true
@@ -8499,7 +8485,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@2973",
+          "name": "__@headerFormatSymbol@2964",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true
@@ -9079,7 +9065,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9322,7 +9308,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9479,7 +9465,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -9487,7 +9473,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -9495,7 +9481,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -9789,7 +9775,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -21992,7 +21978,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2655",
+          "name": "__@abortController@2645",
           "value": "AbortController",
           "description": "",
           "isPrivate": true
@@ -22000,7 +21986,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2649",
+          "name": "__@dialog@2639",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true
@@ -22008,7 +21994,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2651",
+          "name": "__@focusedElement@2641",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -22016,7 +22002,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2653",
+          "name": "__@nestedModals@2643",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true
@@ -22024,7 +22010,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2657",
+          "name": "__@childrenRerenderObserver@2647",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -22032,7 +22018,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2658",
+          "name": "__@shadowDomRerenderObserver@2648",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -22040,7 +22026,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2652",
+          "name": "__@onEscape@2642",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true
@@ -22048,7 +22034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2654",
+          "name": "__@onBackdropClick@2644",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true
@@ -22056,7 +22042,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2656",
+          "name": "__@onChildModalChange@2646",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true
@@ -22064,7 +22050,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2648",
+          "name": "__@isOpen@2638",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22072,7 +22058,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2650",
+          "name": "__@dismiss@2640",
           "value": "() => void",
           "description": "",
           "isPrivate": true
@@ -22080,7 +22066,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2645",
+          "name": "__@hasOpenChildModal@2635",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22088,7 +22074,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2646",
+          "name": "__@show@2636",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -22096,7 +22082,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2647",
+          "name": "__@hide@2637",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -22104,7 +22090,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22112,7 +22098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -22120,7 +22106,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -23822,7 +23808,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -23830,7 +23816,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -23838,7 +23824,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true

--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/targets.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/targets.json
@@ -3024,18 +3024,6 @@
       "ShouldRenderApi"
     ]
   },
-  "admin.order-index.selection-print-action.should-render": {
-    "components": [],
-    "apis": [
-      "ShouldRenderApi"
-    ]
-  },
-  "admin.product-index.selection-print-action.should-render": {
-    "components": [],
-    "apis": [
-      "ShouldRenderApi"
-    ]
-  },
   "admin.app.tools.data": {
     "components": [],
     "apis": [
@@ -3151,12 +3139,10 @@
       "admin.order-fulfilled-card.action.should-render",
       "admin.order-index.action.should-render",
       "admin.order-index.selection-action.should-render",
-      "admin.order-index.selection-print-action.should-render",
       "admin.product-details.action.should-render",
       "admin.product-details.print-action.should-render",
       "admin.product-index.action.should-render",
       "admin.product-index.selection-action.should-render",
-      "admin.product-index.selection-print-action.should-render",
       "admin.product-variant-details.action.should-render"
     ]
   },

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -482,13 +482,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.order-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-details.action.render",
           "value": "RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems."
@@ -573,13 +566,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.product-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-purchase-option.action.render",
           "value": "RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations."
@@ -642,7 +628,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2490,7 +2476,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -2835,7 +2821,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2279",
+          "name": "__@internals$3@2270",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3517,7 +3503,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3620,7 +3606,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2380",
+          "name": "__@internals$2@2371",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3879,7 +3865,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4040,7 +4026,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2424",
+          "name": "__@dirtyStateSymbol@2415",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -4048,7 +4034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2423",
+          "name": "__@internals$1@2414",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4215,7 +4201,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2459",
+          "name": "__@setFiles@2450",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true
@@ -4223,7 +4209,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2461",
+          "name": "__@getFileInput@2452",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true
@@ -4231,7 +4217,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2460",
+          "name": "__@internals@2451",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4541,7 +4527,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -5949,7 +5935,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -5957,7 +5943,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -5965,7 +5951,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -6176,7 +6162,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6427,7 +6413,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7017,7 +7003,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7320,7 +7306,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7567,7 +7553,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@2874",
+          "name": "__@usedFirstOptionSymbol@2865",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true
@@ -7575,7 +7561,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@2875",
+          "name": "__@hasInitialValueSymbol@2866",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -7605,7 +7591,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8169,7 +8155,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8284,7 +8270,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@2950",
+          "name": "__@actualTableVariantSymbol@2941",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true
@@ -8292,7 +8278,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@2951",
+          "name": "__@tableHeadersSharedDataSymbol@2942",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true
@@ -8499,7 +8485,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@2973",
+          "name": "__@headerFormatSymbol@2964",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true
@@ -9079,7 +9065,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9322,7 +9308,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9479,7 +9465,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -9487,7 +9473,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -9495,7 +9481,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -9789,7 +9775,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -21992,7 +21978,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2655",
+          "name": "__@abortController@2645",
           "value": "AbortController",
           "description": "",
           "isPrivate": true
@@ -22000,7 +21986,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2649",
+          "name": "__@dialog@2639",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true
@@ -22008,7 +21994,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2651",
+          "name": "__@focusedElement@2641",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -22016,7 +22002,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2653",
+          "name": "__@nestedModals@2643",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true
@@ -22024,7 +22010,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2657",
+          "name": "__@childrenRerenderObserver@2647",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -22032,7 +22018,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2658",
+          "name": "__@shadowDomRerenderObserver@2648",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -22040,7 +22026,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2652",
+          "name": "__@onEscape@2642",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true
@@ -22048,7 +22034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2654",
+          "name": "__@onBackdropClick@2644",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true
@@ -22056,7 +22042,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2656",
+          "name": "__@onChildModalChange@2646",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true
@@ -22064,7 +22050,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2648",
+          "name": "__@isOpen@2638",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22072,7 +22058,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2650",
+          "name": "__@dismiss@2640",
           "value": "() => void",
           "description": "",
           "isPrivate": true
@@ -22080,7 +22066,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2645",
+          "name": "__@hasOpenChildModal@2635",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22088,7 +22074,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2646",
+          "name": "__@show@2636",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -22096,7 +22082,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2647",
+          "name": "__@hide@2637",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -22104,7 +22090,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22112,7 +22098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -22120,7 +22106,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -23822,7 +23808,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -23830,7 +23816,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -23838,7 +23824,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2025-10/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2025-10/generated_docs_data_v2.json
@@ -482,13 +482,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.order-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-details.action.render",
           "value": "RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems."
@@ -573,13 +566,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.product-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-purchase-option.action.render",
           "value": "RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations."
@@ -642,7 +628,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2490,7 +2476,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -2835,7 +2821,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2279",
+          "name": "__@internals$3@2270",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3517,7 +3503,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3620,7 +3606,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2380",
+          "name": "__@internals$2@2371",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -3879,7 +3865,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4040,7 +4026,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2424",
+          "name": "__@dirtyStateSymbol@2415",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -4048,7 +4034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2423",
+          "name": "__@internals$1@2414",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4215,7 +4201,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2459",
+          "name": "__@setFiles@2450",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true
@@ -4223,7 +4209,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2461",
+          "name": "__@getFileInput@2452",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true
@@ -4231,7 +4217,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2460",
+          "name": "__@internals@2451",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -4541,7 +4527,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -5949,7 +5935,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -5957,7 +5943,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -5965,7 +5951,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -6176,7 +6162,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -6427,7 +6413,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7017,7 +7003,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7320,7 +7306,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -7567,7 +7553,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@2874",
+          "name": "__@usedFirstOptionSymbol@2865",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true
@@ -7575,7 +7561,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@2875",
+          "name": "__@hasInitialValueSymbol@2866",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -7605,7 +7591,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8169,7 +8155,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -8284,7 +8270,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@2950",
+          "name": "__@actualTableVariantSymbol@2941",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true
@@ -8292,7 +8278,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@2951",
+          "name": "__@tableHeadersSharedDataSymbol@2942",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true
@@ -8499,7 +8485,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@2973",
+          "name": "__@headerFormatSymbol@2964",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true
@@ -9079,7 +9065,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9322,7 +9308,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -9479,7 +9465,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -9487,7 +9473,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -9495,7 +9481,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -9789,7 +9775,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2226",
+          "name": "__@internals$4@2218",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true
@@ -21992,7 +21978,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2655",
+          "name": "__@abortController@2645",
           "value": "AbortController",
           "description": "",
           "isPrivate": true
@@ -22000,7 +21986,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2649",
+          "name": "__@dialog@2639",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true
@@ -22008,7 +21994,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2651",
+          "name": "__@focusedElement@2641",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -22016,7 +22002,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2653",
+          "name": "__@nestedModals@2643",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true
@@ -22024,7 +22010,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2657",
+          "name": "__@childrenRerenderObserver@2647",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -22032,7 +22018,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2658",
+          "name": "__@shadowDomRerenderObserver@2648",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true
@@ -22040,7 +22026,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2652",
+          "name": "__@onEscape@2642",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true
@@ -22048,7 +22034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2654",
+          "name": "__@onBackdropClick@2644",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true
@@ -22056,7 +22042,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2656",
+          "name": "__@onChildModalChange@2646",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true
@@ -22064,7 +22050,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2648",
+          "name": "__@isOpen@2638",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22072,7 +22058,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2650",
+          "name": "__@dismiss@2640",
           "value": "() => void",
           "description": "",
           "isPrivate": true
@@ -22080,7 +22066,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2645",
+          "name": "__@hasOpenChildModal@2635",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22088,7 +22074,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2646",
+          "name": "__@show@2636",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -22096,7 +22082,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2647",
+          "name": "__@hide@2637",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true
@@ -22104,7 +22090,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -22112,7 +22098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -22120,7 +22106,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true
@@ -23822,7 +23808,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2595",
+          "name": "__@overlayHidden@2591",
           "value": "boolean",
           "description": "",
           "isPrivate": true
@@ -23830,7 +23816,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2596",
+          "name": "__@overlayActivator@2592",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true
@@ -23838,7 +23824,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2597",
+          "name": "__@overlayHideFrameId@2593",
           "value": "number",
           "description": "",
           "isPrivate": true

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -606,7 +606,7 @@ export interface ExtensionTargets {
     ShouldRenderOutput
   >;
 
-  // Admin print action and bulk print action shouldRender targets
+  // Admin print action shouldRender targets
 
   /**
    * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.
@@ -621,22 +621,6 @@ export interface ExtensionTargets {
    */
   'admin.product-details.print-action.should-render': RunnableExtension<
     ShouldRenderApi<'admin.product-details.print-action.should-render'>,
-    ShouldRenderOutput
-  >;
-
-  /**
-   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.
-   */
-  'admin.order-index.selection-print-action.should-render': RunnableExtension<
-    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,
-    ShouldRenderOutput
-  >;
-
-  /**
-   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.
-   */
-  'admin.product-index.selection-print-action.should-render': RunnableExtension<
-    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,
     ShouldRenderOutput
   >;
 


### PR DESCRIPTION
## What

Removes unsupported Admin bulk print-action `shouldRender` targets from UI Extensions types and generated docs:

- `admin.order-index.selection-print-action.should-render`
- `admin.product-index.selection-print-action.should-render`

Keeps the supported detail print-action `shouldRender` targets:

- `admin.order-details.print-action.should-render`
- `admin.product-details.print-action.should-render`

## Why

The platform direction is detail-only print-action `should_render` support. Bulk/selection print actions are not supported by Core/Admin Web, so the public types and generated docs should not advertise them.

Companion World PRs:

- Core asset mapping: shop/world#2016728
- Admin Web runtime target registration: shop/world#2016776

Tracking issue: shop/issues-admin-extensibility#3011

## Validation

- `node packages/ui-extensions/docs/surfaces/admin/build-docs.mjs 2025-10`
- `git diff --check`
- `yarn lint`
- `yarn type-check`
