### PR TITLE
fix(admin): use field-generic wording for details/error prop docs (2025-10)

### DIFF
--- a/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/admin_extensions/2025-10/generated_docs_data_v2.json
@@ -2433,14 +2433,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2769,14 +2769,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3413,14 +3413,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3759,14 +3759,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4148,7 +4148,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4429,14 +4429,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6064,14 +6064,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6315,14 +6315,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6905,14 +6905,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7208,14 +7208,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7494,14 +7494,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8112,14 +8112,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8967,14 +8967,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9210,14 +9210,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9677,14 +9677,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -13945,11 +13945,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -13964,7 +13964,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14009,11 +14009,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -14036,7 +14036,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14053,7 +14053,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14162,7 +14162,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14179,7 +14179,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16995,7 +16995,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17012,7 +17012,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17097,7 +17097,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17114,7 +17114,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17206,7 +17206,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17223,7 +17223,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17517,7 +17517,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17534,7 +17534,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17603,7 +17603,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17620,7 +17620,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18604,7 +18604,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18621,7 +18621,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18902,7 +18902,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18937,7 +18937,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19075,7 +19075,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19110,7 +19110,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19583,7 +19583,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19697,7 +19697,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19825,7 +19825,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19842,7 +19842,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22326,7 +22326,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22343,7 +22343,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22462,7 +22462,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22479,7 +22479,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22630,7 +22630,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22647,7 +22647,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22802,7 +22802,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22819,7 +22819,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -23558,7 +23558,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -23575,7 +23575,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24133,7 +24133,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24150,7 +24150,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24368,7 +24368,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24385,7 +24385,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24477,7 +24477,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24494,7 +24494,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25263,7 +25263,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25280,7 +25280,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25366,7 +25366,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25383,7 +25383,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26080,7 +26080,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26097,7 +26097,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26266,7 +26266,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26283,7 +26283,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26604,7 +26604,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26621,7 +26621,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home/generated_docs_data_v2.json
@@ -2433,14 +2433,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2769,14 +2769,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3413,14 +3413,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3759,14 +3759,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4148,7 +4148,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4429,14 +4429,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6064,14 +6064,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6315,14 +6315,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6905,14 +6905,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7208,14 +7208,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7494,14 +7494,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8112,14 +8112,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8967,14 +8967,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9210,14 +9210,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9677,14 +9677,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -13945,11 +13945,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -13964,7 +13964,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14009,11 +14009,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -14036,7 +14036,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14053,7 +14053,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14162,7 +14162,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14179,7 +14179,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16995,7 +16995,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17012,7 +17012,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17097,7 +17097,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17114,7 +17114,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17206,7 +17206,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17223,7 +17223,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17517,7 +17517,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17534,7 +17534,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17603,7 +17603,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17620,7 +17620,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18604,7 +18604,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18621,7 +18621,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18902,7 +18902,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18937,7 +18937,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19075,7 +19075,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19110,7 +19110,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19583,7 +19583,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19697,7 +19697,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19825,7 +19825,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19842,7 +19842,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22326,7 +22326,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22343,7 +22343,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22462,7 +22462,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22479,7 +22479,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22630,7 +22630,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22647,7 +22647,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22802,7 +22802,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22819,7 +22819,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -23558,7 +23558,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -23575,7 +23575,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24133,7 +24133,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24150,7 +24150,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24368,7 +24368,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24385,7 +24385,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24477,7 +24477,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24494,7 +24494,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25263,7 +25263,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25280,7 +25280,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25366,7 +25366,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25383,7 +25383,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26080,7 +26080,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26097,7 +26097,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26266,7 +26266,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26283,7 +26283,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26604,7 +26604,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26621,7 +26621,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2025-10/generated_docs_data_v2.json
+++ b/packages/ui-extensions/docs/surfaces/admin/generated/app_home_ui_extension/2025-10/generated_docs_data_v2.json
@@ -2433,14 +2433,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -2769,14 +2769,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3413,14 +3413,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -3759,14 +3759,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4148,7 +4148,7 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -4429,14 +4429,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6064,14 +6064,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6315,14 +6315,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -6905,14 +6905,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7208,14 +7208,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -7494,14 +7494,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8112,14 +8112,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -8967,14 +8967,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9210,14 +9210,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -9677,14 +9677,14 @@
           "syntaxKind": "PropertyDeclaration",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers."
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
           "syntaxKind": "PropertyDeclaration",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers."
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers."
         },
         {
           "filePath": "src/surfaces/admin/components.ts",
@@ -13945,11 +13945,11 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the checkbox to indicate validation problems.\n   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
+      "value": "export interface FieldErrorProps {\n  /**\n   * An error message displayed below the field to indicate validation problems.\n   * When set, the field is styled with error indicators and the message is announced to screen readers.\n   */\n  error?: string;\n}"
     }
   },
   "BasicFieldProps": {
@@ -13964,7 +13964,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14009,11 +14009,11 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         }
       ],
-      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.\n   * Use this to explain what checking the box means or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
+      "value": "export interface FieldDetailsProps {\n  /**\n   * Supplementary text displayed below the field to provide additional context, instructions, or help.\n   * Use this to clarify the expected input or provide guidance to users.\n   * This text is announced to screen readers.\n   */\n  details?: string;\n}"
     }
   },
   "FieldProps": {
@@ -14036,7 +14036,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14053,7 +14053,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14162,7 +14162,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -14179,7 +14179,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -16995,7 +16995,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17012,7 +17012,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17097,7 +17097,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17114,7 +17114,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17206,7 +17206,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17223,7 +17223,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17517,7 +17517,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17534,7 +17534,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17603,7 +17603,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -17620,7 +17620,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18604,7 +18604,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18621,7 +18621,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18902,7 +18902,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -18937,7 +18937,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19075,7 +19075,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19110,7 +19110,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19583,7 +19583,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19697,7 +19697,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19825,7 +19825,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -19842,7 +19842,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22326,7 +22326,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22343,7 +22343,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22462,7 +22462,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22479,7 +22479,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22630,7 +22630,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22647,7 +22647,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22802,7 +22802,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -22819,7 +22819,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -23558,7 +23558,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -23575,7 +23575,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24133,7 +24133,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24150,7 +24150,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24368,7 +24368,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24385,7 +24385,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24477,7 +24477,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -24494,7 +24494,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25263,7 +25263,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25280,7 +25280,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25366,7 +25366,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -25383,7 +25383,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26080,7 +26080,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26097,7 +26097,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26266,7 +26266,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26283,7 +26283,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26604,7 +26604,7 @@
           "syntaxKind": "PropertySignature",
           "name": "details",
           "value": "string",
-          "description": "Supplementary text displayed below the checkbox to provide additional context, instructions, or help. Use this to explain what checking the box means or provide guidance to users. This text is announced to screen readers.",
+          "description": "Supplementary text displayed below the field to provide additional context, instructions, or help. Use this to clarify the expected input or provide guidance to users. This text is announced to screen readers.",
           "isOptional": true
         },
         {
@@ -26621,7 +26621,7 @@
           "syntaxKind": "PropertySignature",
           "name": "error",
           "value": "string",
-          "description": "An error message displayed below the checkbox to indicate validation problems. When set, the checkbox is styled with error indicators and the message is announced to screen readers.",
+          "description": "An error message displayed below the field to indicate validation problems. When set, the field is styled with error indicators and the message is announced to screen readers.",
           "isOptional": true
         },
         {

--- a/packages/ui-extensions/src/surfaces/admin/components.d.ts
+++ b/packages/ui-extensions/src/surfaces/admin/components.d.ts
@@ -1910,8 +1910,8 @@ export interface FileInputProps extends BaseInputProps {
  */
 export interface FieldErrorProps {
   /**
-   * An error message displayed below the checkbox to indicate validation problems.
-   * When set, the checkbox is styled with error indicators and the message is announced to screen readers.
+   * An error message displayed below the field to indicate validation problems.
+   * When set, the field is styled with error indicators and the message is announced to screen readers.
    */
   error?: string;
 }
@@ -1938,8 +1938,8 @@ export interface BasicFieldProps
  */
 export interface FieldDetailsProps {
   /**
-   * Supplementary text displayed below the checkbox to provide additional context, instructions, or help.
-   * Use this to explain what checking the box means or provide guidance to users.
+   * Supplementary text displayed below the field to provide additional context, instructions, or help.
+   * Use this to clarify the expected input or provide guidance to users.
    * This text is announced to screen readers.
    */
   details?: string;


### PR DESCRIPTION
Backport of #4662 to `2025-10`.

## What

The shared `FieldDetailsProps.details` and `FieldErrorProps.error` JSDoc in `src/surfaces/admin/components.d.ts` was written for `checkbox` ("displayed below **the checkbox**", "what **checking the box** means"). Both interfaces are inherited by every Admin and App Home form component, so the copy renders on non-checkbox reference pages where it reads incorrectly.

Reported via shopify.dev CSAT feedback. Tracked in shop/issues-learn#2959.

## Why this version

`admin_extensions` docs are published per API version on shopify.dev, so each maintained version needs the fix independently. Verified against the live data in World — `db/data/docs/templated_apis/admin_extensions/2025-10` still carries the checkbox wording today.

(`app_home` is published unversioned, so it is fixed by whichever branch syncs last; it is updated here too for consistency within the branch.)

## Change

Two JSDoc blocks in `components.d.ts`, plus the generated docs data: 3 files, **254 replacements total**.

Note: this version has a third generated file (`app_home_ui_extension/2025-10`) and a wider set of inheriting components — 84 per generated file.

The generated JSON was patched textually rather than by running `yarn docs:admin`, because the generator copies these strings verbatim. Every occurrence was matched against a known literal — the patch fails loudly on any unrecognized form — all files re-parse as valid JSON, and no residual checkbox wording remains under `src/` or `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)