### PR TITLE
Limit admin print action shouldRender targets to details

### DIFF
--- a/.changeset/print-action-should-render-detail-targets.md
+++ b/.changeset/print-action-should-render-detail-targets.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions': patch
+'@shopify/ui-extensions-tester': patch
+---
+
+Remove unsupported bulk print action `shouldRender` targets from Admin UI extension types and generated docs.

--- a/packages/ui-extensions-tester/src/admin/factories.ts
+++ b/packages/ui-extensions-tester/src/admin/factories.ts
@@ -429,10 +429,6 @@ const adminMockFactories: AdminMockFactory = {
   // Should-render targets (print action)
   'admin.order-details.print-action.should-render': createShouldRenderMock,
   'admin.product-details.print-action.should-render': createShouldRenderMock,
-  'admin.order-index.selection-print-action.should-render':
-    createShouldRenderMock,
-  'admin.product-index.selection-print-action.should-render':
-    createShouldRenderMock,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -574,13 +574,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.order-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-details.action.render",
           "value": "RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems."
@@ -665,13 +658,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.product-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-purchase-option.action.render",
           "value": "RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations."
@@ -734,7 +720,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2752,7 +2738,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -3137,7 +3123,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2409",
+          "name": "__@internals$3@2412",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -3901,7 +3887,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4016,7 +4002,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2510",
+          "name": "__@internals$2@2513",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4307,7 +4293,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4487,7 +4473,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2554",
+          "name": "__@dirtyStateSymbol@2557",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -4496,7 +4482,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2553",
+          "name": "__@internals$1@2556",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4683,7 +4669,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2589",
+          "name": "__@setFiles@2592",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true,
@@ -4692,7 +4678,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2591",
+          "name": "__@getFileInput@2594",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true,
@@ -4701,7 +4687,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2590",
+          "name": "__@internals@2593",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -5048,7 +5034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -6617,7 +6603,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -6626,7 +6612,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -6635,7 +6621,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -6872,7 +6858,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -7154,7 +7140,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -7812,7 +7798,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -8151,7 +8137,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -8427,7 +8413,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@3004",
+          "name": "__@usedFirstOptionSymbol@3007",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true,
@@ -8436,7 +8422,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@3005",
+          "name": "__@hasInitialValueSymbol@3008",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -8470,7 +8456,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -9100,7 +9086,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -9228,7 +9214,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@3080",
+          "name": "__@actualTableVariantSymbol@3083",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true,
@@ -9237,7 +9223,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@3081",
+          "name": "__@tableHeadersSharedDataSymbol@3084",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true,
@@ -9462,7 +9448,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@3103",
+          "name": "__@headerFormatSymbol@3106",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true,
@@ -10109,7 +10095,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -10382,7 +10368,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -10556,7 +10542,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -10565,7 +10551,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -10574,7 +10560,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -10903,7 +10889,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -12049,7 +12035,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2785",
+          "name": "__@abortController@2788",
           "value": "AbortController",
           "description": "",
           "isPrivate": true,
@@ -12058,7 +12044,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2779",
+          "name": "__@dialog@2782",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true,
@@ -12067,7 +12053,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2781",
+          "name": "__@focusedElement@2784",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -12076,7 +12062,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2783",
+          "name": "__@nestedModals@2786",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true,
@@ -12085,7 +12071,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2787",
+          "name": "__@childrenRerenderObserver@2790",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true,
@@ -12094,7 +12080,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2788",
+          "name": "__@shadowDomRerenderObserver@2791",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true,
@@ -12103,7 +12089,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2782",
+          "name": "__@onEscape@2785",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true,
@@ -12112,7 +12098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2784",
+          "name": "__@onBackdropClick@2787",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true,
@@ -12121,7 +12107,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2786",
+          "name": "__@onChildModalChange@2789",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true,
@@ -12130,7 +12116,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2778",
+          "name": "__@isOpen@2781",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12139,7 +12125,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2780",
+          "name": "__@dismiss@2783",
           "value": "() => void",
           "description": "",
           "isPrivate": true,
@@ -12148,7 +12134,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2775",
+          "name": "__@hasOpenChildModal@2778",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12157,7 +12143,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2776",
+          "name": "__@show@2779",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true,
@@ -12166,7 +12152,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2777",
+          "name": "__@hide@2780",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true,
@@ -12175,7 +12161,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12184,7 +12170,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -12193,7 +12179,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -12956,12 +12942,40 @@
         {
           "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
           "syntaxKind": "PropertySignature",
+          "name": "purchaseType",
+          "value": "ReadonlySignalLike<PurchaseType>",
+          "description": "A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "recurringCycleLimit",
+          "value": "ReadonlySignalLike<number | null>",
+          "description": "A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
           "name": "updateDiscountClasses",
           "value": "UpdateSignalFunction<DiscountClass[]>",
           "description": "A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "updatePurchaseType",
+          "value": "UpdateSignalFunction<PurchaseType>",
+          "description": "A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`)."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "updateRecurringCycleLimit",
+          "value": "UpdateSignalFunction<number | null>",
+          "description": "A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit."
         }
       ],
-      "value": "export interface DiscountsApi {\n  /**\n   * A signal that contains the discount classes (Product, Order, or Shipping). Read this to determine where the discount applies in the purchase flow. A discount can apply to multiple classes simultaneously.\n   */\n  discountClasses: ReadonlySignalLike<DiscountClass[]>;\n  /**\n   * A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects.\n   */\n  updateDiscountClasses: UpdateSignalFunction<DiscountClass[]>;\n  /**\n   * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.\n   */\n  discountMethod: ReadonlySignalLike<DiscountMethod>;\n}"
+      "value": "export interface DiscountsApi {\n  /**\n   * A signal that contains the discount classes (Product, Order, or Shipping). Read this to determine where the discount applies in the purchase flow. A discount can apply to multiple classes simultaneously.\n   */\n  discountClasses: ReadonlySignalLike<DiscountClass[]>;\n  /**\n   * A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects.\n   */\n  updateDiscountClasses: UpdateSignalFunction<DiscountClass[]>;\n  /**\n   * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.\n   */\n  discountMethod: ReadonlySignalLike<DiscountMethod>;\n  /**\n   * A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both.\n   */\n  purchaseType: ReadonlySignalLike<PurchaseType>;\n  /**\n   * A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`).\n   */\n  updatePurchaseType: UpdateSignalFunction<PurchaseType>;\n  /**\n   * A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set.\n   */\n  recurringCycleLimit: ReadonlySignalLike<number | null>;\n  /**\n   * A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit.\n   */\n  updateRecurringCycleLimit: UpdateSignalFunction<number | null>;\n}"
     }
   },
   "ReadonlySignalLike": {
@@ -13005,6 +13019,16 @@
       "name": "DiscountMethod",
       "value": "'automatic' | 'code'",
       "description": "The method used to apply a discount. Use `'automatic'` for discounts that apply automatically at checkout, or `'code'` for discounts that require a code entered by the customer.",
+      "isPublicDocs": true
+    }
+  },
+  "PurchaseType": {
+    "src/surfaces/admin/api/discount-function-settings/launch-options.ts": {
+      "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "PurchaseType",
+      "value": "'one_time_purchase' | 'subscription' | 'both'",
+      "description": "The purchase type that determines which purchases the discount applies to. Use `'one_time_purchase'` for one-time purchases only, `'subscription'` for subscription purchases only, or `'both'` for both.",
       "isPublicDocs": true
     }
   },
@@ -20812,7 +20836,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -20821,7 +20845,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -20830,7 +20854,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,

--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/targets.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/targets.json
@@ -3283,18 +3283,6 @@
       "ShouldRenderApi"
     ]
   },
-  "admin.order-index.selection-print-action.should-render": {
-    "components": [],
-    "apis": [
-      "ShouldRenderApi"
-    ]
-  },
-  "admin.product-index.selection-print-action.should-render": {
-    "components": [],
-    "apis": [
-      "ShouldRenderApi"
-    ]
-  },
   "admin.app.tools.data": {
     "components": [],
     "apis": [
@@ -3424,12 +3412,10 @@
       "admin.order-fulfilled-card.action.should-render",
       "admin.order-index.action.should-render",
       "admin.order-index.selection-action.should-render",
-      "admin.order-index.selection-print-action.should-render",
       "admin.product-details.action.should-render",
       "admin.product-details.print-action.should-render",
       "admin.product-index.action.should-render",
       "admin.product-index.selection-action.should-render",
-      "admin.product-index.selection-print-action.should-render",
       "admin.product-variant-details.action.should-render"
     ]
   },

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -574,13 +574,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.order-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-details.action.render",
           "value": "RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems."
@@ -665,13 +658,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.product-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-purchase-option.action.render",
           "value": "RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations."
@@ -734,7 +720,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2752,7 +2738,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -3137,7 +3123,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2409",
+          "name": "__@internals$3@2412",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -3901,7 +3887,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4016,7 +4002,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2510",
+          "name": "__@internals$2@2513",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4307,7 +4293,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4487,7 +4473,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2554",
+          "name": "__@dirtyStateSymbol@2557",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -4496,7 +4482,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2553",
+          "name": "__@internals$1@2556",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4683,7 +4669,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2589",
+          "name": "__@setFiles@2592",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true,
@@ -4692,7 +4678,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2591",
+          "name": "__@getFileInput@2594",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true,
@@ -4701,7 +4687,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2590",
+          "name": "__@internals@2593",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -5048,7 +5034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -6617,7 +6603,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -6626,7 +6612,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -6635,7 +6621,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -6872,7 +6858,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -7154,7 +7140,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -7812,7 +7798,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -8151,7 +8137,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -8427,7 +8413,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@3004",
+          "name": "__@usedFirstOptionSymbol@3007",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true,
@@ -8436,7 +8422,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@3005",
+          "name": "__@hasInitialValueSymbol@3008",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -8470,7 +8456,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -9100,7 +9086,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -9228,7 +9214,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@3080",
+          "name": "__@actualTableVariantSymbol@3083",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true,
@@ -9237,7 +9223,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@3081",
+          "name": "__@tableHeadersSharedDataSymbol@3084",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true,
@@ -9462,7 +9448,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@3103",
+          "name": "__@headerFormatSymbol@3106",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true,
@@ -10109,7 +10095,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -10382,7 +10368,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -10556,7 +10542,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -10565,7 +10551,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -10574,7 +10560,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -10903,7 +10889,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -12049,7 +12035,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2785",
+          "name": "__@abortController@2788",
           "value": "AbortController",
           "description": "",
           "isPrivate": true,
@@ -12058,7 +12044,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2779",
+          "name": "__@dialog@2782",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true,
@@ -12067,7 +12053,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2781",
+          "name": "__@focusedElement@2784",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -12076,7 +12062,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2783",
+          "name": "__@nestedModals@2786",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true,
@@ -12085,7 +12071,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2787",
+          "name": "__@childrenRerenderObserver@2790",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true,
@@ -12094,7 +12080,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2788",
+          "name": "__@shadowDomRerenderObserver@2791",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true,
@@ -12103,7 +12089,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2782",
+          "name": "__@onEscape@2785",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true,
@@ -12112,7 +12098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2784",
+          "name": "__@onBackdropClick@2787",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true,
@@ -12121,7 +12107,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2786",
+          "name": "__@onChildModalChange@2789",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true,
@@ -12130,7 +12116,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2778",
+          "name": "__@isOpen@2781",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12139,7 +12125,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2780",
+          "name": "__@dismiss@2783",
           "value": "() => void",
           "description": "",
           "isPrivate": true,
@@ -12148,7 +12134,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2775",
+          "name": "__@hasOpenChildModal@2778",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12157,7 +12143,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2776",
+          "name": "__@show@2779",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true,
@@ -12166,7 +12152,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2777",
+          "name": "__@hide@2780",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true,
@@ -12175,7 +12161,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12184,7 +12170,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -12193,7 +12179,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -12956,12 +12942,40 @@
         {
           "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
           "syntaxKind": "PropertySignature",
+          "name": "purchaseType",
+          "value": "ReadonlySignalLike<PurchaseType>",
+          "description": "A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "recurringCycleLimit",
+          "value": "ReadonlySignalLike<number | null>",
+          "description": "A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
           "name": "updateDiscountClasses",
           "value": "UpdateSignalFunction<DiscountClass[]>",
           "description": "A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "updatePurchaseType",
+          "value": "UpdateSignalFunction<PurchaseType>",
+          "description": "A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`)."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "updateRecurringCycleLimit",
+          "value": "UpdateSignalFunction<number | null>",
+          "description": "A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit."
         }
       ],
-      "value": "export interface DiscountsApi {\n  /**\n   * A signal that contains the discount classes (Product, Order, or Shipping). Read this to determine where the discount applies in the purchase flow. A discount can apply to multiple classes simultaneously.\n   */\n  discountClasses: ReadonlySignalLike<DiscountClass[]>;\n  /**\n   * A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects.\n   */\n  updateDiscountClasses: UpdateSignalFunction<DiscountClass[]>;\n  /**\n   * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.\n   */\n  discountMethod: ReadonlySignalLike<DiscountMethod>;\n}"
+      "value": "export interface DiscountsApi {\n  /**\n   * A signal that contains the discount classes (Product, Order, or Shipping). Read this to determine where the discount applies in the purchase flow. A discount can apply to multiple classes simultaneously.\n   */\n  discountClasses: ReadonlySignalLike<DiscountClass[]>;\n  /**\n   * A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects.\n   */\n  updateDiscountClasses: UpdateSignalFunction<DiscountClass[]>;\n  /**\n   * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.\n   */\n  discountMethod: ReadonlySignalLike<DiscountMethod>;\n  /**\n   * A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both.\n   */\n  purchaseType: ReadonlySignalLike<PurchaseType>;\n  /**\n   * A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`).\n   */\n  updatePurchaseType: UpdateSignalFunction<PurchaseType>;\n  /**\n   * A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set.\n   */\n  recurringCycleLimit: ReadonlySignalLike<number | null>;\n  /**\n   * A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit.\n   */\n  updateRecurringCycleLimit: UpdateSignalFunction<number | null>;\n}"
     }
   },
   "ReadonlySignalLike": {
@@ -13005,6 +13019,16 @@
       "name": "DiscountMethod",
       "value": "'automatic' | 'code'",
       "description": "The method used to apply a discount. Use `'automatic'` for discounts that apply automatically at checkout, or `'code'` for discounts that require a code entered by the customer.",
+      "isPublicDocs": true
+    }
+  },
+  "PurchaseType": {
+    "src/surfaces/admin/api/discount-function-settings/launch-options.ts": {
+      "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "PurchaseType",
+      "value": "'one_time_purchase' | 'subscription' | 'both'",
+      "description": "The purchase type that determines which purchases the discount applies to. Use `'one_time_purchase'` for one-time purchases only, `'subscription'` for subscription purchases only, or `'both'` for both.",
       "isPublicDocs": true
     }
   },
@@ -20812,7 +20836,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -20821,7 +20845,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -20830,7 +20854,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
@@ -574,13 +574,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.order-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-details.action.render",
           "value": "RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems."
@@ -665,13 +658,6 @@
         {
           "filePath": "src/surfaces/admin/extension-targets.ts",
           "syntaxKind": "PropertySignature",
-          "name": "admin.product-index.selection-print-action.should-render",
-          "value": "RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >",
-          "description": "A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data."
-        },
-        {
-          "filePath": "src/surfaces/admin/extension-targets.ts",
-          "syntaxKind": "PropertySignature",
           "name": "admin.product-purchase-option.action.render",
           "value": "RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >",
           "description": "An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations."
@@ -734,7 +720,7 @@
           "description": "A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules."
         }
       ],
-      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action and bulk print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
+      "value": "export interface ExtensionTargets {\n  /**\n   * A runnable target that provides [customer segment templates](/docs/apps/build/marketing-analytics/customer-segments/build-a-template-extension) in the [customer segment editor](https://help.shopify.com/manual/customers/customer-segmentation/create-customer-segments). Use this target to provide pre-built segment templates that merchants can use as starting points for creating targeted customer groups based on custom criteria.\n   */\n  'admin.customers.segmentation-templates.data': RunnableExtension<\n    CustomerSegmentTemplateApi<'admin.customers.segmentation-templates.data'>,\n    {templates: CustomerSegmentTemplate[]}\n  >;\n\n  // Blocks\n  /**\n   * A block target that displays inline content within the product details page. Use this to show product-specific information, tools, or actions directly on the product page.\n   */\n  'admin.product-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the order details page. Use this to show order-specific information, fulfillment tools, or custom order actions.\n   */\n  'admin.order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that appears when merchants create or edit a discount powered by your discount function, allowing them to configure function-specific settings. Use this to build custom configuration interfaces for discount function parameters.\n   */\n  'admin.discount-details.function-settings.render': RenderExtension<\n    DiscountFunctionSettingsApi<'admin.discount-details.function-settings.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the customer details page. Use this to show customer-specific information, loyalty data, or custom customer actions.\n   */\n  'admin.customer-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.customer-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the collection details page. Use this to show collection analytics, bulk product operations, or collection-specific tools.\n   */\n  'admin.collection-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.collection-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the draft order details page. Use this to show custom pricing calculations, special order handling tools, or order-specific information.\n   */\n  'admin.draft-order-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.draft-order-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the abandoned checkout details page. Use this to show cart recovery tools, abandonment analysis, or customer re-engagement options.\n   */\n  'admin.abandoned-checkout-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.abandoned-checkout-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the catalog details page. Use this to show catalog-specific settings, market information, or synchronization tools.\n   */\n  'admin.catalog-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.catalog-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company details page. Use this to show B2B customer information, credit limits, or company-specific data.\n   */\n  'admin.company-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the company location details page. Use this to show location-specific information, shipping preferences, or location management tools.\n   */\n  'admin.company-location-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.company-location-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the gift card details page. Use this to show gift card balance tracking, usage history, or custom gift card metadata.\n   */\n  'admin.gift-card-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.gift-card-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that displays inline content within the product variant details page. Use this to show variant-specific data, inventory tools, or variant configuration options.\n   */\n  'admin.product-variant-details.block.render': RenderExtension<\n    BlockExtensionApi<'admin.product-variant-details.block.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A block target that provides custom reordering functionality on the product details page. Use this to help merchants rearrange product data.\n   */\n  'admin.product-details.reorder.render': RenderExtension<\n    BlockExtensionApi<'admin.product-details.reorder.render'>,\n    BlockExtensionComponents\n  >;\n\n  // Actions\n  /**\n   * An action target that appears in the **More actions** menu on the product details page. Use this to create workflows for processing products, syncing data, or integrating with external systems.\n   */\n  'admin.product-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the catalog details page. Use this to create workflows for catalog management, market synchronization, or data exports.\n   */\n  'admin.catalog-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.catalog-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the company details page. Use this to create workflows for B2B customer management, credit operations, or company data synchronization.\n   */\n  'admin.company-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.company-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the gift card details page. Use this to create workflows for gift card processing, balance adjustments, or custom gift card operations.\n   */\n  'admin.gift-card-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.gift-card-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order details page. Use this to create workflows for order processing, fulfillment operations, or external system integrations.\n   */\n  'admin.order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer details page. Use this to create workflows for customer data management, loyalty operations, or CRM integrations.\n   */\n  'admin.customer-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears from the **Use segment** button on the customer segment details page. Use this to create workflows for marketing campaigns, email operations, or segment-based actions.\n   */\n  'admin.customer-segment-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-segment-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product index page. Use this to create workflows for product management, catalog operations, or inventory synchronization.\n   */\n  'admin.product-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the order index page. Use this to create workflows for order management, reporting, or fulfillment operations.\n   */\n  'admin.order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the customer index page. Use this to create workflows for customer management, marketing operations, or bulk data processing.\n   */\n  'admin.customer-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page. Use this to create workflows for discount management, promotional operations, or bulk discount updates.\n   */\n  'admin.discount-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection details page. Use this to create workflows for collection management, product operations, or merchandising tools.\n   */\n  'admin.collection-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the collection index page. Use this to create workflows for collection management, bulk operations, or catalog organization.\n   */\n  'admin.collection-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.collection-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout details page. Use this to create workflows for cart recovery, customer engagement, or checkout analysis.\n   */\n  'admin.abandoned-checkout-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the abandoned checkout index page. Use this to create workflows for cart recovery, bulk customer engagement, or checkout analysis across multiple abandoned carts.\n   */\n  'admin.abandoned-checkout-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.abandoned-checkout-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the product variant details page. Use this to create workflows for variant management, inventory operations, or data synchronization.\n   */\n  'admin.product-variant-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-variant-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order details page. Use this to create workflows for draft order processing, custom pricing, or order preparation tools.\n   */\n  'admin.draft-order-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the draft order index page. Use this to create workflows for draft order management, bulk operations, or order conversion tools.\n   */\n  'admin.draft-order-index.action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount details page. Use this to create workflows for discount management, promotion analysis, or discount synchronization.\n   */\n  'admin.discount-details.action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-details.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the actions menu inside the order fulfilled card, visible only on orders fulfilled by your app. Use this to create workflows for fulfillment operations, tracking updates, or post-fulfillment actions.\n   */\n  'admin.order-fulfilled-card.action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-fulfilled-card.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Bulk Actions\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the product index page when multiple products are selected. Use this to create workflows for bulk product operations, batch updates, or mass data processing.\n   */\n  'admin.product-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.product-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the order index page when multiple orders are selected. Use this to create workflows for bulk order operations, batch fulfillment, or mass order processing.\n   */\n  'admin.order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the customer index page when multiple customers are selected. Use this to create workflows for bulk customer operations, mass email campaigns, or batch data updates.\n   */\n  'admin.customer-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.customer-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **More actions** menu on the discount index page when multiple discounts are selected. Use this to create workflows for bulk discount operations or batch data updates.\n   */\n  'admin.discount-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.discount-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * A selection action target that appears in the **More actions** menu on the draft order index page when multiple draft orders are selected. Use this to create workflows for bulk draft order operations, batch conversions, or mass order processing.\n   */\n  'admin.draft-order-index.selection-action.render': RenderExtension<\n    ActionExtensionApi<'admin.draft-order-index.selection-action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product details page when a selling plan group is present. Use this to create workflows for subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  /**\n   * An action target that appears in the **Purchase Options** card on the product variant details page when a selling plan group is present. Use this to create workflows for variant-specific subscription management, selling plan configuration, or purchase option operations.\n   */\n  'admin.product-variant-purchase-option.action.render': RenderExtension<\n    PurchaseOptionsCardConfigurationApi<'admin.product-variant-purchase-option.action.render'>,\n    ActionExtensionComponents\n  >;\n\n  // Print actions and bulk print actions\n\n  /**\n   * A print action target that appears in the **Print** menu on the order details page. Use this to generate custom documents such as packing slips, shipping labels, or invoices.\n   */\n  'admin.order-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product details page. Use this to generate custom documents such as product labels, barcode sheets, or specification sheets.\n   */\n  'admin.product-details.print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-details.print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the order index page when multiple orders are selected. Use this to generate batch documents such as combined packing slips, shipping manifests, or bulk invoices.\n   */\n  'admin.order-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.order-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  /**\n   * A print action target that appears in the **Print** menu on the product index page when multiple products are selected. Use this to generate batch documents such as combined product labels, barcode sheets, or catalog pages.\n   */\n  'admin.product-index.selection-print-action.render': RenderExtension<\n    PrintActionExtensionApi<'admin.product-index.selection-print-action.render'>,\n    PrintActionExtensionComponents\n  >;\n\n  // Other\n\n  /**\n   * A configuration target that renders product configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product details page. Use this to define bundle component selections, customization options, or product configuration rules.\n   */\n  'admin.product-details.configuration.render': RenderExtension<\n    ProductDetailsConfigurationApi<'admin.product-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A configuration target that renders product variant configuration settings for [product bundles](/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui) and customizable products on the product variant details page. Use this to define variant-specific bundle components, customization options, or configuration rules.\n   */\n  'admin.product-variant-details.configuration.render': RenderExtension<\n    ProductVariantDetailsConfigurationApi<'admin.product-variant-details.configuration.render'>,\n    BlockExtensionComponents\n  >;\n\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions.\n   * @private\n   */\n  'admin.settings.internal-order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.internal-order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n  /**\n   * A function settings target that renders within order routing settings, allowing merchants to configure order routing rule functions. Use this to build custom configuration interfaces for order routing function parameters.\n   */\n  'admin.settings.order-routing-rule.render': RenderExtension<\n    OrderRoutingRuleApi<'admin.settings.order-routing-rule.render'>,\n    FunctionSettingsComponents\n  >;\n\n  /**\n   * A function settings target that renders within a validation's add and edit views, allowing merchants to configure validation function settings. Use this to build custom configuration interfaces for validation function parameters and rules.\n   */\n  'admin.settings.validation.render': RenderExtension<\n    ValidationSettingsApi<'admin.settings.validation.render'>,\n    FunctionSettingsComponents\n  >;\n\n  // Admin action shouldRender targets\n  /**\n   * A non-rendering target that controls whether the product details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the catalog details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on catalog properties, user permissions, or external data.\n   */\n  'admin.catalog-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.catalog-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the company details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on company properties, user permissions, or external data.\n   */\n  'admin.company-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.company-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the gift card details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on gift card properties, user permissions, or external data.\n   */\n  'admin.gift-card-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.gift-card-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on order properties, fulfillment status, or external data.\n   */\n  'admin.order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on customer properties, user permissions, or external data.\n   */\n  'admin.customer-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer segment details action appears from the **Use segment** button. Use this to conditionally show or hide your action based on segment properties, user permissions, or external data.\n   */\n  'admin.customer-segment-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-segment-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.product-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.customer-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.discount-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on collection properties, user permissions, or external data.\n   */\n  'admin.collection-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the collection index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.collection-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.collection-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on checkout properties, user permissions, or external data.\n   */\n  'admin.abandoned-checkout-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the abandoned checkout index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.abandoned-checkout-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.abandoned-checkout-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product variant details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on variant properties, user permissions, or external data.\n   */\n  'admin.product-variant-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-variant-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on draft order properties, user permissions, or external data.\n   */\n  'admin.draft-order-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index action appears in the **More actions** menu. Use this to conditionally show or hide your action based on user permissions, store configuration, or external data.\n   */\n  'admin.draft-order-index.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount details action appears in the **More actions** menu. Use this to conditionally show or hide your action based on discount properties, user permissions, or external data.\n   */\n  'admin.discount-details.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-details.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order fulfilled card action appears in the actions menu. Use this to conditionally show or hide your action based on fulfillment properties, user permissions, or external data.\n   */\n  'admin.order-fulfilled-card.action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-fulfilled-card.action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin bulk action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the product index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.product-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the customer index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.customer-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.customer-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the discount index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.discount-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.discount-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the draft order index selection action appears in the **More actions** menu. Use this to conditionally show or hide your bulk action based on selection criteria, user permissions, or external data.\n   */\n  'admin.draft-order-index.selection-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.draft-order-index.selection-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  // Admin print action shouldRender targets\n\n  /**\n   * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.\n   */\n  'admin.order-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.order-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A non-rendering target that controls whether the product details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on product properties, user permissions, or external data.\n   */\n  'admin.product-details.print-action.should-render': RunnableExtension<\n    ShouldRenderApi<'admin.product-details.print-action.should-render'>,\n    ShouldRenderOutput\n  >;\n\n  /**\n   * A runnable target that enables your app to expose data to [Sidekick](/docs/apps/build/sidekick/build-app-data). Use this target to register tools that Sidekick can invoke to search your app's data and answer merchant questions.\n   */\n  'admin.app.tools.data': RunnableExtension<\n    StandardApi<'admin.app.tools.data'>,\n    undefined\n  >;\n\n  /**\n   * Renders an admin extension for handling app intents.\n   */\n  'admin.app.intent.render': RenderExtension<\n    IntentRenderApi<'admin.app.intent.render'>,\n    FormExtensionComponents\n  >;\n\n  /**\n   * Renders an admin extension on the app home page.\n   */\n  'admin.app.home.render': RenderExtension<\n    AppHomeApi<'admin.app.home.render'>,\n    FormExtensionComponents | 'Modal' | 'Page' | 'AppNav'\n  >;\n}"
     }
   },
   "RenderExtension": {
@@ -2752,7 +2738,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -3137,7 +3123,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$3@2409",
+          "name": "__@internals$3@2412",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -3901,7 +3887,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4016,7 +4002,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$2@2510",
+          "name": "__@internals$2@2513",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4307,7 +4293,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4487,7 +4473,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dirtyStateSymbol@2554",
+          "name": "__@dirtyStateSymbol@2557",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -4496,7 +4482,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$1@2553",
+          "name": "__@internals$1@2556",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -4683,7 +4669,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@setFiles@2589",
+          "name": "__@setFiles@2592",
           "value": "(files: File[]) => void",
           "description": "",
           "isPrivate": true,
@@ -4692,7 +4678,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@getFileInput@2591",
+          "name": "__@getFileInput@2594",
           "value": "() => HTMLInputElement",
           "description": "",
           "isPrivate": true,
@@ -4701,7 +4687,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals@2590",
+          "name": "__@internals@2593",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -5048,7 +5034,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -6617,7 +6603,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -6626,7 +6612,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -6635,7 +6621,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -6872,7 +6858,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -7154,7 +7140,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -7812,7 +7798,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -8151,7 +8137,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -8427,7 +8413,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@usedFirstOptionSymbol@3004",
+          "name": "__@usedFirstOptionSymbol@3007",
           "value": "boolean",
           "description": "A flag used to determine if no value or defaultValue was set, in which case the first non-disabled option was used.\n\nThis is important because we need to use the placeholder in these situations, even though the first value will be submitted as part of the form.",
           "isPrivate": true,
@@ -8436,7 +8422,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@hasInitialValueSymbol@3005",
+          "name": "__@hasInitialValueSymbol@3008",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -8470,7 +8456,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -9100,7 +9086,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -9228,7 +9214,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@actualTableVariantSymbol@3080",
+          "name": "__@actualTableVariantSymbol@3083",
           "value": "AddedContext<ActualTableVariant>",
           "description": "",
           "isPrivate": true,
@@ -9237,7 +9223,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@tableHeadersSharedDataSymbol@3081",
+          "name": "__@tableHeadersSharedDataSymbol@3084",
           "value": "AddedContext<{ listSlot: ListSlotType; textContent: string; format: HeaderFormat; }[]>",
           "description": "",
           "isPrivate": true,
@@ -9462,7 +9448,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@headerFormatSymbol@3103",
+          "name": "__@headerFormatSymbol@3106",
           "value": "HeaderFormat",
           "description": "",
           "isPrivate": true,
@@ -10109,7 +10095,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -10382,7 +10368,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -10556,7 +10542,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -10565,7 +10551,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -10574,7 +10560,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -10903,7 +10889,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@internals$4@2356",
+          "name": "__@internals$4@2359",
           "value": "ElementInternals",
           "description": "",
           "isPrivate": true,
@@ -12049,7 +12035,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@abortController@2785",
+          "name": "__@abortController@2788",
           "value": "AbortController",
           "description": "",
           "isPrivate": true,
@@ -12058,7 +12044,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@dialog@2779",
+          "name": "__@dialog@2782",
           "value": "HTMLDialogElement",
           "description": "",
           "isPrivate": true,
@@ -12067,7 +12053,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@focusedElement@2781",
+          "name": "__@focusedElement@2784",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -12076,7 +12062,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@nestedModals@2783",
+          "name": "__@nestedModals@2786",
           "value": "Map<Modal, boolean>",
           "description": "",
           "isPrivate": true,
@@ -12085,7 +12071,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@childrenRerenderObserver@2787",
+          "name": "__@childrenRerenderObserver@2790",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true,
@@ -12094,7 +12080,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@shadowDomRerenderObserver@2788",
+          "name": "__@shadowDomRerenderObserver@2791",
           "value": "MutationObserver",
           "description": "",
           "isPrivate": true,
@@ -12103,7 +12089,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onEscape@2782",
+          "name": "__@onEscape@2785",
           "value": "(event: KeyboardEvent) => void",
           "description": "",
           "isPrivate": true,
@@ -12112,7 +12098,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onBackdropClick@2784",
+          "name": "__@onBackdropClick@2787",
           "value": "(event: MouseEvent) => void",
           "description": "",
           "isPrivate": true,
@@ -12121,7 +12107,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@onChildModalChange@2786",
+          "name": "__@onChildModalChange@2789",
           "value": "EventListenerOrEventListenerObject",
           "description": "",
           "isPrivate": true,
@@ -12130,7 +12116,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@isOpen@2778",
+          "name": "__@isOpen@2781",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12139,7 +12125,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@dismiss@2780",
+          "name": "__@dismiss@2783",
           "value": "() => void",
           "description": "",
           "isPrivate": true,
@@ -12148,7 +12134,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "GetAccessor",
-          "name": "__@hasOpenChildModal@2775",
+          "name": "__@hasOpenChildModal@2778",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12157,7 +12143,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@show@2776",
+          "name": "__@show@2779",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true,
@@ -12166,7 +12152,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "MethodDeclaration",
-          "name": "__@hide@2777",
+          "name": "__@hide@2780",
           "value": "() => Promise<void>",
           "description": "",
           "isPrivate": true,
@@ -12175,7 +12161,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -12184,7 +12170,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -12193,7 +12179,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,
@@ -12956,12 +12942,40 @@
         {
           "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
           "syntaxKind": "PropertySignature",
+          "name": "purchaseType",
+          "value": "ReadonlySignalLike<PurchaseType>",
+          "description": "A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "recurringCycleLimit",
+          "value": "ReadonlySignalLike<number | null>",
+          "description": "A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
           "name": "updateDiscountClasses",
           "value": "UpdateSignalFunction<DiscountClass[]>",
           "description": "A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "updatePurchaseType",
+          "value": "UpdateSignalFunction<PurchaseType>",
+          "description": "A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`)."
+        },
+        {
+          "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "updateRecurringCycleLimit",
+          "value": "UpdateSignalFunction<number | null>",
+          "description": "A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit."
         }
       ],
-      "value": "export interface DiscountsApi {\n  /**\n   * A signal that contains the discount classes (Product, Order, or Shipping). Read this to determine where the discount applies in the purchase flow. A discount can apply to multiple classes simultaneously.\n   */\n  discountClasses: ReadonlySignalLike<DiscountClass[]>;\n  /**\n   * A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects.\n   */\n  updateDiscountClasses: UpdateSignalFunction<DiscountClass[]>;\n  /**\n   * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.\n   */\n  discountMethod: ReadonlySignalLike<DiscountMethod>;\n}"
+      "value": "export interface DiscountsApi {\n  /**\n   * A signal that contains the discount classes (Product, Order, or Shipping). Read this to determine where the discount applies in the purchase flow. A discount can apply to multiple classes simultaneously.\n   */\n  discountClasses: ReadonlySignalLike<DiscountClass[]>;\n  /**\n   * A function that updates the discount classes to change where the discount applies. Call this function with an array of `DiscountClass` values to set which parts of the purchase (products, order total, or shipping) the discount affects.\n   */\n  updateDiscountClasses: UpdateSignalFunction<DiscountClass[]>;\n  /**\n   * A signal that contains the discount method (`'automatic'` or `'code'`). Read this to determine whether the discount applies automatically at checkout or requires a customer-entered code.\n   */\n  discountMethod: ReadonlySignalLike<DiscountMethod>;\n  /**\n   * A signal that contains the purchase type. Read this to determine whether the discount applies to one-time purchases, subscriptions, or both.\n   */\n  purchaseType: ReadonlySignalLike<PurchaseType>;\n  /**\n   * A function that updates the purchase type to change which types of purchases the discount applies to. Call this with a `PurchaseType` value (`'one_time_purchase'`, `'subscription'`, or `'both'`).\n   */\n  updatePurchaseType: UpdateSignalFunction<PurchaseType>;\n  /**\n   * A signal that contains the recurring cycle limit for subscription purchases. A positive integer limits how many billing cycles the discount applies for. Both `0` and `null` mean unlimited (no limit). `null` is the default when no value has been explicitly set.\n   */\n  recurringCycleLimit: ReadonlySignalLike<number | null>;\n  /**\n   * A function that updates the recurring cycle limit for subscription purchases. Pass a positive integer to limit the number of billing cycles, `0` or `null` to remove the limit.\n   */\n  updateRecurringCycleLimit: UpdateSignalFunction<number | null>;\n}"
     }
   },
   "ReadonlySignalLike": {
@@ -13005,6 +13019,16 @@
       "name": "DiscountMethod",
       "value": "'automatic' | 'code'",
       "description": "The method used to apply a discount. Use `'automatic'` for discounts that apply automatically at checkout, or `'code'` for discounts that require a code entered by the customer.",
+      "isPublicDocs": true
+    }
+  },
+  "PurchaseType": {
+    "src/surfaces/admin/api/discount-function-settings/launch-options.ts": {
+      "filePath": "src/surfaces/admin/api/discount-function-settings/launch-options.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "PurchaseType",
+      "value": "'one_time_purchase' | 'subscription' | 'both'",
+      "description": "The purchase type that determines which purchases the discount applies to. Use `'one_time_purchase'` for one-time purchases only, `'subscription'` for subscription purchases only, or `'both'` for both.",
       "isPublicDocs": true
     }
   },
@@ -20812,7 +20836,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHidden@2725",
+          "name": "__@overlayHidden@2728",
           "value": "boolean",
           "description": "",
           "isPrivate": true,
@@ -20821,7 +20845,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayActivator@2726",
+          "name": "__@overlayActivator@2729",
           "value": "HTMLElement",
           "description": "",
           "isPrivate": true,
@@ -20830,7 +20854,7 @@
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
-          "name": "__@overlayHideFrameId@2727",
+          "name": "__@overlayHideFrameId@2730",
           "value": "number",
           "description": "",
           "isPrivate": true,

--- a/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
+++ b/packages/ui-extensions/src/surfaces/admin/extension-targets.ts
@@ -643,7 +643,7 @@ export interface ExtensionTargets {
     ShouldRenderOutput
   >;
 
-  // Admin print action and bulk print action shouldRender targets
+  // Admin print action shouldRender targets
 
   /**
    * A non-rendering target that controls whether the order details print action appears in the **Print** menu. Use this to conditionally show or hide your print action based on order properties, user permissions, or external data.
@@ -658,22 +658,6 @@ export interface ExtensionTargets {
    */
   'admin.product-details.print-action.should-render': RunnableExtension<
     ShouldRenderApi<'admin.product-details.print-action.should-render'>,
-    ShouldRenderOutput
-  >;
-
-  /**
-   * A non-rendering target that controls whether the order index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.
-   */
-  'admin.order-index.selection-print-action.should-render': RunnableExtension<
-    ShouldRenderApi<'admin.order-index.selection-print-action.should-render'>,
-    ShouldRenderOutput
-  >;
-
-  /**
-   * A non-rendering target that controls whether the product index selection print action appears in the **Print** menu. Use this to conditionally show or hide your bulk print action based on selection criteria, user permissions, or external data.
-   */
-  'admin.product-index.selection-print-action.should-render': RunnableExtension<
-    ShouldRenderApi<'admin.product-index.selection-print-action.should-render'>,
     ShouldRenderOutput
   >;
 


### PR DESCRIPTION
## What

Removes unsupported Admin selection print-action `shouldRender` targets from the `2026-07` docs/types branch.

Keeps the supported detail targets:

- `admin.order-details.print-action.should-render`
- `admin.product-details.print-action.should-render`

Removes unsupported selection targets:

- `admin.order-index.selection-print-action.should-render`
- `admin.product-index.selection-print-action.should-render`

## Why

Core and Admin Web now support print-action `should_render` only for detail pages. The selection/bulk print-action targets should not be advertised or typed for the 2026-07 Admin UI Extensions branch.

Follow-up to the `2025-10` cleanup: https://github.com/Shopify/ui-extensions/pull/4652
World support PRs: shop/world#2016728 and shop/world#2016776

Note: the `2026-07` branch currently stores generated Admin docs under the existing `2026-07-rc` generated folder, so this PR updates that tracked folder.

## Testing

- `yarn workspace @shopify/ui-extensions docs:admin 2026-07-rc 2026-07-rc`
- `git diff --check`
- `yarn lint`
- `yarn type-check`
