### PR TITLE
fix(admin): use field-generic wording for details/error prop docs (2026-01)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2026-01/generated_docs_data_v2.json
@@ -2449,14 +2449,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2785,14 +2785,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3429,14 +3429,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3775,14 +3775,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4165,7 +4165,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4446,14 +4446,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6091,14 +6091,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6342,14 +6342,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6933,14 +6933,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7237,14 +7237,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7524,14 +7524,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8142,14 +8142,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9000,14 +9000,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9243,14 +9243,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9710,14 +9710,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -15287,7 +15287,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -15304,7 +15304,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -6433,14 +6433,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6769,14 +6769,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7413,14 +7413,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7759,14 +7759,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8149,7 +8149,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8430,14 +8430,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9887,14 +9887,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10138,14 +10138,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -10729,14 +10729,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11033,14 +11033,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11320,14 +11320,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -11938,14 +11938,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -12796,14 +12796,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -13039,14 +13039,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -13506,14 +13506,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -18805,7 +18805,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18822,7 +18822,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -1842,8 +1842,8 @@ export interface FileInputProps extends BaseInputProps {
 }
 export interface FieldErrorProps {
   /**
-   * An error message displayed below the checkbox to indicate validation problems.
-   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.
+   * An error message displayed below the field to indicate validation problems.
+   * When set, the field is styled with error indicators and the message is announced to screen readers.
    */
   error?: string;
 }
@@ -1864,8 +1864,8 @@ export interface BasicFieldProps
 }
 export interface FieldDetailsProps {
   /**
-   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.
-   * Use this to explain what checking the box means or provide guidance to users.
+   * Supplementary text displayed below the field to provide additional context, instructions, or help.
+   * Use this to clarify the expected input or provide guidance to users.
    * This text is announced to screen readers.
    */
   details?: string;


### PR DESCRIPTION
Backport of #4662 to `2026-01`.

## What

The shared `FieldDetailsProps.details` and `FieldErrorProps.error` JSDoc in `src/surfaces/admin/components.d.ts` was written for `checkbox` ("displayed below **the checkbox**", "what **checking the box** means"). Both interfaces are inherited by every Admin and App Home form component, so the copy renders on non-checkbox reference pages where it reads incorrectly.

Reported via shopify.dev CSAT feedback. Tracked in shop/issues-learn#2959.

## Why this version

`admin_extensions` docs are published per API version on shopify.dev, so each maintained version needs the fix independently. Verified against the live data in World — `db/data/docs/templated_apis/admin_extensions/2026-01` still carries the checkbox wording today.

(`app_home` is published unversioned, so it is fixed by whichever branch syncs last; it is updated here too for consistency within the branch.)

## Change

Two JSDoc blocks in `components.d.ts`, plus the generated docs data: 2 files, **64 replacements total**.

Note: this version's generator does not emit the interface source blocks, so only the flattened description strings are present — 31 per generated file rather than 40.

The generated JSON was patched textually rather than by running `yarn docs:admin`, because the generator copies these strings verbatim. Every occurrence was matched against a known literal — the patch fails loudly on any unrecognized form — all files re-parse as valid JSON, and no residual checkbox wording remains under `src/` or `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)