### PR TITLE
Pin GitHub Actions to Node 24 v7 releases

### DIFF
--- a/.github/workflows/actions/prepare/action.yml
+++ b/.github/workflows/actions/prepare/action.yml
@@ -4,6 +4,8 @@ runs:
   steps:
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       name: Setup node.js and yarn
+      env:
+        NODE_AUTH_TOKEN: ''
       with:
         registry-url: 'https://registry.npmjs.org' # Required for OIDC
         cache: yarn

--- a/.github/workflows/actions/prepare/action.yml
+++ b/.github/workflows/actions/prepare/action.yml
@@ -2,7 +2,7 @@ name: Prepare repo
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       name: Setup node.js and yarn
       with:
         registry-url: 'https://registry.npmjs.org' # Required for OIDC

--- a/.github/workflows/actions/prepare/action.yml
+++ b/.github/workflows/actions/prepare/action.yml
@@ -2,7 +2,7 @@ name: Prepare repo
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       name: Setup node.js and yarn
       with:
         registry-url: 'https://registry.npmjs.org' # Required for OIDC

--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 2
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: mskelton/changelog-reminder-action@7039cd14fb784c0a2b37f6e7a6ade2c9148c2245 # v2.0.0
         with:
           changelogRegex: "\\.changeset"

--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 2
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: mskelton/changelog-reminder-action@7039cd14fb784c0a2b37f6e7a6ade2c9148c2245 # v2.0.0
         with:
           changelogRegex: "\\.changeset"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/workflows/actions/prepare
 
       - id: typescript-cache
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/workflows/actions/prepare
 
       - id: eslint-cache
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/workflows/actions/prepare
 
       - name: Build packages
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/workflows/actions/prepare
 
       - id: test-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
 
       - id: typescript-cache
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
 
       - id: eslint-cache
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
 
       - name: Build packages
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
 
       - id: test-build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # WARNING: DO NOT RUN ANY CUSTOM LOCAL SCRIPT BEFORE RUNNING THE SNAPIT ACTION
       # This action can be executed by 3rd party users and it should not be able to run arbitrary code from a PR.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
@@ -62,7 +62,7 @@ jobs:
       contents: read
       id-token: write # Required for OIDC
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # WARNING: DO NOT RUN ANY CUSTOM LOCAL SCRIPT BEFORE RUNNING THE SNAPIT ACTION
       # This action can be executed by 3rd party users and it should not be able to run arbitrary code from a PR.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
@@ -62,7 +62,7 @@ jobs:
       contents: read
       id-token: write # Required for OIDC
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/internal-snapshot.yml
+++ b/.github/workflows/internal-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     name: Internal Snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/internal-snapshot.yml
+++ b/.github/workflows/internal-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     name: Internal Snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/unstable-snapshot.yml
+++ b/.github/workflows/unstable-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unstable Snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 

--- a/.github/workflows/unstable-snapshot.yml
+++ b/.github/workflows/unstable-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     name: Unstable Snapshot
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## What changed

- Upgrade every `actions/checkout` usage from v3/v4 to v7.0.0, pinned to immutable commit `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`.
- Upgrade `actions/setup-node` from v4 to v7.0.0, pinned to immutable commit `820762786026740c76f36085b0efc47a31fe5020`.

Both selected releases run natively on Node 24.

## Why

GitHub now runs JavaScript actions on Node 24 by default as part of the [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The `2026-10-rc` release workflow still uses `actions/checkout@v3`; after the runner migration, checkout configures credentials but its authenticated fetch fails.

This blocked `@shopify/ui-extensions@2026.10.0-rc.8` from publishing even after the Version Packages PR merged. The failed workflow is https://github.com/Shopify/ui-extensions/actions/runs/33114738095.

## Validation

- `yarn lint`
- Prettier check across `.github/workflows/**/*.{yml,yaml}`
- Verified the pinned v7.0.0 `action.yml` files declare `runs.using: node24`
