### PR TITLE
fix(admin): use field-generic wording for details/error prop docs (2026-04)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-04/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-04/generated_docs_data_v2.json
@@ -2567,14 +2567,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2903,14 +2903,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3547,14 +3547,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3893,14 +3893,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4283,7 +4283,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4564,14 +4564,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6209,14 +6209,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6460,14 +6460,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7051,14 +7051,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7355,14 +7355,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7642,14 +7642,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8260,14 +8260,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9118,14 +9118,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9361,14 +9361,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9828,14 +9828,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -14886,11 +14886,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -14905,7 +14905,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14950,11 +14950,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -14977,7 +14977,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14994,7 +14994,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -15103,7 +15103,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -15120,7 +15120,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19035,7 +19035,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19052,7 +19052,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -2567,14 +2567,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2903,14 +2903,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3547,14 +3547,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3893,14 +3893,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4283,7 +4283,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4564,14 +4564,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6209,14 +6209,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6460,14 +6460,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7051,14 +7051,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7355,14 +7355,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7642,14 +7642,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8260,14 +8260,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9118,14 +9118,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9361,14 +9361,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9828,14 +9828,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -14886,11 +14886,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -14905,7 +14905,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14950,11 +14950,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -14977,7 +14977,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14994,7 +14994,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -15103,7 +15103,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -15120,7 +15120,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19035,7 +19035,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19052,7 +19052,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -1864,8 +1864,8 @@ export interface FileInputProps extends BaseInputProps {
 /** @publicDocs */
 export interface FieldErrorProps {
   /**
-   * An error message displayed below the checkbox to indicate validation problems.
-   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.
+   * An error message displayed below the field to indicate validation problems.
+   * When set, the field is styled with error indicators and the message is announced to screen readers.
    */
   error?: string;
 }
@@ -1888,8 +1888,8 @@ export interface BasicFieldProps
 /** @publicDocs */
 export interface FieldDetailsProps {
   /**
-   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.
-   * Use this to explain what checking the box means or provide guidance to users.
+   * Supplementary text displayed below the field to provide additional context, instructions, or help.
+   * Use this to clarify the expected input or provide guidance to users.
    * This text is announced to screen readers.
    */
   details?: string;


### PR DESCRIPTION
Backport of #4662 to `2026-04`.

## What

The shared `FieldDetailsProps.details` and `FieldErrorProps.error` JSDoc in `src/surfaces/admin/components.d.ts` was written for `checkbox` ("displayed below **the checkbox**", "what **checking the box** means"). Both interfaces are inherited by every Admin and App Home form component, so the copy renders on non-checkbox reference pages where it reads incorrectly.

Reported via shopify.dev CSAT feedback. Tracked in shop/issues-learn#2959.

## Why this version

`admin_extensions` docs are published per API version on shopify.dev, so each maintained version needs the fix independently. Verified against the live data in World — `db/data/docs/templated_apis/admin_extensions/2026-04` still carries the checkbox wording today.

(`app_home` is published unversioned, so it is fixed by whichever branch syncs last; it is updated here too for consistency within the branch.)

## Change

Two JSDoc blocks in `components.d.ts`, plus the generated docs data: 2 files, **82 replacements total**.

Counts match the 2026-07 fix exactly (40 per generated file).

The generated JSON was patched textually rather than by running `yarn docs:admin`, because the generator copies these strings verbatim. Every occurrence was matched against a known literal — the patch fails loudly on any unrecognized form — all files re-parse as valid JSON, and no residual checkbox wording remains under `src/` or `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)