### PR TITLE
fix(admin): use field-generic wording for details/error prop docs

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-07-rc/generated_docs_data_v2.json
@@ -2673,7 +2673,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -2681,7 +2681,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3048,7 +3048,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3056,7 +3056,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3769,7 +3769,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3777,7 +3777,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4157,7 +4157,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4165,7 +4165,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4593,7 +4593,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4907,7 +4907,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4915,7 +4915,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -6731,7 +6731,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -6739,7 +6739,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7013,7 +7013,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7021,7 +7021,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7671,7 +7671,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7679,7 +7679,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8010,7 +8010,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8018,7 +8018,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8330,7 +8330,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8338,7 +8338,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9021,7 +9021,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9029,7 +9029,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9968,7 +9968,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9976,7 +9976,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10241,7 +10241,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10249,7 +10249,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10762,7 +10762,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10770,7 +10770,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16708,11 +16708,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -16727,7 +16727,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16772,11 +16772,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -16799,7 +16799,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16816,7 +16816,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16925,7 +16925,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16942,7 +16942,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -20613,7 +20613,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -20630,7 +20630,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -2673,7 +2673,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -2681,7 +2681,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3048,7 +3048,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3056,7 +3056,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3769,7 +3769,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3777,7 +3777,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4157,7 +4157,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4165,7 +4165,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4593,7 +4593,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4907,7 +4907,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4915,7 +4915,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -6731,7 +6731,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -6739,7 +6739,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7013,7 +7013,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7021,7 +7021,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7671,7 +7671,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7679,7 +7679,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8010,7 +8010,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8018,7 +8018,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8330,7 +8330,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8338,7 +8338,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9021,7 +9021,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9029,7 +9029,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9968,7 +9968,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9976,7 +9976,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10241,7 +10241,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10249,7 +10249,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10762,7 +10762,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10770,7 +10770,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16708,11 +16708,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -16727,7 +16727,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16772,11 +16772,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -16799,7 +16799,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16816,7 +16816,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16925,7 +16925,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16942,7 +16942,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -20613,7 +20613,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -20630,7 +20630,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2026-07-rc/generated_docs_data_v2.json
@@ -2673,7 +2673,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -2681,7 +2681,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3048,7 +3048,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3056,7 +3056,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3769,7 +3769,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -3777,7 +3777,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4157,7 +4157,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4165,7 +4165,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4593,7 +4593,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4907,7 +4907,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -4915,7 +4915,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -6731,7 +6731,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -6739,7 +6739,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7013,7 +7013,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7021,7 +7021,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7671,7 +7671,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -7679,7 +7679,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8010,7 +8010,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8018,7 +8018,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8330,7 +8330,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -8338,7 +8338,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9021,7 +9021,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9029,7 +9029,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9968,7 +9968,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -9976,7 +9976,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10241,7 +10241,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10249,7 +10249,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10762,7 +10762,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -10770,7 +10770,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16708,11 +16708,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -16727,7 +16727,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16772,11 +16772,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -16799,7 +16799,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16816,7 +16816,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16925,7 +16925,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16942,7 +16942,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -20613,7 +20613,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -20630,7 +20630,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -1864,8 +1864,8 @@ export interface FileInputProps extends BaseInputProps {
 /** @publicDocs */
 export interface FieldErrorProps {
   /**
-   * An error message displayed below the checkbox to indicate validation problems.
-   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.
+   * An error message displayed below the field to indicate validation problems.
+   * When set, the field is styled with error indicators and the message is announced to screen readers.
    */
   error?: string;
 }
@@ -1888,8 +1888,8 @@ export interface BasicFieldProps
 /** @publicDocs */
 export interface FieldDetailsProps {
   /**
-   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.
-   * Use this to explain what checking the box means or provide guidance to users.
+   * Supplementary text displayed below the field to provide additional context, instructions, or help.
+   * Use this to clarify the expected input or provide guidance to users.
    * This text is announced to screen readers.
    */
   details?: string;


### PR DESCRIPTION
## What

The shared `FieldDetailsProps.details` and `FieldErrorProps.error` JSDoc in `src/surfaces/admin/components.d.ts` was written for `checkbox`:

> Supplementary text displayed below **the checkbox** to provide additional context, instructions, or help. Use this to explain **what checking the box means** or provide guidance to users.

Both interfaces are inherited by every Admin and App Home form component, so this checkbox-specific copy renders on ~18 non-checkbox reference pages, where it reads incorrectly. Reported via shopify.dev CSAT feedback on the [App Home text field page](https://shopify.dev/docs/api/app-home/web-components/forms/text-field).

## How

Two JSDoc blocks changed. The docs generator expands inherited members, so those two blocks produce **all 40 occurrences per generated file** — the fix corrects every inheriting component in one change:

`text-field`, `text-area`, `select`, `color-field`, `date-field`, `email-field`, `money-field`, `number-field`, `password-field`, `search-field`, `url-field`, `choice-list`, `switch`, plus the `FieldProps` / `BaseTextFieldProps` / `RequiredMoneyFieldProps` interfaces.

Contrary to the issue's description, `checkbox` had **no override** — it inherited the same string, so no component had correct wording. The new generic phrasing reads correctly for checkbox too, so no override was added.

## Generated docs

`generated_docs_data_v2.json` updated for `admin_extensions/2026-07-rc`, `app_home`, and `app_home_ui_extension/2026-07-rc` — 40 replacements each across four distinct literals (20 flattened `error`, 18 flattened `details`, and the two interface source blocks).

These were patched textually rather than by running `yarn docs:admin`, because the generator copies these strings verbatim and the branch is cut from the freshly-regenerated files in c44c777db. The diff arithmetic closes exactly (`40 × 3 + 4 = 124`), all three files re-parse as valid JSON, and no residual checkbox wording remains under `src/` or `docs/`.

## Follow-up (not in this PR)

This file is a vendored copy of `@shopify/admin-ui-components`, bulk-replaced by `bump admin-ui-components` commits. The durable fix lives in **World** at `libraries/javascript/polaris/admin-ui-components/lib/publicDocsMemberDescriptions.js`, which hand-overrides the (already-correct) `ui-api-design` JSDoc and duplicates the bad string **per component** — 36 strings across 19 entries, including `DropZone`. Without that change this regresses on the next vendor bump. Tracked in shop/issues-learn#2959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)